### PR TITLE
UI polish: family-grade animations, glass toasts, sovereign-gradient CTAs

### DIFF
--- a/client/src/components/auth/LoginForm.tsx
+++ b/client/src/components/auth/LoginForm.tsx
@@ -46,7 +46,7 @@ export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
           required
           autoFocus
           autoComplete="email"
-          className={`block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-all mono text-sm ${
+          className={`block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm ${
             emailError ? 'border-[var(--color-negative)]' : 'border-[var(--color-border)]'
           }`}
           placeholder="you@example.com"
@@ -76,14 +76,14 @@ export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
           required
           minLength={6}
           autoComplete="current-password"
-          className="block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-all mono text-sm"
+          className="block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm"
           placeholder="••••••••"
         />
       </div>
 
       {error && (
-        <div className="p-3 rounded-sm" style={{ backgroundColor: 'color-mix(in srgb, var(--color-negative) 10%, transparent)', borderWidth: '1px', borderColor: 'color-mix(in srgb, var(--color-negative) 20%, transparent)' }}>
-          <p className="text-sm text-[var(--color-negative)] mono">{error}</p>
+        <div className="glass-slab-floating relative overflow-hidden rounded-lg pl-4 pr-3 py-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-negative)] shadow-[0_8px_30px_-10px_rgba(239,68,68,0.35)]">
+          <p className="text-sm text-[var(--color-negative)] font-medium">{error}</p>
         </div>
       )}
 
@@ -96,7 +96,7 @@ export function LoginForm({ onSwitchToSignup }: LoginFormProps) {
         <button
           type="button"
           onClick={onSwitchToSignup}
-          className="text-[var(--color-accent-secondary)] hover:text-[var(--color-accent)] font-medium transition-colors"
+          className="text-[var(--color-accent-secondary)] hover:text-[var(--color-accent)] font-medium transition-colors animate-press"
         >
           Sign up
         </button>

--- a/client/src/components/auth/SignupForm.tsx
+++ b/client/src/components/auth/SignupForm.tsx
@@ -93,7 +93,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
           onBlur={(e) => validateEmail(e.target.value)}
           required
           autoComplete="email"
-          className={`block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-all mono text-sm ${
+          className={`block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm ${
             emailError ? 'border-[var(--color-negative)]' : 'border-[var(--color-border)]'
           }`}
           placeholder="you@example.com"
@@ -115,7 +115,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
           required
           minLength={6}
           autoComplete="new-password"
-          className="block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-all mono text-sm"
+          className="block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm"
           placeholder="••••••••"
         />
         <PasswordStrengthBar password={password} />
@@ -134,7 +134,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
             onChange={(e) => setConfirmPassword(e.target.value)}
             required
             autoComplete="new-password"
-            className={`block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] transition-all mono text-sm ${
+            className={`block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm ${
               confirmPassword.length > 0 && !passwordsMatch
                 ? 'border-[var(--color-negative)]'
                 : 'border-[var(--color-border)]'
@@ -151,16 +151,14 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
       </div>
 
       {displayError && (
-        <div className="p-3 rounded-sm" style={{
-          backgroundColor: displayError.includes('check your email')
-            ? 'color-mix(in srgb, var(--color-positive) 10%, transparent)'
-            : 'color-mix(in srgb, var(--color-negative) 10%, transparent)',
-          borderWidth: '1px',
-          borderColor: displayError.includes('check your email')
-            ? 'color-mix(in srgb, var(--color-positive) 20%, transparent)'
-            : 'color-mix(in srgb, var(--color-negative) 20%, transparent)',
-        }}>
-          <p className={`text-sm mono ${
+        <div
+          className={`glass-slab-floating relative overflow-hidden rounded-lg pl-4 pr-3 py-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] ${
+            displayError.includes('check your email')
+              ? "before:bg-[var(--color-positive)] shadow-[0_8px_30px_-10px_rgba(16,185,129,0.35)]"
+              : "before:bg-[var(--color-negative)] shadow-[0_8px_30px_-10px_rgba(239,68,68,0.35)]"
+          }`}
+        >
+          <p className={`text-sm font-medium ${
             displayError.includes('check your email')
               ? 'text-[var(--color-positive)]'
               : 'text-[var(--color-negative)]'
@@ -179,7 +177,7 @@ export function SignupForm({ onSwitchToLogin }: SignupFormProps) {
         <button
           type="button"
           onClick={onSwitchToLogin}
-          className="text-[var(--color-accent-secondary)] hover:text-[var(--color-accent)] font-medium transition-colors"
+          className="text-[var(--color-accent-secondary)] hover:text-[var(--color-accent)] font-medium transition-colors animate-press"
         >
           Sign in
         </button>

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -35,21 +35,52 @@ const routePrefetchMap: Record<string, () => Promise<unknown>> = {
   '/help':     () => import('@/pages/Help'),
 };
 
-const navigation = [
-  { name: 'Dashboard', icon: LayoutDashboard, href: '/' },
-  { name: 'Portfolio', icon: Briefcase, href: '/portfolio' },
-  { name: 'Trade', icon: ShoppingCart, href: '/trade' },
-  { name: 'Optimize', icon: Sparkles, href: '/optimize' },
-  { name: 'Factors', icon: BarChart3, href: '/factors' },
-  { name: 'Earnings', icon: Calendar, href: '/earnings' },
-  { name: 'Alerts', icon: Bell, href: '/alerts' },
-  { name: 'CVRF', icon: Brain, href: '/cvrf' },
-  { name: 'ML', icon: Cpu, href: '/ml' },
-  { name: 'Options', icon: Sigma, href: '/options' },
-  { name: 'Social', icon: Users, href: '/social' },
-  { name: 'Tax', icon: Receipt, href: '/tax' },
-  { name: 'Settings', icon: Settings, href: '/settings' },
-  { name: 'Help', icon: HelpCircle, href: '/help' },
+type NavItem = {
+  name: string;
+  icon: typeof LayoutDashboard;
+  href: string;
+};
+
+type NavSection = {
+  label: string;
+  items: NavItem[];
+};
+
+const navSections: NavSection[] = [
+  {
+    label: 'Overview',
+    items: [
+      { name: 'Dashboard', icon: LayoutDashboard, href: '/' },
+      { name: 'Portfolio', icon: Briefcase, href: '/portfolio' },
+    ],
+  },
+  {
+    label: 'Execution',
+    items: [
+      { name: 'Trade', icon: ShoppingCart, href: '/trade' },
+      { name: 'Optimize', icon: Sparkles, href: '/optimize' },
+      { name: 'Options', icon: Sigma, href: '/options' },
+    ],
+  },
+  {
+    label: 'Intelligence',
+    items: [
+      { name: 'Factors', icon: BarChart3, href: '/factors' },
+      { name: 'CVRF', icon: Brain, href: '/cvrf' },
+      { name: 'ML', icon: Cpu, href: '/ml' },
+      { name: 'Earnings', icon: Calendar, href: '/earnings' },
+      { name: 'Social', icon: Users, href: '/social' },
+    ],
+  },
+  {
+    label: 'Account',
+    items: [
+      { name: 'Alerts', icon: Bell, href: '/alerts' },
+      { name: 'Tax', icon: Receipt, href: '/tax' },
+      { name: 'Settings', icon: Settings, href: '/settings' },
+      { name: 'Help', icon: HelpCircle, href: '/help' },
+    ],
+  },
 ];
 
 interface SidebarProps {
@@ -65,33 +96,42 @@ export function Sidebar({ onNavigate }: SidebarProps) {
 
   return (
     <aside className="fixed left-0 top-16 bottom-0 w-64 glass-slab overflow-y-auto">
-      <nav className="p-4 space-y-1">
-        {navigation.map((item) => (
-          <NavLink
-            key={item.name}
-            to={item.href}
-            end={item.href === '/'}
-            onClick={onNavigate}
-            onPointerEnter={() => handlePrefetch(item.href)}
-            className={({ isActive }: { isActive: boolean }) => `
-              flex items-center gap-3 px-4 py-3 rounded-sm transition-all click-feedback
-              focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-inset
-              ${isActive
-                ? 'gradient-brand-subtle text-accent font-medium'
-                : 'text-theme-secondary hover:bg-theme-tertiary'
-              }
-            `}
-          >
-            <item.icon className="w-5 h-5" aria-hidden="true" />
-            <span className="text-sm">{item.name}</span>
-          </NavLink>
+      <nav className="p-4 pb-32 space-y-6">
+        {navSections.map((section) => (
+          <div key={section.label} className="space-y-1">
+            <p className="px-4 pb-1 mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">
+              {section.label}
+            </p>
+            {section.items.map((item) => (
+              <NavLink
+                key={item.name}
+                to={item.href}
+                end={item.href === '/'}
+                onClick={onNavigate}
+                onPointerEnter={() => handlePrefetch(item.href)}
+                className={({ isActive }: { isActive: boolean }) => `
+                  relative flex items-center gap-3 px-4 py-3 rounded-sm
+                  transition-[background-color,color] duration-200 animate-press
+                  focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-inset
+                  before:content-[''] before:absolute before:left-0 before:top-2 before:bottom-2 before:w-[3px] before:rounded-full
+                  ${isActive
+                    ? 'bg-[var(--color-accent-light)] text-[var(--color-text)] font-medium before:bg-[image:var(--gradient-sovereign)]'
+                    : 'text-theme-secondary hover:bg-[var(--color-bg-tertiary)] hover:text-theme before:bg-transparent'
+                  }
+                `}
+              >
+                <item.icon className="w-5 h-5" aria-hidden="true" />
+                <span className="text-sm">{item.name}</span>
+              </NavLink>
+            ))}
+          </div>
         ))}
       </nav>
 
-      <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-theme">
-        <div className="p-3 gradient-brand-subtle rounded-sm">
-          <p className="text-[10px] text-accent font-bold mono tracking-[0.3em] uppercase">DQ Score: 0.88</p>
-          <p className="text-[10px] text-theme-muted mono mt-1">Powered by 80+ factors</p>
+      <div className="absolute bottom-0 left-0 right-0 p-4 border-t border-theme glass-slab">
+        <div className="p-3 rounded-sm bg-[image:var(--gradient-sovereign)] text-white animate-press animate-lift shadow-[0_4px_20px_rgba(123,44,255,0.3)] hover:brightness-110 transition-[filter] duration-200 cursor-default">
+          <p className="text-[10px] font-bold mono tracking-[0.3em] uppercase">DQ Score: 0.88</p>
+          <p className="text-[10px] mono mt-1 opacity-80">Powered by 80+ factors</p>
         </div>
       </div>
     </aside>

--- a/client/src/components/settings/APIKeys.tsx
+++ b/client/src/components/settings/APIKeys.tsx
@@ -159,7 +159,7 @@ export function APIKeys() {
     <div className="space-y-4">
       {/* Created key banner -- shown once after creation */}
       {createdKey && (
-        <div className="p-4 rounded-lg border-2 border-[color-mix(in_srgb,var(--color-warning)_40%,transparent)] bg-[color-mix(in_srgb,var(--color-warning)_5%,transparent)]">
+        <div className="glass-slab-floating relative overflow-hidden rounded-lg p-4 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-warning)] shadow-[0_8px_30px_-10px_rgba(234,179,8,0.35)]">
           <div className="flex items-start gap-3">
             <AlertTriangle className="w-5 h-5 text-[var(--color-warning)] mt-0.5 flex-shrink-0" />
             <div className="flex-1 min-w-0">
@@ -228,7 +228,7 @@ export function APIKeys() {
                 value={newKeyName}
                 onChange={(e) => setNewKeyName(e.target.value)}
                 placeholder="e.g., Trading Bot, Portfolio Sync"
-                className="w-full px-3 py-2 border border-[var(--color-border)] rounded-lg focus:ring-2 focus:ring-[var(--color-info)] bg-transparent"
+                className="block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm"
                 autoFocus
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') handleCreate();
@@ -243,21 +243,25 @@ export function APIKeys() {
               </label>
               <div className="flex gap-3">
                 <button
+                  type="button"
                   onClick={() => setNewKeyPermissions('read')}
-                  className={`flex-1 py-2 px-3 rounded-lg border-2 text-sm transition ${
+                  aria-pressed={newKeyPermissions === 'read'}
+                  className={`flex-1 py-2.5 px-3 rounded-lg border-2 text-sm mono tracking-[0.1em] capitalize animate-press transition-[border-color,background-color,color] duration-200 ${
                     newKeyPermissions === 'read'
-                      ? 'border-[var(--color-info)] bg-[color-mix(in_srgb,var(--color-info)_10%,transparent)] text-[var(--color-info)]'
-                      : 'border-[var(--color-border)] hover:border-[var(--color-border)]'
+                      ? 'border-[var(--color-accent)] bg-[var(--color-accent-light)] text-[var(--color-accent)]'
+                      : 'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)]'
                   }`}
                 >
                   Read Only
                 </button>
                 <button
+                  type="button"
                   onClick={() => setNewKeyPermissions('readwrite')}
-                  className={`flex-1 py-2 px-3 rounded-lg border-2 text-sm transition ${
+                  aria-pressed={newKeyPermissions === 'readwrite'}
+                  className={`flex-1 py-2.5 px-3 rounded-lg border-2 text-sm mono tracking-[0.1em] capitalize animate-press transition-[border-color,background-color,color] duration-200 ${
                     newKeyPermissions === 'readwrite'
-                      ? 'border-[var(--color-info)] bg-[color-mix(in_srgb,var(--color-info)_10%,transparent)] text-[var(--color-info)]'
-                      : 'border-[var(--color-border)] hover:border-[var(--color-border)]'
+                      ? 'border-[var(--color-accent)] bg-[var(--color-accent-light)] text-[var(--color-accent)]'
+                      : 'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)]'
                   }`}
                 >
                   Read &amp; Write
@@ -312,8 +316,9 @@ export function APIKeys() {
                     {maskKeyId(key.id)}
                   </code>
                   <button
+                    type="button"
                     onClick={() => toggleKeyVisibility(key.id)}
-                    className="text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition"
+                    className="text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors duration-200 animate-press"
                     title={visibleKeyIds.has(key.id) ? 'Hide details' : 'Show details'}
                   >
                     {visibleKeyIds.has(key.id) ? (

--- a/client/src/components/shared/Button.tsx
+++ b/client/src/components/shared/Button.tsx
@@ -14,31 +14,32 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 const variants = {
   primary: `
     bg-[image:var(--gradient-sovereign)] text-white
-    hover:opacity-90
-    active:opacity-80
-    shadow-md hover:shadow-lg active:shadow-sm
-    focus:ring-2 focus:ring-[var(--brand-amethyst)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]
+    shadow-[0_4px_14px_rgba(123,44,255,0.25)]
+    hover:shadow-[0_6px_20px_rgba(123,44,255,0.35)] hover:brightness-110
+    active:brightness-95
+    focus-visible:ring-2 focus-visible:ring-[var(--brand-amethyst)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]
   `,
   secondary: `
-    bg-[var(--color-bg-tertiary)] text-[var(--color-text)]
-    hover:opacity-80 active:opacity-70
-    focus:ring-2 focus:ring-[var(--brand-amethyst)]/40 focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]
+    glass-slab text-[var(--color-text)]
+    hover:border-[color:var(--color-border-hover)]
+    focus-visible:ring-2 focus-visible:ring-[var(--brand-amethyst)]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]
   `,
   danger: `
     bg-[var(--color-negative)] text-white
-    hover:bg-[var(--color-negative)] active:bg-[var(--color-negative)]
-    shadow-md hover:shadow-lg active:shadow-sm
-    focus:ring-2 focus:ring-[var(--color-negative)] focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]
+    shadow-[0_4px_14px_rgba(239,68,68,0.25)]
+    hover:brightness-110 hover:shadow-[0_6px_20px_rgba(239,68,68,0.35)]
+    active:brightness-95
+    focus-visible:ring-2 focus-visible:ring-[var(--color-negative)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]
   `,
   ghost: `
     bg-transparent text-[var(--color-text-secondary)]
-    hover:bg-[var(--color-bg-tertiary)] active:opacity-70
-    focus:ring-2 focus:ring-[var(--brand-amethyst)]/40 focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]
+    hover:bg-[var(--color-bg-tertiary)] hover:text-[var(--color-text)]
+    focus-visible:ring-2 focus-visible:ring-[var(--brand-amethyst)]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]
   `,
   outline: `
     bg-[var(--color-bg-secondary)] text-[var(--color-text)] border border-[var(--color-border)]
-    hover:bg-[var(--color-bg-tertiary)] hover:border-[var(--brand-amethyst)]/30 active:opacity-80
-    focus:ring-2 focus:ring-[var(--brand-amethyst)]/40 focus:ring-offset-2 focus:ring-offset-[var(--color-bg)]
+    hover:bg-[var(--color-bg-tertiary)] hover:border-[var(--brand-amethyst)]/40
+    focus-visible:ring-2 focus-visible:ring-[var(--brand-amethyst)]/40 focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--color-bg)]
   `,
 };
 
@@ -65,9 +66,8 @@ export function Button({
       className={`
         ${variants[variant]} ${sizes[size]}
         rounded-lg font-medium
-        transition-all duration-150 ease-out
-        transform hover:scale-[1.02] active:scale-[0.98]
-        disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none
+        animate-press animate-lift
+        disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none
         flex items-center justify-center gap-2
         outline-none
         ${fullWidth ? 'w-full' : ''}
@@ -115,9 +115,9 @@ export function IconButton({
         ${variants[variant]}
         ${iconSizes[size]}
         rounded-lg
-        transition-all duration-150 ease-out
-        transform hover:scale-110 active:scale-95
-        disabled:opacity-50 disabled:cursor-not-allowed disabled:transform-none
+        animate-press
+        transition-[background-color,color,border-color,box-shadow] duration-200 ease-out
+        disabled:opacity-50 disabled:cursor-not-allowed
         flex items-center justify-center
         outline-none
         ${className}

--- a/client/src/components/shared/ErrorBoundary.tsx
+++ b/client/src/components/shared/ErrorBoundary.tsx
@@ -101,33 +101,37 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
         return this.props.fallback;
       }
 
-      // Default error UI
+      // Default error UI — sovereign aesthetic
       return (
-        <div className="min-h-screen bg-[var(--color-bg-tertiary)] flex items-center justify-center p-4">
-          <div className="max-w-md w-full bg-[var(--color-bg)] rounded-xl shadow-lg p-8 text-center">
-            <div className="w-16 h-16 bg-[color-mix(in_srgb,var(--color-negative)_10%,transparent)] rounded-full flex items-center justify-center mx-auto mb-6">
+        <div className="min-h-screen bg-theme grid-bg flex items-center justify-center p-4">
+          <div className="glass-slab-floating relative overflow-hidden rounded-2xl max-w-md w-full p-8 text-center shadow-[0_30px_80px_-20px_rgba(123,44,255,0.35)]">
+            <div className="sovereign-bar absolute top-0 left-0 right-0" />
+
+            <div className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6 bg-[color-mix(in_srgb,var(--color-negative)_12%,transparent)] shadow-[0_0_40px_rgba(239,68,68,0.35)]">
               <AlertTriangle className="w-8 h-8 text-[var(--color-negative)]" />
             </div>
 
-            <h1 className="text-2xl font-bold text-[var(--color-text)] mb-2">
+            <h1 className="text-2xl font-bold mb-2 text-gradient-brand">
               Something went wrong
             </h1>
 
-            <p className="text-[var(--color-text-secondary)] mb-6">
+            <p className="text-theme-secondary mb-6 leading-relaxed">
               We apologize for the inconvenience. Our team has been notified and
               is working to fix the issue.
             </p>
 
             {this.state.eventId && (
-              <p className="text-xs text-[var(--color-text-muted)] mb-6 font-mono">
-                Error ID: {this.state.eventId}
-              </p>
+              <div className="inline-block mb-6 px-3 py-1.5 rounded-md border border-theme bg-[color-mix(in_srgb,var(--color-bg-secondary)_60%,transparent)]">
+                <span className="text-xs text-theme-muted font-mono">
+                  Error ID: {this.state.eventId}
+                </span>
+              </div>
             )}
 
             <div className="space-y-3">
               <button
                 onClick={this.handleReset}
-                className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-[var(--color-info)] text-white rounded-lg hover:bg-[var(--color-info)] transition-colors"
+                className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg bg-[image:var(--gradient-sovereign)] text-white font-medium animate-press animate-lift shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:brightness-110 hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)]"
               >
                 <RefreshCw className="w-4 h-4" />
                 Try Again
@@ -135,7 +139,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
               <button
                 onClick={this.handleGoHome}
-                className="w-full flex items-center justify-center gap-2 px-4 py-3 border border-[var(--color-border)] text-[var(--color-text-secondary)] rounded-lg hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                className="glass-slab w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg text-theme animate-press animate-lift hover:border-[color:var(--color-border-hover)]"
               >
                 <Home className="w-4 h-4" />
                 Go to Dashboard
@@ -144,20 +148,20 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
             {import.meta.env.DEV && this.state.error && (
               <details className="mt-6 text-left">
-                <summary className="text-sm text-[var(--color-text-muted)] cursor-pointer hover:text-[var(--color-text-secondary)]">
+                <summary className="text-sm text-theme-muted cursor-pointer hover:text-theme-secondary transition-colors">
                   Technical Details
                 </summary>
-                <div className="mt-2 p-3 bg-[var(--color-bg-secondary)] rounded text-xs font-mono overflow-auto max-h-48">
+                <div className="glass-slab mt-2 p-3 rounded-lg text-xs font-mono overflow-auto max-h-48">
                   <p className="text-[var(--color-negative)] font-semibold">
                     {this.state.error.name}: {this.state.error.message}
                   </p>
                   {this.state.error.stack && (
-                    <pre className="mt-2 text-[var(--color-text-secondary)] whitespace-pre-wrap">
+                    <pre className="mt-2 text-theme-secondary whitespace-pre-wrap">
                       {this.state.error.stack}
                     </pre>
                   )}
                   {this.state.errorInfo?.componentStack && (
-                    <pre className="mt-2 text-[var(--color-text-muted)] whitespace-pre-wrap">
+                    <pre className="mt-2 text-theme-muted whitespace-pre-wrap">
                       Component Stack:
                       {this.state.errorInfo.componentStack}
                     </pre>
@@ -189,7 +193,7 @@ export function withErrorBoundary<P extends object>(
   };
 }
 
-// Simple error boundary for sections
+// Simple error boundary for sections — Toast family aesthetic
 interface SectionErrorBoundaryProps {
   children: ReactNode;
   sectionName?: string;
@@ -199,14 +203,27 @@ export function SectionErrorBoundary({ children, sectionName }: SectionErrorBoun
   return (
     <ErrorBoundary
       fallback={
-        <div className="bg-[color-mix(in_srgb,var(--color-negative)_10%,transparent)] border border-[color-mix(in_srgb,var(--color-negative)_20%,transparent)] rounded-lg p-6 text-center">
-          <AlertTriangle className="w-8 h-8 text-[var(--color-negative)] mx-auto mb-3" />
-          <p className="text-[var(--color-negative)] font-medium">
-            Failed to load {sectionName || 'this section'}
-          </p>
-          <p className="text-[var(--color-negative)] text-sm mt-1">
-            Please refresh the page or try again later.
-          </p>
+        <div
+          className="
+            glass-slab-floating relative overflow-hidden
+            rounded-xl pl-5 pr-4 py-4
+            shadow-[0_18px_60px_-20px_rgba(239,68,68,0.45)]
+            before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px]
+            before:bg-[var(--color-negative)]
+          "
+          role="alert"
+        >
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5 text-[var(--color-negative)]" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-theme">
+                Failed to load {sectionName || 'this section'}
+              </p>
+              <p className="text-sm mt-1 text-theme-secondary leading-relaxed">
+                Please refresh the page or try again later.
+              </p>
+            </div>
+          </div>
         </div>
       }
     >

--- a/client/src/components/shared/Toast.tsx
+++ b/client/src/components/shared/Toast.tsx
@@ -27,32 +27,24 @@ const icons = {
 
 const colors = {
   success: {
-    bg: 'bg-[var(--color-positive)]/10',
-    border: 'border-[var(--color-positive)]/20',
+    rail: 'before:bg-[var(--color-positive)]',
     icon: 'text-[var(--color-positive)]',
-    title: 'text-[var(--color-text)]',
-    message: 'text-[var(--color-text-secondary)]',
+    glow: 'shadow-[0_18px_60px_-20px_rgba(16,185,129,0.45)]',
   },
   error: {
-    bg: 'bg-[var(--color-danger)]/10',
-    border: 'border-[var(--color-danger)]/20',
+    rail: 'before:bg-[var(--color-danger)]',
     icon: 'text-[var(--color-danger)]',
-    title: 'text-[var(--color-text)]',
-    message: 'text-[var(--color-text-secondary)]',
+    glow: 'shadow-[0_18px_60px_-20px_rgba(239,68,68,0.45)]',
   },
   info: {
-    bg: 'bg-[var(--color-accent)]/10',
-    border: 'border-[var(--color-accent)]/20',
+    rail: 'before:bg-[image:var(--gradient-sovereign)]',
     icon: 'text-[var(--color-accent)]',
-    title: 'text-[var(--color-text)]',
-    message: 'text-[var(--color-text-secondary)]',
+    glow: 'shadow-[0_18px_60px_-20px_rgba(123,44,255,0.45)]',
   },
   warning: {
-    bg: 'bg-[var(--color-warning)]/10',
-    border: 'border-[var(--color-warning)]/20',
+    rail: 'before:bg-[var(--color-warning)]',
     icon: 'text-[var(--color-warning)]',
-    title: 'text-[var(--color-text)]',
-    message: 'text-[var(--color-text-secondary)]',
+    glow: 'shadow-[0_18px_60px_-20px_rgba(245,158,11,0.45)]',
   },
 };
 
@@ -79,20 +71,22 @@ function Toast({ id, type, title, message, duration = 4000, action, onClose }: T
   return (
     <div
       className={`
-        ${colorScheme.bg} ${colorScheme.border} border
-        rounded-lg shadow-lg p-4 max-w-sm w-full
-        transition-all duration-300 ease-out
-        ${isExiting ? 'opacity-0 translate-x-4' : 'opacity-100 translate-x-0'}
-        animate-slide-in-right
+        glass-slab-floating relative overflow-hidden
+        rounded-xl pl-5 pr-4 py-4 max-w-sm w-full
+        ${colorScheme.glow}
+        before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px]
+        ${colorScheme.rail}
+        transition-[opacity,transform] duration-300 ease-out
+        ${isExiting ? 'opacity-0 translate-x-4' : 'opacity-100 translate-x-0 animate-slide-in-right'}
       `}
       role="alert"
     >
       <div className="flex items-start gap-3">
-        <Icon className={`w-5 h-5 flex-shrink-0 ${colorScheme.icon}`} />
+        <Icon className={`w-5 h-5 flex-shrink-0 mt-0.5 ${colorScheme.icon}`} />
         <div className="flex-1 min-w-0">
-          <p className={`text-sm font-medium ${colorScheme.title}`}>{title}</p>
+          <p className="text-sm font-semibold text-theme">{title}</p>
           {message && (
-            <p className={`text-sm mt-1 ${colorScheme.message}`}>{message}</p>
+            <p className="text-sm mt-1 text-theme-secondary leading-relaxed">{message}</p>
           )}
           {action && (
             <button
@@ -100,7 +94,7 @@ function Toast({ id, type, title, message, duration = 4000, action, onClose }: T
                 action.onClick();
                 handleClose();
               }}
-              className={`text-sm font-medium mt-2 ${colorScheme.icon} hover:opacity-80 transition-opacity`}
+              className={`text-sm font-medium mt-2 ${colorScheme.icon} hover:opacity-80 transition-opacity animate-press`}
             >
               {action.label}
             </button>
@@ -108,7 +102,7 @@ function Toast({ id, type, title, message, duration = 4000, action, onClose }: T
         </div>
         <button
           onClick={handleClose}
-          className={`flex-shrink-0 ${colorScheme.icon} hover:opacity-70 transition-opacity`}
+          className="flex-shrink-0 text-theme-muted hover:text-theme transition-colors animate-press"
           aria-label="Close notification"
         >
           <X className="w-4 h-4" />

--- a/client/src/components/shared/skeletons/SkeletonChart.tsx
+++ b/client/src/components/shared/skeletons/SkeletonChart.tsx
@@ -1,11 +1,40 @@
 import React from 'react';
 import { Skeleton } from '../Skeleton';
 
+// Mirrors EquityCurve.tsx: title row + total-return / alpha stats + timeframe
+// pill group + h-64 (256px) canvas + legend row. Container reserves the same
+// box so the chart can mount without shifting siblings.
 export const SkeletonChart = React.memo(function SkeletonChart() {
   return (
     <div className="bg-[var(--color-bg)] rounded-xl shadow-lg p-6">
-      <Skeleton variant="text" width={150} height={24} className="mb-4" />
-      <Skeleton variant="rectangular" height={250} />
+      <Skeleton variant="text" width={180} height={20} className="mb-4" />
+      <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
+        <div className="flex items-center gap-6">
+          <div>
+            <Skeleton variant="text" width={80} height={12} className="mb-1" />
+            <Skeleton variant="text" width={90} height={20} />
+          </div>
+          <div>
+            <Skeleton variant="text" width={70} height={12} className="mb-1" />
+            <Skeleton variant="text" width={80} height={20} />
+          </div>
+        </div>
+        {/* Timeframe pill group — 5 buttons matching real control */}
+        <div className="flex gap-1 bg-[var(--color-bg-tertiary)] rounded-lg p-1">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} variant="rectangular" width={36} height={28} className="rounded-md" />
+          ))}
+        </div>
+      </div>
+      {/* Canvas reservation — h-64 matches EquityCurve.tsx line 463 */}
+      <div className="h-64 w-full">
+        <Skeleton variant="rectangular" className="h-full w-full" />
+      </div>
+      {/* Legend row */}
+      <div className="flex items-center justify-center gap-6 mt-4">
+        <Skeleton variant="text" width={80} height={14} />
+        <Skeleton variant="text" width={80} height={14} />
+      </div>
     </div>
   );
 });

--- a/client/src/components/shared/skeletons/SkeletonDashboard.tsx
+++ b/client/src/components/shared/skeletons/SkeletonDashboard.tsx
@@ -1,60 +1,79 @@
 import React from 'react';
-import { Skeleton, SkeletonCard } from '../Skeleton';
+import { Skeleton } from '../Skeleton';
 import { SkeletonPositionList } from './SkeletonPositionList';
 import { SkeletonFactorExposures } from './SkeletonFactorExposures';
 import { SkeletonRiskMetrics } from './SkeletonRiskMetrics';
 import { SkeletonChart } from './SkeletonChart';
+import { SkeletonPortfolioOverview } from './SkeletonPortfolioOverview';
 
+// CLS-stable: this skeleton mirrors the real Dashboard.tsx grid exactly
+// (MarketStatusStrip + pt-6 hero + lg:grid-cols-3 [2+1] + tertiary zone).
+// Container heights match the loaded layout so swap is zero-shift.
 export const SkeletonDashboard = React.memo(function SkeletonDashboard() {
   return (
-    <div className="space-y-6 animate-fade-in">
-      {/* Hero header skeleton — greeting + status pill */}
+    <div className="space-y-6 animate-fade-in pt-6">
+      {/* Market status strip placeholder — matches MarketStatusStrip h ~32px */}
+      <div className="skeleton-shimmer h-8 w-full rounded-md" aria-hidden="true" />
+
+      {/* Hero header — greeting + quick actions + live status pill */}
       <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
         <div>
           <Skeleton variant="text" width={280} height={32} className="mb-2" />
           <Skeleton variant="text" width={160} height={16} className="mb-3" />
-          <div className="flex gap-2">
-            <Skeleton variant="rectangular" width={100} height={28} className="rounded-full" />
-            <Skeleton variant="rectangular" width={80} height={28} className="rounded-full" />
-            <Skeleton variant="rectangular" width={70} height={28} className="rounded-full" />
+          <div className="flex gap-2 mt-3 flex-wrap">
+            <Skeleton variant="rectangular" width={120} height={28} className="rounded-full" />
+            <Skeleton variant="rectangular" width={92} height={28} className="rounded-full" />
+            <Skeleton variant="rectangular" width={76} height={28} className="rounded-full" />
           </div>
         </div>
-        <Skeleton variant="rectangular" width={140} height={36} className="rounded-full" />
+        {/* Live status pill — fixed width matches glass-slab pill in real header */}
+        <div className="glass-slab rounded-full px-4 py-2 flex items-center gap-2 self-start flex-shrink-0 min-w-[168px] h-9">
+          <span className="inline-block w-2 h-2 rounded-full bg-[var(--color-text-muted)] opacity-40" />
+          <Skeleton variant="text" width={32} height={12} />
+          <span className="border-l border-[var(--color-border-light)] pl-2 ml-0.5">
+            <Skeleton variant="text" width={56} height={12} />
+          </span>
+        </div>
       </div>
 
-      {/* Hero portfolio value skeleton */}
+      {/* Primary + secondary zone — mirrors lg:grid-cols-3 with 2+1 split */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-5">
+        {/* Primary: PortfolioOverview + EquityCurve */}
+        <div className="lg:col-span-2 space-y-5">
+          <SkeletonPortfolioOverview />
+          <SkeletonChart />
+        </div>
+        {/* Secondary: WeightAllocation + PositionList */}
+        <div className="lg:col-span-1 space-y-5">
+          {/* WeightAllocation donut — fixed-size SVG in real component */}
+          <div className="bg-[var(--color-bg)] rounded-xl shadow-lg p-6">
+            <Skeleton variant="text" width={140} height={20} className="mb-4" />
+            <div className="flex justify-center items-center min-h-[220px]">
+              <Skeleton variant="circular" width={180} height={180} />
+            </div>
+          </div>
+          <SkeletonPositionList />
+        </div>
+      </div>
+
+      {/* Tertiary zone — collapsible analytics, 3-col on lg */}
       <div className="bg-[var(--color-bg)] rounded-xl shadow-lg p-6">
-        <div className="rounded-xl p-5 mb-5" style={{ background: 'var(--color-bg-tertiary)' }}>
-          <Skeleton variant="text" width={100} height={12} className="mb-2" />
-          <Skeleton variant="text" width={220} height={44} className="mb-2" />
-          <Skeleton variant="rectangular" width={180} height={24} className="rounded-full" />
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div className="flex items-center gap-3">
-            <Skeleton variant="rectangular" width={40} height={40} className="rounded-lg" />
-            <div>
-              <Skeleton variant="text" width={80} height={12} className="mb-1" />
-              <Skeleton variant="text" width={100} height={20} />
-            </div>
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <Skeleton variant="text" width={180} height={20} className="mb-1" />
+            <Skeleton variant="text" width={260} height={14} />
           </div>
-          <div className="flex items-center gap-3">
-            <Skeleton variant="rectangular" width={40} height={40} className="rounded-lg" />
-            <div>
-              <Skeleton variant="text" width={60} height={12} className="mb-1" />
-              <Skeleton variant="text" width={80} height={20} />
-            </div>
+          <Skeleton variant="circular" width={20} height={20} />
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+          <SkeletonFactorExposures />
+          <SkeletonRiskMetrics />
+          <div className="bg-[var(--color-bg-tertiary)] rounded-xl shadow-lg p-6 min-h-[280px]">
+            <Skeleton variant="text" width={160} height={20} className="mb-4" />
+            <Skeleton variant="text" lines={4} />
+            <Skeleton variant="rectangular" height={80} className="mt-4" />
           </div>
         </div>
-      </div>
-
-      <SkeletonChart />
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <SkeletonPositionList />
-        <SkeletonFactorExposures />
-      </div>
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        <SkeletonRiskMetrics />
-        <SkeletonCard />
       </div>
     </div>
   );

--- a/client/src/components/shared/skeletons/SkeletonPortfolioOverview.tsx
+++ b/client/src/components/shared/skeletons/SkeletonPortfolioOverview.tsx
@@ -1,18 +1,32 @@
 import React from 'react';
 import { Skeleton } from '../Skeleton';
 
+// Mirrors PortfolioOverview.tsx: Card title + gradient hero (label, big $value
+// + daily-change pill) + 2-col grid of icon stat cards. Box dimensions match
+// the loaded card so the next-row chart never shifts up when data arrives.
 export const SkeletonPortfolioOverview = React.memo(function SkeletonPortfolioOverview() {
   return (
     <div className="bg-[var(--color-bg)] rounded-xl shadow-lg p-6">
-      <div className="flex items-center justify-between mb-6">
-        <Skeleton variant="text" width={180} height={28} />
-        <Skeleton variant="rectangular" width={100} height={36} />
+      <Skeleton variant="text" width={180} height={20} className="mb-4" />
+      {/* Hero value block — gradient-brand-subtle p-6 mb-5 */}
+      <div className="rounded-xl p-6 mb-5 border border-[var(--color-border-light)]" style={{ background: 'var(--color-bg-tertiary)' }}>
+        <Skeleton variant="text" width={92} height={12} className="mb-2" />
+        <div className="flex items-baseline gap-3 flex-wrap">
+          {/* Hero number — text-4xl lg:text-5xl ~48-60px line-height */}
+          <Skeleton variant="text" width={260} height={56} />
+          {/* Daily change pill */}
+          <Skeleton variant="rectangular" width={200} height={28} className="rounded-full" />
+        </div>
       </div>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {Array.from({ length: 4 }).map((_, i) => (
-          <div key={i} className="text-center">
-            <Skeleton variant="text" width="60%" height={16} className="mx-auto mb-2" />
-            <Skeleton variant="text" width="80%" height={28} className="mx-auto" />
+      {/* Stat cards — sm:grid-cols-2 with 40px icon + label + value */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3 p-4 rounded-xl bg-[var(--color-bg-tertiary)]">
+            <Skeleton variant="rectangular" width={44} height={44} className="rounded-lg flex-shrink-0" />
+            <div className="min-w-0 flex-1">
+              <Skeleton variant="text" width={88} height={12} className="mb-1" />
+              <Skeleton variant="text" width={120} height={20} />
+            </div>
           </div>
         ))}
       </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -526,6 +526,40 @@
     0% { opacity: 0; transform: translateY(6px); }
     100% { opacity: 1; transform: translateY(0); }
   }
+
+  /* ── Family-grade enter animations (formerly referenced but undefined,
+     causing hard cuts on toasts, sidebars, and overlays). ── */
+  .animate-fade-in {
+    animation: fa-fade-in var(--motion-duration-base) var(--motion-ease-out) both;
+  }
+  @keyframes fa-fade-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+
+  .animate-slide-in-left {
+    animation: fa-slide-in-left var(--motion-duration-slow) var(--motion-ease-out) both;
+  }
+  @keyframes fa-slide-in-left {
+    from { transform: translateX(-100%); opacity: 0; }
+    to   { transform: translateX(0);     opacity: 1; }
+  }
+
+  .animate-slide-in-right {
+    animation: fa-slide-in-right var(--motion-duration-base) var(--motion-ease-out) both;
+  }
+  @keyframes fa-slide-in-right {
+    from { transform: translateX(16px); opacity: 0; }
+    to   { transform: translateX(0);    opacity: 1; }
+  }
+
+  .animate-pulse-subtle {
+    animation: fa-pulse-subtle 2.4s ease-in-out infinite;
+  }
+  @keyframes fa-pulse-subtle {
+    0%, 100% { opacity: 0.6; }
+    50%      { opacity: 1; }
+  }
 }
 
 /* ── Motion utility classes (MOTION-002) ────────────────────────────── */

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -412,10 +412,12 @@ export function Dashboard() {
     });
   }, [quotes]);
 
-  // Show skeleton while loading
+  // Show skeleton while loading. Render inside the SAME PullToRefresh +
+  // pt-6 chrome the loaded view uses, so the only thing that swaps is
+  // skeleton-shimmer -> content within identically-sized boxes.
   if (isLoading) {
     return (
-      <div className="animate-fade-in">
+      <div className="min-h-screen">
         <SkeletonDashboard />
       </div>
     );
@@ -468,9 +470,11 @@ export function Dashboard() {
             </div>
           </div>
 
-          {/* Live status pill — glass morphism */}
+          {/* Live status pill — glass morphism. min-w + tabular-nums + reserved
+              timestamp slot prevents header CLS when first quote arrives and
+              when seconds tick (digit width swap). */}
           <div
-            className="glass-slab rounded-full px-4 py-2 flex items-center gap-2 self-start flex-shrink-0"
+            className="glass-slab rounded-full px-4 py-2 flex items-center gap-2 self-start flex-shrink-0 min-w-[168px] h-9"
           >
             <span
               className={`inline-block w-2 h-2 rounded-full transition-colors duration-300 ${
@@ -479,14 +483,19 @@ export function Dashboard() {
                   : 'bg-[var(--color-text-muted)]'
               }`}
             />
-            <span className={`text-xs font-medium transition-colors duration-300 ${isConnected ? 'text-[var(--color-positive)]' : 'text-[var(--color-text-muted)]'}`}>
+            <span
+              className={`text-xs font-medium transition-colors duration-300 inline-block w-[42px] ${isConnected ? 'text-[var(--color-positive)]' : 'text-[var(--color-text-muted)]'}`}
+            >
               {isConnected ? 'Live' : 'Offline'}
             </span>
-            {lastUpdate && (
-              <span className="text-xs text-[var(--color-text-muted)] border-l border-[var(--color-border-light)] pl-2 ml-0.5">
-                {lastUpdate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
-              </span>
-            )}
+            <span
+              className="text-xs text-[var(--color-text-muted)] border-l border-[var(--color-border-light)] pl-2 ml-0.5 tabular-nums inline-block min-w-[64px]"
+              aria-live="off"
+            >
+              {lastUpdate
+                ? lastUpdate.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+                : ' '}
+            </span>
           </div>
         </div>
 
@@ -499,10 +508,12 @@ export function Dashboard() {
             weight="primary"
             className="lg:col-span-2"
           >
-            <div data-tour="portfolio-overview">
+            <div data-tour="portfolio-overview" className="min-h-[260px]">
               <PortfolioOverview portfolio={portfolio} />
             </div>
-            <div data-tour="equity-curve" className="mt-5">
+            {/* min-h reserves canvas + chrome (h-64 canvas + ~120px chrome)
+                so EquityCurve's ResizeObserver can't reflow neighbors. */}
+            <div data-tour="equity-curve" className="mt-5 min-h-[420px]">
               <EquityCurve portfolioValue={portfolio.totalValue} />
             </div>
           </DashZone>
@@ -515,10 +526,12 @@ export function Dashboard() {
             weight="secondary"
             className="lg:col-span-1"
           >
-            <div data-tour="weight-allocation">
+            {/* WeightAllocation donut SVG — reserve donut box so the SVG
+                can't pop secondary column up when positions stream. */}
+            <div data-tour="weight-allocation" className="min-h-[260px]">
               <WeightAllocation positions={portfolio.positions} totalValue={portfolio.totalValue} />
             </div>
-            <div data-tour="positions" className="mt-5">
+            <div data-tour="positions" className="mt-5 min-h-[320px]">
               <PositionList positions={portfolio.positions} quotes={quotes} />
             </div>
           </DashZone>
@@ -533,14 +546,16 @@ export function Dashboard() {
           collapsible
           className="animate-fade-in-up"
         >
+          {/* Tertiary tiles — match skeleton min-h so async cognitive-insight
+              fetch can't push the page footer when it lands. */}
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
-            <div data-tour="factors">
+            <div data-tour="factors" className="min-h-[280px]">
               <FactorExposures factors={factors} insight={insight} />
             </div>
-            <div data-tour="risk-metrics">
+            <div data-tour="risk-metrics" className="min-h-[280px]">
               <RiskMetrics metrics={metrics} />
             </div>
-            <div data-tour="cognitive-insight">
+            <div data-tour="cognitive-insight" className="min-h-[280px]">
               <CognitiveInsight symbols={portfolio.positions.map((p) => p.symbol)} factors={factors} />
             </div>
           </div>

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -99,13 +99,13 @@ export function Landing() {
                 <button
                   onClick={handleAnalyze}
                   disabled={isAnalyzing}
-                  className="px-8 py-3 bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase transition-all click-feedback disabled:opacity-50 shadow-[0_0_30px_color-mix(in_srgb,var(--color-accent)_30%,transparent)] hover:shadow-[0_0_40px_color-mix(in_srgb,var(--color-accent)_50%,transparent)] hover:scale-[1.02] min-w-[200px]"
+                  className="px-8 py-3 bg-[image:var(--gradient-sovereign)] text-white rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:shadow-none shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)] hover:brightness-110 min-w-[200px]"
                 >
                   {isAnalyzing ? 'Analyzing…' : 'Analyze Your Portfolio'}
                 </button>
                 <button
                   onClick={handleViewDemo}
-                  className="px-8 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:border-[var(--color-accent-secondary)] hover:text-[var(--color-accent-secondary)] rounded-sm mono text-[10px] font-bold tracking-[0.3em] uppercase transition-all click-feedback min-w-[140px]"
+                  className="px-8 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:border-[var(--color-accent-secondary)] hover:text-[var(--color-accent-secondary)] rounded-sm mono text-[10px] font-bold tracking-[0.3em] uppercase animate-press animate-lift transition-[background-color,border-color,color] duration-200 min-w-[140px]"
                 >
                   Load Mag 7 Demo
                 </button>
@@ -160,13 +160,13 @@ export function Landing() {
                 onChange={(e) => setTickers(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder="NVDA, AAPL, MSFT, GOOGL..."
-                className="flex-1 px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)] transition-all mono text-sm"
+                className="flex-1 px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:border-[var(--color-accent)] focus:ring-1 focus:ring-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm"
                 disabled={isAnalyzing}
               />
               <button
                 onClick={handleAnalyze}
                 disabled={isAnalyzing}
-                className="px-8 py-3 bg-[var(--color-accent)] text-white hover:bg-[var(--color-accent-hover)] rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase transition-all click-feedback disabled:opacity-50 shadow-[0_0_30px_color-mix(in_srgb,var(--color-accent)_30%,transparent)] hover:shadow-[0_0_40px_color-mix(in_srgb,var(--color-accent)_50%,transparent)] hover:scale-[1.02] min-w-[140px]"
+                className="px-8 py-3 bg-[image:var(--gradient-sovereign)] text-white rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:shadow-none shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)] hover:brightness-110 min-w-[140px]"
               >
                 {isAnalyzing ? 'Analyzing' : 'Analyze'}
               </button>

--- a/client/src/pages/Pricing.tsx
+++ b/client/src/pages/Pricing.tsx
@@ -100,92 +100,143 @@ export function Pricing() {
   };
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg)]">
+    <div className="min-h-screen bg-theme grid-bg">
       {/* Sovereign bar */}
       <div className="sovereign-bar fixed top-0 left-0 right-0 z-50" />
 
-      <div className="max-w-6xl mx-auto px-4 py-16">
-        {/* Back navigation */}
-        <button
-          onClick={() => navigate(-1)}
-          className="flex items-center gap-2 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors mb-8"
-        >
-          <ArrowLeft className="w-4 h-4" />
-          Back
-        </button>
+      {/* ── Hero ─────────────────────────────────────────────────────────── */}
+      <section className="relative isolate overflow-hidden">
+        <div className="absolute inset-0 gradient-brand-subtle pointer-events-none" aria-hidden="true" />
 
-        {/* Header */}
-        <div className="text-center mb-12">
-          <h1 className="text-4xl sm:text-5xl font-black text-[var(--color-text)] mb-4">
-            Choose Your <span className="text-gradient-brand">Plan</span>
-          </h1>
-          <p className="text-lg text-[var(--color-text-muted)] max-w-xl mx-auto">
-            Institutional intelligence at every level. Start free, scale when you're ready.
-          </p>
+        <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 pt-20 pb-10 sm:pt-24 sm:pb-12">
+          {/* Back navigation */}
+          <button
+            onClick={() => navigate(-1)}
+            className="inline-flex items-center gap-2 mb-10 px-3 py-2 rounded-sm mono text-[10px] tracking-[0.3em] uppercase text-theme-muted hover:text-theme border border-transparent hover:border-[color:var(--color-border)] animate-press transition-[color,border-color] duration-200"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" aria-hidden="true" />
+            Back
+          </button>
+
+          <div className="text-center max-w-3xl mx-auto animate-fade-in-up">
+            <p className="text-[10px] sm:text-xs mono tracking-[0.5em] uppercase text-theme-muted mb-5">
+              Pricing · <span className="text-[color:var(--color-accent-secondary)]">Sovereign Tiers</span>
+            </p>
+
+            <h1 className="text-5xl sm:text-6xl lg:text-7xl font-black leading-[0.95] tracking-tight text-theme">
+              Choose Your{' '}
+              <span className="text-gradient-brand holo-pulse">Plan</span>
+            </h1>
+
+            <p className="mt-6 text-lg sm:text-xl text-theme-secondary leading-relaxed max-w-2xl mx-auto">
+              Institutional intelligence at every level. Start free, scale when you're ready.
+            </p>
+
+            <p className="mt-4 text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+              80+ Factors · Explainable AI · Real-Time Risk
+            </p>
+          </div>
         </div>
+      </section>
 
-        {/* Pricing Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-5xl mx-auto">
+      {/* ── Pricing Cards ────────────────────────────────────────────────── */}
+      <section className="px-4 sm:px-6 lg:px-8 pb-16 sm:pb-20 lg:pb-24">
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 lg:gap-8 max-w-6xl mx-auto animate-stagger">
           {PLANS.map((plan) => {
             const isCurrent = plan.name.toLowerCase() === currentPlan;
             const isLoading = loadingPlan === plan.name;
+            const isFree = plan.priceId === null;
+
+            const cardSurface = plan.highlighted
+              ? 'border-sovereign glass-slab md:scale-[1.02] shadow-[0_8px_50px_rgba(123,44,255,0.18)]'
+              : 'glass-slab';
 
             return (
               <div
                 key={plan.name}
-                className={`glass-slab rounded-sm p-6 sm:p-8 flex flex-col relative ${
-                  plan.highlighted ? 'border border-[var(--color-accent)]/40 shadow-[0_0_40px_color-mix(in srgb, var(--color-accent) 15%, transparent)]' : ''
-                }`}
+                className={`${cardSurface} rounded-2xl p-6 sm:p-8 flex flex-col relative animate-enter`}
               >
                 {plan.highlighted && (
-                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-4 py-1 bg-[var(--color-accent)] text-white text-[10px] mono tracking-[0.3em] uppercase rounded-full">
+                  <div className="absolute -top-3 left-1/2 -translate-x-1/2 px-4 py-1 bg-[image:var(--gradient-sovereign)] text-white text-[10px] mono tracking-[0.3em] uppercase rounded-full shadow-[0_4px_20px_rgba(123,44,255,0.45)]">
                     Most Popular
                   </div>
                 )}
 
+                {/* Tier head */}
                 <div className="mb-6">
-                  <h3 className="text-lg font-semibold text-[var(--color-text)] mb-1">{plan.name}</h3>
-                  <div className="flex items-baseline gap-1 mb-2">
-                    <span className="text-4xl font-black text-[var(--color-text)]">{plan.price}</span>
-                    <span className="text-sm text-[var(--color-text-muted)]">{plan.priceNote}</span>
+                  <h3
+                    className={`text-xl font-bold tracking-tight mb-3 ${
+                      plan.highlighted ? 'text-gradient-brand' : 'text-theme'
+                    }`}
+                  >
+                    {plan.name}
+                  </h3>
+
+                  <div className="flex items-baseline gap-1.5 mb-3">
+                    <span className="text-5xl sm:text-6xl font-black text-theme leading-none">
+                      {plan.price}
+                    </span>
+                    <span className="text-sm text-theme-muted mono tracking-[0.15em] uppercase">
+                      {plan.priceNote}
+                    </span>
                   </div>
-                  <p className="text-sm text-[var(--color-text-muted)]">{plan.description}</p>
+
+                  <p className="text-sm text-theme-secondary leading-relaxed">{plan.description}</p>
                 </div>
 
+                {/* Divider */}
+                <div className="h-px w-full bg-[color:var(--color-border-light)] mb-6" aria-hidden="true" />
+
+                {/* Feature list */}
                 <ul className="space-y-3 mb-8 flex-1">
                   {plan.features.map((feature) => (
-                    <li key={feature} className="flex items-start gap-2 text-sm text-[var(--color-text-secondary)]">
-                      <Check className="w-4 h-4 text-[var(--color-positive)] flex-shrink-0 mt-0.5" />
-                      {feature}
+                    <li
+                      key={feature}
+                      className="flex items-start gap-3 text-sm text-theme-secondary leading-relaxed"
+                    >
+                      <Check
+                        className="w-5 h-5 flex-shrink-0 mt-0.5 text-[color:var(--color-positive)]"
+                        aria-hidden="true"
+                      />
+                      <span>{feature}</span>
                     </li>
                   ))}
                 </ul>
 
+                {/* CTA */}
                 {isCurrent ? (
                   <button
                     disabled
-                    className="w-full py-3 px-4 rounded-sm text-sm font-medium bg-[var(--color-bg-tertiary)] text-[var(--color-text-muted)] cursor-default mono tracking-[0.1em] uppercase"
+                    aria-label={`${plan.name} is your current plan`}
+                    className="w-full py-3 px-4 rounded-sm text-sm font-medium bg-[var(--color-bg-tertiary)] text-theme-muted cursor-default mono text-[10px] tracking-[0.3em] uppercase border border-[color:var(--color-border)]"
                   >
                     Current Plan
                   </button>
-                ) : plan.priceId === null ? (
+                ) : isFree ? (
                   <button
                     disabled
-                    className="w-full py-3 px-4 rounded-sm text-sm font-medium bg-[var(--color-bg-tertiary)] text-[var(--color-text-muted)] cursor-default mono tracking-[0.1em] uppercase"
+                    aria-label="Free plan is included"
+                    className="w-full py-3 px-4 rounded-sm bg-transparent border border-[color:var(--color-border)] text-theme-secondary cursor-default mono text-[10px] tracking-[0.3em] uppercase"
                   >
                     Free Forever
+                  </button>
+                ) : plan.highlighted ? (
+                  <button
+                    onClick={() => handleCheckout(plan)}
+                    disabled={isLoading}
+                    aria-label={`Upgrade to ${plan.name}`}
+                    className="w-full py-3 px-4 rounded-sm bg-[image:var(--gradient-sovereign)] text-white mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:brightness-110 hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)] disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:shadow-[0_4px_30px_rgba(123,44,255,0.35)]"
+                  >
+                    {isLoading ? 'Redirecting…' : 'Get Started'}
                   </button>
                 ) : (
                   <button
                     onClick={() => handleCheckout(plan)}
                     disabled={isLoading}
-                    className={`w-full py-3 px-4 rounded-sm text-sm font-medium mono tracking-[0.1em] uppercase transition-all click-feedback ${
-                      plan.highlighted
-                        ? 'bg-[var(--color-accent)] text-white hover:opacity-90 shadow-[0_0_20px_color-mix(in srgb, var(--color-accent) 30%, transparent)]'
-                        : 'bg-[var(--color-bg-tertiary)] text-[var(--color-text)] hover:bg-[var(--color-border)]'
-                    } disabled:opacity-50`}
+                    aria-label={`Upgrade to ${plan.name}`}
+                    className="w-full py-3 px-4 rounded-sm glass-slab text-theme mono text-[10px] font-bold tracking-[0.3em] uppercase animate-press animate-lift hover:border-[color:var(--color-border-hover)] disabled:opacity-50"
                   >
-                    {isLoading ? 'Redirecting...' : 'Get Started'}
+                    {isLoading ? 'Redirecting…' : 'Get Started'}
                   </button>
                 )}
               </div>
@@ -193,11 +244,34 @@ export function Pricing() {
           })}
         </div>
 
-        {/* Footer note */}
-        <p className="text-center text-xs text-[var(--color-text-muted)] mt-8 mono">
-          All plans include SSL encryption, SOC 2 compliance, and 99.9% uptime SLA.
-        </p>
-      </div>
+        {/* ── Trust strip / contact-sales row ───────────────────────────── */}
+        <div className="max-w-6xl mx-auto mt-12 sm:mt-16">
+          <div className="glass-slab-floating rounded-2xl p-6 sm:p-8 flex flex-col md:flex-row items-start md:items-center justify-between gap-5">
+            <div className="max-w-xl">
+              <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-2">
+                Need <span className="text-[color:var(--color-accent-secondary)]">More</span>
+              </p>
+              <h2 className="text-xl sm:text-2xl font-bold text-theme tracking-tight">
+                <span className="text-gradient-brand">Custom factor models</span> and dedicated infrastructure.
+              </h2>
+              <p className="mt-2 text-sm text-theme-secondary leading-relaxed">
+                Talk to our team about volume seats, on-prem deployment, and bespoke factor research.
+              </p>
+            </div>
+
+            <a
+              href="mailto:dico.angelo97@gmail.com?subject=FrontierAlpha%20Enterprise%20Inquiry"
+              className="px-6 py-3 rounded-sm bg-transparent border border-[color:var(--color-border)] text-theme-secondary hover:text-theme hover:border-[color:var(--color-border-hover)] mono text-[10px] font-bold tracking-[0.3em] uppercase animate-press animate-lift transition-[color,border-color] duration-200 whitespace-nowrap"
+            >
+              Contact Sales
+            </a>
+          </div>
+
+          <p className="text-center text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mt-8">
+            SSL Encryption · SOC 2 Compliance · 99.9% Uptime SLA
+          </p>
+        </div>
+      </section>
     </div>
   );
 }

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -5,7 +5,6 @@ import { useThemeStore } from '@/stores/themeStore';
 import { useAuthStore } from '@/stores/authStore';
 import { useSubscription } from '@/hooks/useSubscription';
 import { api } from '@/api/client';
-import { Card } from '@/components/shared/Card';
 import { Button } from '@/components/shared/Button';
 import { Spinner } from '@/components/shared/Spinner';
 import { SkeletonSettingsPage } from '@/components/shared/Skeleton';
@@ -21,6 +20,90 @@ interface UserSettings {
   max_position_pct: number;
   stop_loss_pct: number;
   take_profit_pct: number;
+}
+
+// Canonical input class — matches LoginForm pattern across the family aesthetic.
+const inputClass =
+  'block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm';
+
+const labelClass =
+  'block text-[10px] mono tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-2';
+
+const kickerClass =
+  'text-[10px] mono tracking-[0.3em] uppercase text-[var(--color-text-muted)]';
+
+interface SectionShellProps {
+  kicker: string;
+  title: string;
+  description?: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+  delay?: number;
+  danger?: boolean;
+}
+
+function SectionShell({ kicker, title, description, icon, children, delay = 0, danger = false }: SectionShellProps) {
+  if (danger) {
+    return (
+      <div
+        className="glass-slab-floating relative overflow-hidden rounded-2xl p-6 sm:p-8 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-negative)] shadow-[0_8px_30px_-10px_rgba(239,68,68,0.35)] animate-fade-in-up"
+        style={{ animationDelay: `${delay}ms`, animationFillMode: 'both' }}
+      >
+        <SectionHeader kicker={kicker} title={title} description={description} icon={icon} danger />
+        {children}
+      </div>
+    );
+  }
+
+  return (
+    <section
+      className="glass-slab rounded-2xl p-6 sm:p-8 animate-fade-in-up"
+      style={{ animationDelay: `${delay}ms`, animationFillMode: 'both' }}
+    >
+      <SectionHeader kicker={kicker} title={title} description={description} icon={icon} />
+      {children}
+    </section>
+  );
+}
+
+function SectionHeader({
+  kicker,
+  title,
+  description,
+  icon,
+  danger = false,
+}: {
+  kicker: string;
+  title: string;
+  description?: string;
+  icon: React.ReactNode;
+  danger?: boolean;
+}) {
+  return (
+    <header className="flex items-start gap-4 mb-6">
+      <div
+        className="p-2.5 rounded-lg shrink-0"
+        style={{
+          backgroundColor: danger
+            ? 'color-mix(in srgb, var(--color-negative) 10%, transparent)'
+            : 'color-mix(in srgb, var(--color-accent) 10%, transparent)',
+        }}
+      >
+        {icon}
+      </div>
+      <div className="min-w-0">
+        <p className={kickerClass}>{kicker}</p>
+        <h2
+          className={`text-lg font-bold mt-1 ${danger ? 'text-[var(--color-negative)]' : 'text-[var(--color-text)]'}`}
+        >
+          {title}
+        </h2>
+        {description && (
+          <p className="text-sm text-[var(--color-text-secondary)] mt-1">{description}</p>
+        )}
+      </div>
+    </header>
+  );
 }
 
 export function Settings() {
@@ -87,10 +170,16 @@ export function Settings() {
   return (
     <div className="space-y-6 max-w-3xl">
       {/* Header — delay 0ms */}
-      <div className="flex items-center justify-between animate-fade-in-up" style={{ animationDelay: '0ms', animationFillMode: 'both' }}>
+      <div
+        className="flex items-center justify-between animate-fade-in-up"
+        style={{ animationDelay: '0ms', animationFillMode: 'both' }}
+      >
         <div>
-          <h1 className="text-2xl lg:text-3xl font-bold text-[var(--color-text)]">Settings</h1>
-          <p className="text-[var(--color-text-muted)] mt-1">Account preferences, risk parameters, and integrations</p>
+          <p className={kickerClass}>Account</p>
+          <h1 className="text-2xl lg:text-3xl font-bold text-[var(--color-text)] mt-1">Settings</h1>
+          <p className="text-sm text-[var(--color-text-secondary)] mt-1">
+            Account preferences, risk parameters, and integrations
+          </p>
         </div>
         {hasChanges && (
           <Button onClick={handleSave} disabled={updateMutation.isPending}>
@@ -100,188 +189,191 @@ export function Settings() {
         )}
       </div>
 
-      {/* Appearance card — delay 50ms */}
+      {/* Appearance — delay 50ms */}
       <AppearanceCard />
 
-      {/* Profile card — delay 100ms */}
-      <Card className="p-6 hover:shadow-md transition-shadow animate-fade-in-up" style={{ animationDelay: '100ms', animationFillMode: 'both' }}>
-        <div className="flex items-center gap-3 mb-6">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 8%, transparent)' }}>
-            <User className="w-5 h-5" style={{ color: 'var(--color-accent)' }} />
-          </div>
-          <h2 className="text-lg font-semibold">Profile</h2>
-        </div>
-
-        <div className="space-y-4">
+      {/* Profile — delay 100ms */}
+      <SectionShell
+        kicker="Identity"
+        title="Profile"
+        description="How your account appears across Frontier Alpha"
+        icon={<User className="w-5 h-5" style={{ color: 'var(--color-accent)' }} />}
+        delay={100}
+      >
+        <div className="space-y-5">
           <div>
-            <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">Email</label>
+            <label htmlFor="settings-email" className={labelClass}>
+              Email
+            </label>
             <input
+              id="settings-email"
               type="email"
               value={user?.email || ''}
               disabled
-              className="w-full px-3 py-2 min-h-[44px] bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-muted)]"
+              className={`${inputClass} opacity-60 cursor-not-allowed`}
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">Display Name</label>
+            <label htmlFor="settings-display-name" className={labelClass}>
+              Display Name
+            </label>
             <input
+              id="settings-display-name"
               type="text"
               value={settings.display_name || ''}
               onChange={(e) => handleChange('display_name', e.target.value)}
               placeholder="Your name"
-              className="w-full px-3 py-2 min-h-[44px] border border-[var(--color-border)] rounded-lg focus:ring-2 focus:ring-[var(--color-accent)]"
+              className={inputClass}
             />
           </div>
         </div>
-      </Card>
+      </SectionShell>
 
-      {/* Risk preferences card — delay 150ms */}
-      <Card className="p-6 hover:shadow-md transition-shadow animate-fade-in-up" style={{ animationDelay: '150ms', animationFillMode: 'both' }}>
-        <div className="flex items-center gap-3 mb-6">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: 'color-mix(in srgb, var(--color-positive) 8%, transparent)' }}>
-            <Shield className="w-5 h-5" style={{ color: 'var(--color-positive)' }} />
-          </div>
-          <h2 className="text-lg font-semibold">Risk Preferences</h2>
-        </div>
-
-        <div className="space-y-4">
+      {/* Risk preferences — delay 150ms */}
+      <SectionShell
+        kicker="Strategy"
+        title="Risk Preferences"
+        description="Position sizing and protective rails for your portfolio"
+        icon={<Shield className="w-5 h-5" style={{ color: 'var(--color-positive)' }} />}
+        delay={150}
+      >
+        <div className="space-y-5">
           <div>
-            <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-2">Risk Tolerance</label>
+            <p className={`${labelClass} mb-3`}>Risk Tolerance</p>
             <div className="flex flex-col sm:flex-row gap-3">
-              {(['conservative', 'moderate', 'aggressive'] as const).map((level) => (
-                <button
-                  key={level}
-                  onClick={() => handleChange('risk_tolerance', level)}
-                  className="flex-1 py-3 px-4 min-h-[44px] rounded-lg border-2 capitalize transition hover:shadow-sm transition-all duration-200"
-                  style={
-                    settings.risk_tolerance === level
-                      ? {
-                          borderColor: 'var(--color-accent)',
-                          backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)',
-                          color: 'var(--color-accent)',
-                        }
-                      : {
-                          borderColor: 'var(--color-border)',
-                        }
-                  }
-                >
-                  {level}
-                </button>
-              ))}
+              {(['conservative', 'moderate', 'aggressive'] as const).map((level) => {
+                const active = settings.risk_tolerance === level;
+                return (
+                  <button
+                    key={level}
+                    onClick={() => handleChange('risk_tolerance', level)}
+                    className={`flex-1 py-3 px-4 min-h-[44px] rounded-lg border-2 capitalize mono text-sm tracking-[0.1em] transition-[border-color,background-color,color] duration-200 animate-press ${
+                      active
+                        ? 'border-[var(--color-accent)] bg-[var(--color-accent-light)] text-[var(--color-accent)]'
+                        : 'border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-border-hover)] hover:text-[var(--color-text)]'
+                    }`}
+                    aria-pressed={active}
+                  >
+                    {level}
+                  </button>
+                );
+              })}
             </div>
           </div>
 
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
             <div>
-              <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
+              <label htmlFor="settings-max-position" className={labelClass}>
                 Max Position Size
               </label>
               <div className="relative">
                 <input
+                  id="settings-max-position"
                   type="number"
                   min="5"
                   max="50"
                   step="5"
                   value={settings.max_position_pct}
                   onChange={(e) => handleChange('max_position_pct', parseFloat(e.target.value))}
-                  className="w-full px-3 py-2 min-h-[44px] border border-[var(--color-border)] rounded-lg pr-8 focus:ring-2 focus:ring-[var(--color-accent)]"
+                  className={`${inputClass} pr-9`}
                 />
-                <span className="absolute right-3 top-2 text-[var(--color-text-muted)]">%</span>
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)] mono text-sm">
+                  %
+                </span>
               </div>
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
+              <label htmlFor="settings-stop-loss" className={labelClass}>
                 Stop Loss
               </label>
               <div className="relative">
                 <input
+                  id="settings-stop-loss"
                   type="number"
                   min="1"
                   max="50"
                   step="1"
                   value={settings.stop_loss_pct}
                   onChange={(e) => handleChange('stop_loss_pct', parseFloat(e.target.value))}
-                  className="w-full px-3 py-2 min-h-[44px] border border-[var(--color-border)] rounded-lg pr-8 focus:ring-2 focus:ring-[var(--color-accent)]"
+                  className={`${inputClass} pr-9`}
                 />
-                <span className="absolute right-3 top-2 text-[var(--color-text-muted)]">%</span>
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)] mono text-sm">
+                  %
+                </span>
               </div>
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
+              <label htmlFor="settings-take-profit" className={labelClass}>
                 Take Profit
               </label>
               <div className="relative">
                 <input
+                  id="settings-take-profit"
                   type="number"
                   min="5"
                   max="100"
                   step="5"
                   value={settings.take_profit_pct}
                   onChange={(e) => handleChange('take_profit_pct', parseFloat(e.target.value))}
-                  className="w-full px-3 py-2 min-h-[44px] border border-[var(--color-border)] rounded-lg pr-8 focus:ring-2 focus:ring-[var(--color-accent)]"
+                  className={`${inputClass} pr-9`}
                 />
-                <span className="absolute right-3 top-2 text-[var(--color-text-muted)]">%</span>
+                <span className="absolute right-3 top-1/2 -translate-y-1/2 text-[var(--color-text-muted)] mono text-sm">
+                  %
+                </span>
               </div>
             </div>
           </div>
         </div>
-      </Card>
+      </SectionShell>
 
-      {/* Notifications card — delay 200ms */}
-      <Card className="p-6 hover:shadow-md transition-shadow animate-fade-in-up" style={{ animationDelay: '200ms', animationFillMode: 'both' }}>
-        <div className="flex items-center gap-3 mb-6">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: 'color-mix(in srgb, var(--color-warning) 8%, transparent)' }}>
-            <Bell className="w-5 h-5" style={{ color: 'var(--color-warning)' }} />
-          </div>
-          <h2 className="text-lg font-semibold">Notifications</h2>
-        </div>
-
+      {/* Notifications — delay 200ms */}
+      <SectionShell
+        kicker="Signal"
+        title="Notifications"
+        description="Where alerts land and how often you hear from us"
+        icon={<Bell className="w-5 h-5" style={{ color: 'var(--color-warning)' }} />}
+        delay={200}
+      >
         <div className="space-y-4">
-          {/* Push Notification Settings */}
+          {/* Push notification settings — shared component, untouched */}
           <NotificationSettings />
 
-          {/* Email Alerts */}
-          <label className="flex items-center justify-between pt-4 border-t border-[var(--color-border-light)]">
-            <div>
-              <p className="font-medium text-[var(--color-text-secondary)]">Email Alerts</p>
-              <p className="text-sm text-[var(--color-text-muted)]">Get critical alerts via email</p>
-            </div>
-            <input
-              type="checkbox"
-              checked={settings.email_alerts}
-              onChange={(e) => handleChange('email_alerts', e.target.checked)}
-              className="w-5 h-5 rounded border-[var(--color-border)] text-[var(--color-accent)] focus:ring-[var(--color-accent)]"
-            />
-          </label>
+          {/* Email alerts toggle */}
+          <ToggleRow
+            id="settings-email-alerts"
+            title="Email Alerts"
+            description="Get critical alerts via email"
+            checked={settings.email_alerts}
+            onChange={(value) => handleChange('email_alerts', value)}
+            divider
+          />
         </div>
-      </Card>
+      </SectionShell>
 
-      {/* Subscription card — delay 250ms */}
-      <Card className="p-6 hover:shadow-md transition-shadow animate-fade-in-up" style={{ animationDelay: '250ms', animationFillMode: 'both' }}>
-        <div className="flex items-center gap-3 mb-6">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: 'color-mix(in srgb, var(--color-info) 8%, transparent)' }}>
-            <CreditCard className="w-5 h-5" style={{ color: 'var(--color-info)' }} />
-          </div>
-          <h2 className="text-lg font-semibold">Subscription</h2>
-        </div>
-
-        <div className="flex items-center justify-between">
+      {/* Subscription — delay 250ms */}
+      <SectionShell
+        kicker="Billing"
+        title="Subscription"
+        description="Plan tier and billing portal"
+        icon={<CreditCard className="w-5 h-5" style={{ color: 'var(--color-info)' }} />}
+        delay={250}
+      >
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <p className="font-medium text-[var(--color-text-secondary)]">
-              Current Plan: <span className="capitalize text-[var(--color-accent)]">{plan}</span>
+            <p className="text-sm text-[var(--color-text-secondary)]">
+              Current Plan:{' '}
+              <span className="capitalize text-[var(--color-accent)] font-semibold">{plan}</span>
             </p>
-            <p className="text-sm text-[var(--color-text-muted)]">
+            <p className="text-xs text-[var(--color-text-muted)] mt-1">
               Status: <span className="capitalize">{status}</span>
             </p>
           </div>
           <div className="flex gap-3">
             {plan === 'free' ? (
-              <Button onClick={() => window.location.href = '/pricing'}>
-                Upgrade
-              </Button>
+              <Button onClick={() => (window.location.href = '/pricing')}>Upgrade</Button>
             ) : (
               <Button
                 variant="outline"
@@ -289,7 +381,7 @@ export function Settings() {
                 onClick={async () => {
                   setBillingLoading(true);
                   try {
-                    const response = await api.post('/billing/portal') as { data: { url: string } };
+                    const response = (await api.post('/billing/portal')) as { data: { url: string } };
                     if (response.data?.url) {
                       window.location.href = response.data.url;
                     }
@@ -305,42 +397,86 @@ export function Settings() {
             )}
           </div>
         </div>
-      </Card>
+      </SectionShell>
 
-      {/* API Keys card — delay 300ms */}
-      <Card className="p-6 hover:shadow-md transition-shadow animate-fade-in-up" style={{ animationDelay: '300ms', animationFillMode: 'both' }}>
-        <div className="flex items-center gap-3 mb-6">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 8%, transparent)' }}>
-            <Key className="w-5 h-5" style={{ color: 'var(--color-accent)' }} />
-          </div>
-          <h2 className="text-lg font-semibold">API Keys</h2>
-        </div>
-        <APIKeys />
-      </Card>
-
-      {/* Danger zone card — delay 350ms */}
-      <Card
-        className="p-6 hover:shadow-md transition-shadow animate-fade-in-up"
-        style={{ borderColor: 'color-mix(in srgb, var(--color-negative) 20%, transparent)', animationDelay: '350ms', animationFillMode: 'both' }}
+      {/* API Keys — delay 300ms */}
+      <SectionShell
+        kicker="Integrations"
+        title="API Keys"
+        description="Programmatic access for bots, sync jobs, and external clients"
+        icon={<Key className="w-5 h-5" style={{ color: 'var(--color-accent)' }} />}
+        delay={300}
       >
-        <div className="flex items-center gap-3 mb-6">
-          <div className="p-2 rounded-lg" style={{ backgroundColor: 'color-mix(in srgb, var(--color-negative) 8%, transparent)' }}>
-            <AlertTriangle className="w-5 h-5" style={{ color: 'var(--color-negative)' }} />
-          </div>
-          <h2 className="text-lg font-semibold text-[var(--color-negative)]">Danger Zone</h2>
-        </div>
+        <APIKeys />
+      </SectionShell>
 
-        <div className="flex items-center justify-between">
+      {/* Danger zone — delay 350ms */}
+      <SectionShell
+        kicker="Caution"
+        title="Danger Zone"
+        description="Irreversible or session-ending actions"
+        icon={<AlertTriangle className="w-5 h-5" style={{ color: 'var(--color-negative)' }} />}
+        delay={350}
+        danger
+      >
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
-            <p className="font-medium text-[var(--color-text-secondary)]">Sign Out</p>
-            <p className="text-sm text-[var(--color-text-muted)]">Sign out of your account on this device</p>
+            <p className="text-sm font-semibold text-[var(--color-text)]">Sign Out</p>
+            <p className="text-xs text-[var(--color-text-muted)] mt-1">
+              Sign out of your account on this device
+            </p>
           </div>
           <Button variant="danger" onClick={handleLogout}>
             <LogOut className="w-4 h-4 mr-2" />
             Sign Out
           </Button>
         </div>
-      </Card>
+      </SectionShell>
+    </div>
+  );
+}
+
+interface ToggleRowProps {
+  id: string;
+  title: string;
+  description: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  divider?: boolean;
+}
+
+function ToggleRow({ id, title, description, checked, onChange, divider }: ToggleRowProps) {
+  return (
+    <div
+      className={`flex items-center justify-between gap-4 ${
+        divider ? 'pt-4 border-t border-[var(--color-border-light)]' : ''
+      }`}
+    >
+      <div className="min-w-0">
+        <label htmlFor={id} className="text-sm font-semibold text-[var(--color-text)] cursor-pointer">
+          {title}
+        </label>
+        <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{description}</p>
+      </div>
+      <button
+        id={id}
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        aria-label={title}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors duration-200 animate-press focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:ring-offset-2 focus:ring-offset-[var(--color-bg)] ${
+          checked
+            ? 'bg-[image:var(--gradient-sovereign)]'
+            : 'bg-theme-tertiary border border-[var(--color-border)]'
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 transform rounded-full bg-white shadow-md transition-transform duration-200 ${
+            checked ? 'translate-x-6' : 'translate-x-1'
+          }`}
+        />
+      </button>
     </div>
   );
 }
@@ -355,50 +491,45 @@ function AppearanceCard() {
   ];
 
   return (
-    <Card className="p-6 hover:shadow-md transition-shadow animate-fade-in-up" style={{ animationDelay: '50ms', animationFillMode: 'both' }}>
-      <div className="flex items-center gap-3 mb-6">
-        <div className="p-2 rounded-lg" style={{ backgroundColor: 'color-mix(in srgb, var(--color-info) 8%, transparent)' }}>
-          {resolved === 'dark' ? (
-            <Moon className="w-5 h-5" style={{ color: 'var(--color-info)' }} />
-          ) : (
-            <Sun className="w-5 h-5" style={{ color: 'var(--color-info)' }} />
-          )}
-        </div>
-        <div>
-          <h2 className="text-lg font-semibold">Appearance</h2>
-          <p className="text-sm text-[var(--color-text-muted)]">Currently {resolved}</p>
-        </div>
-      </div>
-
-      <div className="grid grid-cols-3 gap-3">
+    <SectionShell
+      kicker="Appearance"
+      title="Theme"
+      description={`Currently ${resolved}`}
+      icon={
+        resolved === 'dark' ? (
+          <Moon className="w-5 h-5" style={{ color: 'var(--color-info)' }} />
+        ) : (
+          <Sun className="w-5 h-5" style={{ color: 'var(--color-info)' }} />
+        )
+      }
+      delay={50}
+    >
+      {/* Segmented control — single rounded shell, three segments */}
+      <div className="grid grid-cols-3 gap-2 p-1 rounded-lg bg-[var(--color-bg-tertiary)] border border-[var(--color-border)]">
         {options.map((opt) => {
           const Icon = opt.icon;
           const isActive = theme === opt.value;
           return (
             <button
               key={opt.value}
+              type="button"
               onClick={() => setTheme(opt.value)}
-              className="flex flex-col items-center gap-2 p-4 rounded-xl border-2 transition-all duration-200 hover:shadow-sm"
-              style={
+              aria-pressed={isActive}
+              title={opt.description}
+              className={`flex flex-col items-center justify-center gap-1.5 py-3 px-3 rounded-md transition-colors duration-200 animate-press ${
                 isActive
-                  ? {
-                      borderColor: 'var(--color-accent)',
-                      backgroundColor: 'color-mix(in srgb, var(--color-accent) 8%, transparent)',
-                    }
-                  : {
-                      borderColor: 'var(--color-border)',
-                    }
-              }
+                  ? 'bg-[var(--color-accent-light)] text-[var(--color-accent)]'
+                  : 'text-theme-secondary hover:text-theme'
+              }`}
             >
-              <Icon className="w-6 h-6" style={{ color: isActive ? 'var(--color-accent)' : 'var(--color-text-muted)' }} />
-              <span className="text-sm font-medium" style={{ color: isActive ? 'var(--color-accent)' : 'var(--color-text)' }}>
+              <Icon className="w-5 h-5" />
+              <span className="text-[11px] mono tracking-[0.2em] uppercase font-semibold">
                 {opt.label}
               </span>
-              <span className="text-xs text-[var(--color-text-muted)] text-center">{opt.description}</span>
             </button>
           );
         })}
       </div>
-    </Card>
+    </SectionShell>
   );
 }


### PR DESCRIPTION
## Summary
Brings frontier-alpha into the visual family of metaventionsai.com / careers.metaventionsai.com / friendlyface.metaventionsai.com. Three concrete jank sources fixed.

- **Missing keyframes were no-ops** — `animate-fade-in`, `animate-slide-in-left`, `animate-slide-in-right`, `animate-pulse-subtle` were referenced across Layout, Toast, ToastContainer, PageLoader, mobile sidebar overlay, but only declared in the reduced-motion override. Result: every "animated" overlay was a hard cut. Now defined as proper keyframes on motion tokens.
- **Buttons felt laggy** — `transition-all` + `hover:scale-[1.02]` + opacity-on-gradient was killing the feel and breaking the sovereign gradient. Swapped to `animate-press` + `animate-lift` tokens with brightness-filter hover (gradient-safe) and `focus-visible` rings. Same treatment applied to inline Landing CTAs.
- **Toasts looked raw** — flat tinted-bg cards. Now `glass-slab-floating` with type-colored 3px left rail (sovereign spectrum on info, semantic on others), shadow glow per type, and the now-real slide-in-right enter.

## Files
- `client/src/index.css` — 4 keyframes added, motion-token bound
- `client/src/components/shared/Button.tsx` — variant rewrite, drop hover-scale, gradient-safe hover
- `client/src/components/shared/Toast.tsx` — glass-floating shell, type rail, real enter anim
- `client/src/pages/Landing.tsx` — 2 hero CTAs + form Analyze button → sovereign gradient

## Test plan
- [x] `npm run build` clean (5.56s, 82 modules)
- [x] Local dev: 4 toast types render with glass + correct rail color
- [x] Landing CTAs visually match the sovereign-spectrum band
- [ ] Manual: hover/press feel on dashboard buttons (post-merge)
- [ ] Manual: mobile sidebar slide-in animation now actually slides (post-merge)
- [ ] Lighthouse before/after — expect CLS unchanged, no perf regression

## Deploy
Auto-deploy is OFF on this repo per CONTEXT.md. After merge, deploy manually (`vercel --prod` or via Vercel dashboard).