### PR TITLE
UI polish r2: header, widgets, mobile, intelligence + execution pages

### DIFF
--- a/client/src/components/charts/EquityCurve.tsx
+++ b/client/src/components/charts/EquityCurve.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Card } from '@/components/shared/Card';
 import { useThemeStore } from '@/stores/themeStore';
 
 interface DataPoint {
@@ -414,42 +413,33 @@ export const EquityCurve = React.memo(function EquityCurve({
   };
 
   return (
-    <Card title="Portfolio Performance" className="animate-fade-in-up">
-      {/* Header metrics */}
-      <div className="flex flex-wrap items-center justify-between gap-4 mb-4">
-        <div className="flex items-center gap-6">
-          <div>
-            <p className="text-sm text-[var(--color-text-muted)]">Total Return</p>
-            <p className={`text-xl font-bold ${totalReturn >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}>
-              {totalReturn >= 0 ? '+' : ''}{totalReturn.toFixed(2)}%
-            </p>
-          </div>
-          <div>
-            <p className="text-sm text-[var(--color-text-muted)]">vs S&P 500</p>
-            <p className={`text-xl font-bold ${alpha >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}>
-              {alpha >= 0 ? '+' : ''}{alpha.toFixed(2)}%
-            </p>
-          </div>
-          {hoveredPoint && (
-            <div className="border-l pl-4 border-[var(--color-border)]">
-              <p className="text-sm text-[var(--color-text-muted)]">{new Date(hoveredPoint.date).toLocaleDateString()}</p>
-              <p className="text-lg font-semibold text-[var(--color-text)]">
-                ${hoveredPoint.portfolio.toLocaleString(undefined, { maximumFractionDigits: 0 })}
-              </p>
-            </div>
-          )}
+    <section
+      className="glass-slab rounded-2xl p-4 sm:p-6 animate-enter"
+      aria-label="Portfolio Performance"
+    >
+      {/* Title row */}
+      <div className="flex flex-wrap items-start justify-between gap-3 mb-4">
+        <div>
+          <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+            Equity Curve
+          </p>
+          <h3 className="text-lg font-semibold text-theme mt-1">Portfolio Performance</h3>
         </div>
 
-        {/* Timeframe selector */}
-        <div className="flex gap-1 bg-[var(--color-bg-tertiary)] rounded-lg p-1" role="group" aria-label="Chart timeframe">
+        {/* Timeframe selector — segmented control */}
+        <div
+          className="flex gap-1 glass-slab-floating rounded-lg p-1"
+          role="group"
+          aria-label="Chart timeframe"
+        >
           {(['1W', '1M', '3M', '6M', '1Y', 'YTD'] as const).map((tf) => (
             <button
               key={tf}
               onClick={() => setSelectedTimeframe(tf)}
-              className={`px-3 py-2 min-h-[36px] text-xs rounded-md transition-colors touch-manipulation ${
+              className={`px-3 py-1.5 min-h-[32px] text-[10px] mono tracking-[0.2em] uppercase rounded-md animate-press transition-[color,background-color] duration-200 touch-manipulation ${
                 selectedTimeframe === tf
-                  ? 'bg-[var(--color-bg)] shadow text-[var(--color-text)]'
-                  : 'text-[var(--color-text-secondary)] hover:text-[var(--color-text)]'
+                  ? 'bg-[var(--color-accent-light)] text-[var(--color-accent)]'
+                  : 'text-theme-secondary hover:text-theme'
               }`}
               aria-pressed={selectedTimeframe === tf}
             >
@@ -459,8 +449,56 @@ export const EquityCurve = React.memo(function EquityCurve({
         </div>
       </div>
 
-      {/* Chart */}
-      <div ref={containerRef} className="h-64 w-full relative" role="img" aria-label={`Portfolio equity curve showing ${totalReturn >= 0 ? '+' : ''}${totalReturn.toFixed(1)}% total return over ${selectedTimeframe} timeframe`}>
+      {/* Stats row */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 mb-5">
+        <div>
+          <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+            Total Return
+          </p>
+          <p
+            className="text-xl font-bold tabular-nums mt-1"
+            style={{
+              color: totalReturn >= 0 ? 'var(--color-positive)' : 'var(--color-negative)',
+            }}
+          >
+            {totalReturn >= 0 ? '+' : ''}
+            {totalReturn.toFixed(2)}%
+          </p>
+        </div>
+        <div>
+          <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+            vs S&amp;P 500
+          </p>
+          <p
+            className="text-xl font-bold tabular-nums mt-1"
+            style={{ color: alpha >= 0 ? 'var(--color-positive)' : 'var(--color-negative)' }}
+          >
+            {alpha >= 0 ? '+' : ''}
+            {alpha.toFixed(2)}%
+          </p>
+        </div>
+        {hoveredPoint && (
+          <div className="border-l pl-3 border-theme-light col-span-2 sm:col-span-1">
+            <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+              {new Date(hoveredPoint.date).toLocaleDateString()}
+            </p>
+            <p className="text-lg font-semibold text-theme tabular-nums mt-1">
+              $
+              {hoveredPoint.portfolio.toLocaleString(undefined, {
+                maximumFractionDigits: 0,
+              })}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {/* Chart — fixed height wrapper for CLS safety */}
+      <div
+        ref={containerRef}
+        className="h-64 sm:h-72 w-full relative"
+        role="img"
+        aria-label={`Portfolio equity curve showing ${totalReturn >= 0 ? '+' : ''}${totalReturn.toFixed(1)}% total return over ${selectedTimeframe} timeframe`}
+      >
         <canvas
           ref={canvasRef}
           className="w-full h-full cursor-crosshair touch-none"
@@ -474,7 +512,7 @@ export const EquityCurve = React.memo(function EquityCurve({
         {/* Tooltip near cursor */}
         {hoveredPoint && hoveredX !== null && (() => {
           const padding = { left: 60, right: 20 };
-          const tooltipWidth = 160;
+          const tooltipWidth = 168;
           // Clamp tooltip to canvas bounds
           const rawLeft = hoveredX + 12;
           const clampedLeft = Math.min(
@@ -486,14 +524,37 @@ export const EquityCurve = React.memo(function EquityCurve({
             : 0;
           return (
             <div
-              className="pointer-events-none absolute top-2 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg shadow-lg px-3 py-2 text-xs z-10"
+              className="pointer-events-none absolute top-2 backdrop-blur-md bg-[var(--color-bg-tooltip)] text-[var(--color-text-inverse)] border border-theme-light rounded-lg shadow-lg px-3 py-2 text-xs z-10"
               style={{ left: clampedLeft, width: tooltipWidth }}
             >
-              <p className="text-[var(--color-text-muted)] mb-1">{new Date(hoveredPoint.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })}</p>
-              <p className="font-semibold text-[var(--color-text)]">${hoveredPoint.portfolio.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>
-              <p className="text-[var(--color-text-muted)]">Benchmark: ${hoveredPoint.benchmark.toLocaleString(undefined, { maximumFractionDigits: 0 })}</p>
-              <p className={dailyChange >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}>
-                {dailyChange >= 0 ? '+' : ''}{dailyChange.toFixed(2)}%
+              <p className="text-[9px] mono tracking-[0.3em] uppercase opacity-70 mb-1">
+                {new Date(hoveredPoint.date).toLocaleDateString('en-US', {
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </p>
+              <p className="font-semibold tabular-nums">
+                $
+                {hoveredPoint.portfolio.toLocaleString(undefined, {
+                  maximumFractionDigits: 0,
+                })}
+              </p>
+              <p className="opacity-70 tabular-nums text-[11px]">
+                Bench: $
+                {hoveredPoint.benchmark.toLocaleString(undefined, {
+                  maximumFractionDigits: 0,
+                })}
+              </p>
+              <p
+                className="tabular-nums font-semibold"
+                style={{
+                  color:
+                    dailyChange >= 0 ? 'var(--color-positive)' : 'var(--color-negative)',
+                }}
+              >
+                {dailyChange >= 0 ? '+' : ''}
+                {dailyChange.toFixed(2)}%
               </p>
             </div>
           );
@@ -501,16 +562,20 @@ export const EquityCurve = React.memo(function EquityCurve({
       </div>
 
       {/* Legend */}
-      <div className="flex items-center justify-center gap-6 mt-4 text-sm">
+      <div className="flex items-center justify-center gap-6 mt-4">
         <div className="flex items-center gap-2">
-          <div className="w-4 h-0.5 bg-[var(--color-info)]" />
-          <span className="text-[var(--color-text-secondary)]">Portfolio</span>
+          <div className="w-4 h-0.5 bg-[var(--color-accent)]" />
+          <span className="text-[10px] mono tracking-[0.3em] uppercase text-theme-secondary">
+            Portfolio
+          </span>
         </div>
         <div className="flex items-center gap-2">
-          <div className="w-4 h-0.5 border-dashed border-t-2 border-[var(--color-text-muted)]" />
-          <span className="text-[var(--color-text-secondary)]">S&P 500</span>
+          <div className="w-4 h-0.5 border-dashed border-t-2 border-theme" />
+          <span className="text-[10px] mono tracking-[0.3em] uppercase text-theme-secondary">
+            S&amp;P 500
+          </span>
         </div>
       </div>
-    </Card>
+    </section>
   );
 });

--- a/client/src/components/dashboard/MarketStatusStrip.tsx
+++ b/client/src/components/dashboard/MarketStatusStrip.tsx
@@ -144,42 +144,60 @@ export function MarketStatusStrip({ isConnected, lastUpdate }: MarketStatusStrip
   const wsColor = isConnected ? 'var(--color-positive)' : 'var(--color-danger)';
   const wsAnim = isConnected ? 'animate-pulse-green' : '';
 
+  const phaseColor = PHASE_COLOR[phase];
+
   return (
     <div
-      className="sticky top-0 z-40 w-full backdrop-blur-md bg-[var(--color-bg-secondary)] border-b border-[var(--color-border-light)]"
+      className="sticky top-0 z-40 w-full backdrop-blur-md bg-[var(--color-bg-secondary)]/80 border-b border-theme-light"
       role="status"
       aria-label="Market status strip"
     >
-      <div className="max-w-6xl mx-auto px-4 sm:px-6 h-9 flex items-center justify-between gap-4 text-[10px] mono tracking-[0.2em] uppercase">
-        <div className="flex items-center gap-3 sm:gap-5 min-w-0 overflow-hidden">
+      <div className="max-w-6xl mx-auto h-10 flex items-center justify-between gap-4 text-[10px] mono tracking-[0.25em] uppercase">
+        {/* Left scroll rail — edge-to-edge horizontal scroll, scrollbar hidden */}
+        <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1 overflow-x-auto -mx-4 px-4 sm:-mx-6 sm:px-6 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+          {/* Phase pill */}
           <span
-            className="flex items-center gap-1.5 px-2 py-0.5 rounded-sm border"
+            className="glass-slab-floating relative flex items-center gap-1.5 pl-3 pr-3 py-1 rounded-full shrink-0 overflow-hidden animate-press transition-[transform,background-color,border-color] duration-200"
             style={{
-              color: PHASE_COLOR[phase],
-              borderColor: `color-mix(in srgb, ${PHASE_COLOR[phase]} 30%, transparent)`,
-              backgroundColor: `color-mix(in srgb, ${PHASE_COLOR[phase]} 10%, transparent)`,
+              color: phaseColor,
+              borderColor: `color-mix(in srgb, ${phaseColor} 30%, transparent)`,
+              backgroundColor: `color-mix(in srgb, ${phaseColor} 10%, transparent)`,
             }}
           >
             <span
-              className="w-1.5 h-1.5 rounded-full"
-              style={{ backgroundColor: PHASE_COLOR[phase] }}
+              aria-hidden="true"
+              className="absolute left-0 top-0 bottom-0 w-[3px]"
+              style={{ backgroundColor: phaseColor }}
+            />
+            <span
+              className="w-1.5 h-1.5 rounded-full ml-0.5"
+              style={{ backgroundColor: phaseColor }}
               aria-hidden="true"
             />
             {PHASE_LABEL[phase]}
           </span>
 
-          <span className="hidden sm:inline text-[var(--color-text-muted)]">
-            <span className="text-[var(--color-text-secondary)]">{nextLabel}</span>
-            <span className="ml-2 tabular-nums">{countdown}</span>
+          {/* Countdown pill */}
+          <span className="hidden sm:flex glass-slab rounded-full px-3 py-1 items-center gap-2 shrink-0 text-theme-muted">
+            <span className="text-theme-secondary">{nextLabel}</span>
+            <span className="tabular-nums text-theme">{countdown}</span>
           </span>
 
-          <span className="hidden md:inline" style={{ color: freshnessColor }}>
-            Quote <span className="tabular-nums">{freshnessMs === null ? '—' : formatAgo(freshnessMs)}</span>
+          {/* Quote freshness pill */}
+          <span
+            className="hidden md:flex glass-slab rounded-full px-3 py-1 items-center gap-2 shrink-0"
+            style={{ color: freshnessColor }}
+          >
+            <span>Quote</span>
+            <span className="tabular-nums">
+              {freshnessMs === null ? '—' : formatAgo(freshnessMs)}
+            </span>
           </span>
         </div>
 
-        <div className="flex items-center gap-3 sm:gap-5 shrink-0">
-          <span className="hidden sm:flex items-center gap-1.5 text-[var(--color-text-muted)]">
+        <div className="flex items-center gap-2 sm:gap-3 shrink-0 pr-4 sm:pr-6">
+          {/* Stream indicator pill */}
+          <span className="hidden sm:flex glass-slab rounded-full px-3 py-1 items-center gap-1.5 text-theme-muted">
             <span
               className={`w-1.5 h-1.5 rounded-full ${wsAnim}`}
               style={{ backgroundColor: wsColor }}
@@ -192,21 +210,31 @@ export function MarketStatusStrip({ isConnected, lastUpdate }: MarketStatusStrip
             <button
               type="button"
               onClick={() => navigate('/alerts')}
-              className={`flex items-center gap-1 px-2 py-0.5 rounded-sm transition-transform duration-200 hover:scale-[1.04] ${flash ? 'animate-pulse-green' : ''}`}
+              className={`glass-slab-floating relative flex items-center gap-1 pl-3 pr-3 py-1 rounded-full overflow-hidden animate-press transition-[transform,background-color,border-color] duration-200 hover:bg-[var(--color-accent-light)]/50 ${flash ? 'animate-pulse-green' : ''}`}
               style={{
                 color: flash ? 'var(--color-negative)' : 'var(--color-warning)',
                 backgroundColor: `color-mix(in srgb, ${flash ? 'var(--color-negative)' : 'var(--color-warning)'} 14%, transparent)`,
               }}
               aria-label={`View ${unreadAlerts} unread alert${unreadAlerts === 1 ? '' : 's'}`}
             >
-              {unreadAlerts} Alert{unreadAlerts === 1 ? '' : 's'}
+              <span
+                aria-hidden="true"
+                className="absolute left-0 top-0 bottom-0 w-[3px]"
+                style={{
+                  backgroundColor: flash
+                    ? 'var(--color-negative)'
+                    : 'var(--color-warning)',
+                }}
+              />
+              <span className="tabular-nums">{unreadAlerts}</span> Alert
+              {unreadAlerts === 1 ? '' : 's'}
             </button>
           )}
 
           <button
             type="button"
             onClick={() => setHelpOpen((v) => !v)}
-            className="hidden sm:inline w-4 h-4 rounded-sm text-[var(--color-text-muted)] hover:text-[var(--color-accent-secondary)] transition-colors"
+            className="hidden sm:inline w-5 h-5 rounded-full text-theme-muted hover:text-[var(--color-accent-secondary)] animate-press transition-[color] duration-200"
             aria-label="Show market strip help (press ? key)"
             title="Press ? for help"
           >

--- a/client/src/components/help/HelpButton.tsx
+++ b/client/src/components/help/HelpButton.tsx
@@ -30,12 +30,11 @@ export function HelpButton({
       <button
         onClick={onClick}
         className={`
-          flex items-center gap-2 px-3 py-2
-          text-[var(--color-text-secondary)] hover:text-[var(--color-info)]
-          bg-[var(--color-bg-tertiary)] hover:bg-[color-mix(in_srgb,var(--color-info)_10%,transparent)]
-          border border-[var(--color-border)] hover:border-[color-mix(in_srgb,var(--color-info)_20%,transparent)]
-          rounded-lg transition-all duration-150
-          focus:outline-none focus:ring-2 focus:ring-[var(--color-info)] focus:ring-offset-2
+          glass-slab flex items-center gap-2 px-3 py-2 rounded-lg
+          text-theme-secondary hover:text-[var(--color-accent)]
+          hover:border-[color:var(--color-border-hover)]
+          animate-press animate-lift
+          focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]/40
           ${className}
         `}
         aria-label="Open help"
@@ -50,14 +49,11 @@ export function HelpButton({
     <button
       onClick={onClick}
       className={`
-        ${sizeClasses[size]}
-        flex items-center justify-center
-        text-[var(--color-text-muted)] hover:text-[var(--color-info)]
-        bg-[var(--color-bg)] hover:bg-[color-mix(in_srgb,var(--color-info)_10%,transparent)]
-        border border-[var(--color-border)] hover:border-[var(--color-info)]
-        rounded-full shadow-sm hover:shadow
-        transition-all duration-150
-        focus:outline-none focus:ring-2 focus:ring-[var(--color-info)] focus:ring-offset-2
+        glass-slab ${sizeClasses[size]} flex items-center justify-center rounded-full
+        text-theme-muted hover:text-[var(--color-accent)]
+        hover:border-[color:var(--color-border-hover)]
+        animate-press animate-lift
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]/40
         ${className}
       `}
       aria-label="Open help"
@@ -88,20 +84,24 @@ export function FloatingHelpButton({
     <button
       onClick={onClick}
       className={`
-        fixed ${positionClasses[position]} z-40
-        w-12 h-12
+        glass-slab-floating fixed ${positionClasses[position]} z-40
+        w-12 h-12 rounded-full
         flex items-center justify-center
-        bg-[var(--color-accent)]
-        text-white
-        rounded-full shadow-lg hover:shadow-xl
-        transition-all duration-200
-        hover:scale-110 active:scale-95
-        focus:outline-none focus:ring-2 focus:ring-[var(--color-info)] focus:ring-offset-2
+        text-[var(--color-accent)]
+        animate-press animate-lift
+        shadow-[0_10px_40px_-10px_rgba(123,44,255,0.55)]
+        hover:shadow-[0_18px_60px_-12px_rgba(123,44,255,0.75)]
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]/50
       `}
       aria-label="Open help (press ? for keyboard shortcut)"
       title="Help (press ?)"
     >
-      <HelpCircle className="w-6 h-6" />
+      <span
+        aria-hidden="true"
+        className="absolute inset-0 rounded-full opacity-30 pointer-events-none"
+        style={{ background: 'var(--gradient-sovereign)', filter: 'blur(14px)' }}
+      />
+      <HelpCircle className="relative w-6 h-6" />
     </button>
   );
 }
@@ -111,9 +111,11 @@ export function FloatingHelpButton({
  */
 export function HelpKeyboardHint() {
   return (
-    <div className="hidden lg:flex items-center gap-1.5 px-2 py-1 bg-[var(--color-bg-secondary)] rounded text-xs text-[var(--color-text-muted)]">
+    <div className="hidden lg:flex items-center gap-1.5 px-2 py-1 rounded-md text-[10px] mono tracking-[0.2em] uppercase text-theme-muted">
       <span>Press</span>
-      <kbd className="px-1.5 py-0.5 bg-[var(--color-bg)] border border-[var(--color-border)] rounded text-[var(--color-text-secondary)] font-mono">?</kbd>
+      <kbd className="glass-slab rounded px-1.5 py-0.5 mono text-[10px] text-theme-secondary border border-theme">
+        ?
+      </kbd>
       <span>for help</span>
     </div>
   );

--- a/client/src/components/help/HelpPanel.tsx
+++ b/client/src/components/help/HelpPanel.tsx
@@ -34,6 +34,9 @@ const sectionIcons: Record<string, typeof Rocket> = {
   'alerts': Bell,
 };
 
+const kickerClass =
+  'text-[10px] mono tracking-[0.3em] uppercase text-theme-muted';
+
 export function HelpPanel({ isOpen, onClose, initialTopic }: HelpPanelProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [selectedSection, setSelectedSection] = useState<string | null>(null);
@@ -129,38 +132,50 @@ export function HelpPanel({ isOpen, onClose, initialTopic }: HelpPanelProps) {
     <div className="fixed inset-0 z-50">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-fade-in"
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
         onClick={onClose}
         aria-hidden="true"
       />
 
-      {/* Panel */}
+      {/* Panel — side drawer */}
       <div
-        className="absolute right-0 top-0 bottom-0 w-full max-w-lg bg-[var(--color-bg)] shadow-2xl animate-slide-in-right flex flex-col"
+        className="glass-slab-floating absolute right-0 top-0 bottom-0 w-full max-w-lg overflow-hidden animate-slide-in-right flex flex-col shadow-[0_30px_80px_-20px_rgba(123,44,255,0.35)]"
         role="dialog"
         aria-modal="true"
         aria-label="Help panel"
       >
+        {/* Sovereign top rail */}
+        <div className="sovereign-bar absolute top-0 left-0 right-0" />
+
         {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b">
-          <div className="flex items-center gap-3">
+        <div className="flex items-center justify-between px-6 py-5 border-b border-theme">
+          <div className="flex items-center gap-3 min-w-0">
             {selectedTopic ? (
               <button
                 onClick={goBack}
-                className="p-1 -ml-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-secondary)] rounded"
+                className="p-1.5 -ml-1 text-theme-muted hover:text-theme rounded-lg animate-press"
+                aria-label="Back to topics"
               >
                 <ChevronRight className="w-5 h-5 rotate-180" />
               </button>
             ) : (
-              <BookOpen className="w-6 h-6 text-[var(--color-info)]" />
+              <div
+                className="p-2 rounded-lg shrink-0"
+                style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 12%, transparent)' }}
+              >
+                <BookOpen className="w-5 h-5 text-[var(--color-accent)]" aria-hidden="true" />
+              </div>
             )}
-            <h2 className="text-lg font-semibold text-[var(--color-text)]">
-              {selectedTopic ? selectedTopic.title : 'Help Center'}
-            </h2>
+            <div className="min-w-0">
+              <p className={kickerClass}>HELP · Documentation</p>
+              <h2 className="text-lg font-bold text-theme mt-0.5 truncate">
+                {selectedTopic ? selectedTopic.title : 'Help Center'}
+              </h2>
+            </div>
           </div>
           <button
             onClick={onClose}
-            className="p-2 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-secondary)] rounded-lg"
+            className="p-2 text-theme-muted hover:text-theme rounded-lg transition-colors animate-press"
             aria-label="Close help panel"
           >
             <X className="w-5 h-5" />
@@ -169,21 +184,22 @@ export function HelpPanel({ isOpen, onClose, initialTopic }: HelpPanelProps) {
 
         {/* Search (only when not viewing a topic) */}
         {!selectedTopic && (
-          <div className="p-4 border-b">
+          <div className="px-6 py-4 border-b border-theme">
             <div className="relative">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--color-text-muted)]" />
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-theme-muted" />
               <input
                 type="text"
                 placeholder="Search help topics..."
                 value={searchQuery}
                 onChange={(e) => setSearchQuery(e.target.value)}
-                className="w-full pl-10 pr-4 py-2.5 border border-[var(--color-border)] rounded-lg focus:ring-2 focus:ring-[var(--color-info)] focus:border-[var(--color-info)]"
+                className="block w-full pl-10 pr-10 py-2.5 bg-[var(--color-bg-tertiary)] border border-theme rounded-lg text-theme placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] mono text-sm transition-[border-color,box-shadow] duration-200"
                 aria-label="Search help"
               />
               {searchQuery && (
                 <button
                   onClick={() => setSearchQuery('')}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)]"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-theme-muted hover:text-theme rounded animate-press"
+                  aria-label="Clear search"
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -217,19 +233,19 @@ export function HelpPanel({ isOpen, onClose, initialTopic }: HelpPanelProps) {
         </div>
 
         {/* Footer */}
-        <div className="border-t p-4 bg-[var(--color-bg-tertiary)]">
+        <div className="border-t border-theme p-4 bg-[var(--color-bg-tertiary)]">
           <div className="flex flex-col sm:flex-row gap-3">
             <Link
               to="/help"
               onClick={onClose}
-              className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-[var(--color-bg)] border border-[var(--color-border)] rounded-lg text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] transition"
+              className="glass-slab flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-theme-secondary hover:text-theme hover:border-[color:var(--color-border-hover)] animate-press animate-lift"
             >
               <BookOpen className="w-4 h-4" />
               Full Help Guide
             </Link>
             <a
               href="mailto:support@frontieralpha.com"
-              className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-[var(--color-info)] text-white rounded-lg hover:bg-[var(--color-info)] transition"
+              className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg bg-[image:var(--gradient-sovereign)] text-white font-medium animate-press animate-lift shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:brightness-110"
             >
               <MessageCircle className="w-4 h-4" />
               Contact Support
@@ -251,45 +267,48 @@ interface SectionListProps {
 
 function SectionList({ sections, expandedSections, onToggleSection, onSelectTopic }: SectionListProps) {
   return (
-    <div className="p-4 space-y-2">
+    <div className="p-4 space-y-3 animate-stagger">
       {sections.map((section) => {
         const Icon = sectionIcons[section.id] || BookOpen;
         const isExpanded = expandedSections.has(section.id);
 
         return (
-          <div key={section.id} className="border rounded-lg overflow-hidden">
+          <div key={section.id} className="glass-slab rounded-2xl overflow-hidden animate-enter">
             <button
               onClick={() => onToggleSection(section.id)}
-              className="w-full flex items-center gap-3 p-4 bg-[var(--color-bg)] hover:bg-[var(--color-bg-tertiary)] transition text-left"
+              className="w-full flex items-center gap-3 p-4 hover:bg-[var(--color-bg-tertiary)] text-left animate-press"
               aria-expanded={isExpanded}
             >
-              <div className="w-10 h-10 bg-[color-mix(in_srgb,var(--color-info)_10%,transparent)] rounded-lg flex items-center justify-center flex-shrink-0">
-                <Icon className="w-5 h-5 text-[var(--color-info)]" />
+              <div
+                className="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0"
+                style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
+              >
+                <Icon className="w-5 h-5 text-[var(--color-accent)]" />
               </div>
               <div className="flex-1 min-w-0">
-                <h3 className="font-medium text-[var(--color-text)]">{section.title}</h3>
-                <p className="text-sm text-[var(--color-text-muted)] truncate">{section.description}</p>
+                <h3 className="font-semibold text-theme">{section.title}</h3>
+                <p className="text-sm text-theme-secondary leading-relaxed truncate">{section.description}</p>
               </div>
               {isExpanded ? (
-                <ChevronDown className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
+                <ChevronDown className="w-5 h-5 text-theme-muted flex-shrink-0" />
               ) : (
-                <ChevronRight className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" />
+                <ChevronRight className="w-5 h-5 text-theme-muted flex-shrink-0" />
               )}
             </button>
 
             {isExpanded && (
-              <div className="border-t bg-[var(--color-bg-tertiary)]">
+              <div className="border-t border-theme bg-[var(--color-bg-tertiary)]">
                 {section.topics.map((topic) => (
                   <button
                     key={topic.id}
                     onClick={() => onSelectTopic(topic)}
-                    className="w-full flex items-center gap-3 p-3 pl-6 hover:bg-[var(--color-bg-secondary)] transition text-left border-b last:border-b-0"
+                    className="w-full flex items-center gap-3 p-3 pl-6 hover:bg-[var(--color-bg-secondary)] text-left border-b border-theme last:border-b-0 animate-press"
                   >
-                    <div className="flex-1">
-                      <p className="font-medium text-[var(--color-text)]">{topic.title}</p>
-                      <p className="text-sm text-[var(--color-text-muted)]">{topic.summary}</p>
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-theme">{topic.title}</p>
+                      <p className="text-sm text-theme-secondary leading-relaxed">{topic.summary}</p>
                     </div>
-                    <ChevronRight className="w-4 h-4 text-[var(--color-text-muted)] flex-shrink-0" />
+                    <ChevronRight className="w-4 h-4 text-theme-muted flex-shrink-0" />
                   </button>
                 ))}
               </div>
@@ -299,8 +318,8 @@ function SectionList({ sections, expandedSections, onToggleSection, onSelectTopi
       })}
 
       {/* Quick Links */}
-      <div className="pt-4 mt-4 border-t">
-        <h3 className="text-sm font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">Quick Links</h3>
+      <div className="pt-4 mt-4 border-t border-theme">
+        <h3 className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-3">Quick Links</h3>
         <div className="grid grid-cols-2 gap-2">
           <QuickLink to="/help#faq" label="FAQ" />
           <QuickLink to="/help#factors" label="Factor Guide" />
@@ -316,10 +335,10 @@ function QuickLink({ to, label }: { to: string; label: string }) {
   return (
     <Link
       to={to}
-      className="flex items-center justify-between px-3 py-2 bg-[var(--color-bg)] border rounded-lg text-sm text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] hover:border-[var(--color-border)] transition"
+      className="glass-slab flex items-center justify-between px-3 py-2 rounded-lg text-sm text-theme-secondary hover:text-theme hover:border-[color:var(--color-border-hover)] animate-press animate-lift"
     >
       {label}
-      <ExternalLink className="w-3.5 h-3.5 text-[var(--color-text-muted)]" />
+      <ExternalLink className="w-3.5 h-3.5 text-theme-muted" />
     </Link>
   );
 }
@@ -336,14 +355,14 @@ function SearchResults({ query, results, hasResults, onSelectTopic }: SearchResu
   if (!hasResults) {
     return (
       <div className="p-8 text-center">
-        <Search className="w-12 h-12 text-[var(--color-text-muted)] mx-auto mb-4" />
-        <h3 className="text-lg font-medium text-[var(--color-text)] mb-2">No results found</h3>
-        <p className="text-[var(--color-text-muted)] mb-4">
+        <Search className="w-12 h-12 text-theme-muted mx-auto mb-4" />
+        <h3 className="text-lg font-semibold text-theme mb-2">No results found</h3>
+        <p className="text-theme-secondary leading-relaxed mb-4">
           We could not find anything matching "{query}"
         </p>
         <Link
           to="/help"
-          className="text-[var(--color-info)] hover:text-[var(--color-info)] font-medium"
+          className="text-[var(--color-accent)] hover:brightness-125 font-medium animate-press"
         >
           Browse all help topics
         </Link>
@@ -355,21 +374,21 @@ function SearchResults({ query, results, hasResults, onSelectTopic }: SearchResu
     <div className="p-4 space-y-6">
       {results.topics.length > 0 && (
         <div>
-          <h3 className="text-sm font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">
+          <h3 className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-3">
             Topics ({results.topics.length})
           </h3>
-          <div className="space-y-2">
+          <div className="space-y-2 animate-stagger">
             {results.topics.map((topic) => (
               <button
                 key={topic.id}
                 onClick={() => onSelectTopic(topic)}
-                className="w-full flex items-center gap-3 p-3 bg-[var(--color-bg)] border rounded-lg hover:bg-[var(--color-bg-tertiary)] hover:border-[var(--color-info)] transition text-left"
+                className="glass-slab w-full flex items-center gap-3 p-3 rounded-2xl hover:border-[color:var(--color-border-hover)] text-left animate-enter animate-press animate-lift"
               >
-                <div className="flex-1">
-                  <p className="font-medium text-[var(--color-text)]">{topic.title}</p>
-                  <p className="text-sm text-[var(--color-text-muted)]">{topic.summary}</p>
+                <div className="flex-1 min-w-0">
+                  <p className="font-semibold text-theme">{topic.title}</p>
+                  <p className="text-sm text-theme-secondary leading-relaxed">{topic.summary}</p>
                 </div>
-                <ChevronRight className="w-4 h-4 text-[var(--color-text-muted)] flex-shrink-0" />
+                <ChevronRight className="w-4 h-4 text-theme-muted flex-shrink-0" />
               </button>
             ))}
           </div>
@@ -378,17 +397,17 @@ function SearchResults({ query, results, hasResults, onSelectTopic }: SearchResu
 
       {results.faqs.length > 0 && (
         <div>
-          <h3 className="text-sm font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">
+          <h3 className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-3">
             FAQ ({results.faqs.length})
           </h3>
-          <div className="space-y-2">
+          <div className="space-y-2 animate-stagger">
             {results.faqs.map((faq, index) => (
               <div
                 key={index}
-                className="p-4 bg-[var(--color-bg)] border rounded-lg"
+                className="glass-slab p-4 rounded-2xl animate-enter"
               >
-                <p className="font-medium text-[var(--color-text)] mb-2">{faq.question}</p>
-                <p className="text-sm text-[var(--color-text-secondary)]">{faq.answer}</p>
+                <p className="font-semibold text-theme mb-2">{faq.question}</p>
+                <p className="text-sm text-theme-secondary leading-relaxed">{faq.answer}</p>
               </div>
             ))}
           </div>
@@ -406,27 +425,27 @@ interface TopicDetailProps {
 
 const helpPanelMarkdownComponents = {
   h2: ({ children }: { children?: React.ReactNode }) => (
-    <h2 className="text-xl font-bold text-[var(--color-text)] mt-6 mb-3 first:mt-0">{children}</h2>
+    <h2 className="text-xl font-bold text-theme mt-6 mb-3 first:mt-0">{children}</h2>
   ),
   h3: ({ children }: { children?: React.ReactNode }) => (
-    <h3 className="text-lg font-semibold text-[var(--color-text)] mt-5 mb-2">{children}</h3>
+    <h3 className="text-lg font-semibold text-theme mt-5 mb-2">{children}</h3>
   ),
   p: ({ children }: { children?: React.ReactNode }) => (
-    <p className="text-[var(--color-text-secondary)] mb-3 leading-relaxed">{children}</p>
+    <p className="text-theme-secondary mb-3 leading-relaxed">{children}</p>
   ),
   strong: ({ children }: { children?: React.ReactNode }) => (
-    <strong className="font-semibold text-[var(--color-text)]">{children}</strong>
+    <strong className="font-semibold text-theme">{children}</strong>
   ),
   ul: ({ children }: { children?: React.ReactNode }) => (
-    <ul className="list-disc list-inside space-y-1 mb-4 text-[var(--color-text-secondary)]">{children}</ul>
+    <ul className="list-disc list-inside space-y-1 mb-4 text-theme-secondary">{children}</ul>
   ),
   li: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,
-  hr: () => <hr className="my-6 border-[var(--color-border)]" />,
+  hr: () => <hr className="my-6 border-theme" />,
 };
 
 function TopicDetail({ topic, onSelectTopic }: TopicDetailProps) {
   return (
-    <div className="p-6">
+    <div className="p-6 animate-fade-in">
       <div className="prose prose-sm max-w-none">
         <ReactMarkdown remarkPlugins={[remarkGfm]} components={helpPanelMarkdownComponents}>
           {topic.content}
@@ -435,11 +454,11 @@ function TopicDetail({ topic, onSelectTopic }: TopicDetailProps) {
 
       {/* Related Topics */}
       {topic.relatedTopics && topic.relatedTopics.length > 0 && (
-        <div className="mt-8 pt-6 border-t">
-          <h3 className="text-sm font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">
+        <div className="mt-8 pt-6 border-t border-theme">
+          <h3 className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-3">
             Related Topics
           </h3>
-          <div className="space-y-2">
+          <div className="space-y-2 animate-stagger">
             {topic.relatedTopics.map((topicId) => {
               const result = getTopicById(topicId);
               if (!result) return null;
@@ -448,13 +467,13 @@ function TopicDetail({ topic, onSelectTopic }: TopicDetailProps) {
                 <button
                   key={topicId}
                   onClick={() => onSelectTopic(result.topic)}
-                  className="w-full flex items-center gap-3 p-3 bg-[var(--color-bg-tertiary)] rounded-lg hover:bg-[var(--color-bg-secondary)] transition text-left"
+                  className="glass-slab w-full flex items-center gap-3 p-3 rounded-2xl hover:border-[color:var(--color-border-hover)] text-left animate-enter animate-press animate-lift"
                 >
-                  <div className="flex-1">
-                    <p className="font-medium text-[var(--color-text)]">{result.topic.title}</p>
-                    <p className="text-sm text-[var(--color-text-muted)]">{result.topic.summary}</p>
+                  <div className="flex-1 min-w-0">
+                    <p className="font-semibold text-theme">{result.topic.title}</p>
+                    <p className="text-sm text-theme-secondary leading-relaxed">{result.topic.summary}</p>
                   </div>
-                  <ChevronRight className="w-4 h-4 text-[var(--color-text-muted)] flex-shrink-0" />
+                  <ChevronRight className="w-4 h-4 text-theme-muted flex-shrink-0" />
                 </button>
               );
             })}

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -42,40 +42,72 @@ export function Header({ onMenuClick, onHelpClick }: HeaderProps) {
           {/* Mobile menu button */}
           <button
             onClick={onMenuClick}
-            className="lg:hidden p-2 -ml-2 text-theme-secondary hover:text-accent click-feedback rounded-sm"
+            className="lg:hidden p-2 -ml-2 text-theme-secondary hover:text-[var(--color-accent)] hover:bg-[var(--color-bg-tertiary)] animate-press rounded-sm transition-[color,background-color] duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
             aria-label="Toggle navigation"
           >
             <Menu className="w-6 h-6" />
           </button>
 
-          <Link to="/" className="flex items-center gap-3">
+          <Link
+            to="/"
+            className="flex items-center gap-3 animate-press rounded-sm transition-[color] duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+          >
             <img
               src="/metaventions-logo.png"
               alt="Metaventions AI"
               width={40}
               height={40}
+              loading="eager"
+              decoding="async"
               className="w-10 h-10 rounded-sm"
             />
-            <div className="hidden sm:block">
-              <h1 className="text-xl font-bold text-theme">
-                Frontier <span className="text-gradient-brand">Alpha</span>
+            <div className="hidden sm:flex flex-col leading-tight">
+              <h1 className="mono text-base font-bold tracking-[0.18em] uppercase text-theme">
+                FRONTIER <span className="text-gradient-brand">ALPHA</span>
               </h1>
-              <p className="text-[10px] text-theme-muted mono tracking-[0.3em] uppercase">by Metaventions AI</p>
+              <p className="hidden md:block text-[9px] text-theme-muted mono tracking-[0.4em] uppercase mt-0.5">
+                by Metaventions AI
+              </p>
             </div>
           </Link>
 
+          {/* Page title kicker (desktop) */}
+          {pageTitle && (
+            <div className="hidden lg:flex items-center gap-2 ml-2 pl-4 border-l border-theme">
+              <span
+                className="w-1 h-1 rounded-full bg-[var(--color-accent)]"
+                aria-hidden="true"
+              />
+              <span className="mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted holo-pulse">
+                {pageTitle}
+              </span>
+            </div>
+          )}
+
           {/* Mobile page title */}
           {pageTitle && (
-            <span className="lg:hidden text-sm font-semibold text-theme mono tracking-[0.1em] uppercase">
+            <span className="lg:hidden mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">
               {pageTitle}
             </span>
           )}
         </div>
 
-        <div className="flex items-center gap-2 sm:gap-4">
-          <div className="flex items-center gap-1 sm:gap-2" role="status" aria-label="Live connection active">
-            <div className="w-2 h-2 bg-[var(--color-brand-teal)] rounded-full animate-pulse-green shadow-[0_0_8px_var(--color-brand-teal)]" aria-hidden="true" />
-            <span className="text-[10px] text-[var(--color-brand-teal)] mono tracking-[0.3em] uppercase hidden sm:inline" aria-hidden="true">Live</span>
+        <div className="flex items-center gap-2 sm:gap-3">
+          <div
+            className="hidden sm:flex items-center gap-2 px-2.5 py-1 rounded-full glass-slab"
+            role="status"
+            aria-label="Live connection active"
+          >
+            <div
+              className="w-1.5 h-1.5 bg-[var(--color-brand-teal)] rounded-full animate-pulse-green shadow-[0_0_8px_var(--color-brand-teal)]"
+              aria-hidden="true"
+            />
+            <span
+              className="text-[9px] text-[var(--color-brand-teal)] mono tracking-[0.4em] uppercase"
+              aria-hidden="true"
+            >
+              Live
+            </span>
           </div>
 
           <AlertDropdown />
@@ -83,7 +115,7 @@ export function Header({ onMenuClick, onHelpClick }: HeaderProps) {
           {/* Dark mode toggle */}
           <button
             onClick={toggle}
-            className="p-2 text-theme-secondary hover:text-accent click-feedback rounded-sm"
+            className="p-2 text-theme-secondary hover:text-[var(--color-accent)] hover:bg-[var(--color-bg-tertiary)] animate-press rounded-sm transition-[color,background-color] duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
             aria-label={`Switch to ${resolved === 'dark' ? 'light' : 'dark'} mode`}
             title={`${resolved === 'dark' ? 'Light' : 'Dark'} mode`}
           >
@@ -94,7 +126,7 @@ export function Header({ onMenuClick, onHelpClick }: HeaderProps) {
           <HelpKeyboardHint />
           <button
             onClick={onHelpClick}
-            className="p-2 text-theme-secondary hover:text-accent click-feedback rounded-sm"
+            className="p-2 text-theme-secondary hover:text-[var(--color-accent)] hover:bg-[var(--color-bg-tertiary)] animate-press rounded-sm transition-[color,background-color] duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
             aria-label="Open help (press ? key)"
             title="Help (press ?)"
           >
@@ -104,7 +136,7 @@ export function Header({ onMenuClick, onHelpClick }: HeaderProps) {
           {/* Settings */}
           <Link
             to="/settings"
-            className="hidden lg:flex p-2 text-theme-secondary hover:text-theme click-feedback rounded-sm"
+            className="hidden lg:flex p-2 text-theme-secondary hover:text-[var(--color-accent)] hover:bg-[var(--color-bg-tertiary)] animate-press rounded-sm transition-[color,background-color] duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
             aria-label="Settings"
           >
             <Settings className="w-5 h-5" aria-hidden="true" />

--- a/client/src/components/layout/MobileNav.tsx
+++ b/client/src/components/layout/MobileNav.tsx
@@ -39,35 +39,31 @@ const morePages = [
 
 function navButtonClass(isActive: boolean) {
   return `
-    flex flex-col items-center justify-center
-    min-w-[64px] min-h-[56px] px-3 py-2
-    touch-manipulation
-    transition-all duration-150 ease-out
-    active:scale-95 click-feedback
+    relative flex flex-col items-center justify-center gap-1
+    flex-1 min-h-[56px] py-2
+    touch-manipulation animate-press
+    transition-colors duration-200
     focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-inset
-    ${isActive ? 'text-accent' : 'text-theme-muted hover:text-theme-secondary'}
+    before:content-[''] before:absolute before:top-0 before:left-1/2 before:-translate-x-1/2
+    before:h-[3px] before:w-8 before:rounded-full
+    ${isActive
+      ? 'text-[var(--color-accent)] before:bg-[image:var(--gradient-sovereign)]'
+      : 'text-theme-secondary hover:text-theme before:bg-transparent'
+    }
   `;
 }
 
-function NavButtonContent({ icon: Icon, label, isActive }: { icon: React.ElementType; label: string; isActive: boolean }) {
+function NavButtonContent({
+  icon: Icon,
+  label,
+}: {
+  icon: React.ElementType;
+  label: string;
+}) {
   return (
     <>
-      <div
-        className={`
-          relative flex items-center justify-center
-          w-12 h-11 min-h-[44px] rounded-sm
-          transition-all duration-200
-          ${isActive ? 'bg-accent-light' : ''}
-        `}
-      >
-        <Icon className={`w-5 h-5 ${isActive ? 'scale-110' : ''} transition-transform`} />
-        {isActive && (
-          <span className="absolute -bottom-1 w-4 h-[2px] gradient-brand rounded-full" />
-        )}
-      </div>
-      <span className={`text-[9px] mt-0.5 mono tracking-[0.15em] uppercase ${isActive ? 'text-accent' : ''}`}>
-        {label}
-      </span>
+      <Icon className="w-[22px] h-[22px]" aria-hidden="true" />
+      <span className="mono text-[10px] tracking-[0.15em] uppercase">{label}</span>
     </>
   );
 }
@@ -82,11 +78,11 @@ export function MobileNav() {
   return (
     <>
       <nav
-        className="lg:hidden fixed bottom-0 left-0 right-0 glass-slab-floating z-30"
+        className="fixed bottom-0 left-0 right-0 z-40 lg:hidden glass-slab-floating border-t border-theme"
         style={{ paddingBottom: 'env(safe-area-inset-bottom, 0)' }}
         aria-label="Mobile navigation"
       >
-        <div className="flex justify-around items-stretch h-16">
+        <div className="flex items-stretch">
           {mobileNavigation.map((item) => (
             <NavLink
               key={item.name}
@@ -95,19 +91,19 @@ export function MobileNav() {
               aria-label={item.name}
               className={({ isActive }) => navButtonClass(isActive)}
             >
-              {({ isActive }) => (
-                <NavButtonContent icon={item.icon} label={item.name} isActive={isActive} />
-              )}
+              {() => <NavButtonContent icon={item.icon} label={item.name} />}
             </NavLink>
           ))}
 
           {/* More button */}
           <button
+            type="button"
             onClick={() => setMoreOpen(true)}
             aria-label="More pages"
+            aria-expanded={moreOpen}
             className={navButtonClass(isMoreActive)}
           >
-            <NavButtonContent icon={MoreHorizontal} label="More" isActive={isMoreActive} />
+            <NavButtonContent icon={MoreHorizontal} label="More" />
           </button>
         </div>
       </nav>
@@ -117,27 +113,32 @@ export function MobileNav() {
         onClose={() => setMoreOpen(false)}
         title="More"
       >
-        <div className="space-y-1" style={{ paddingBottom: 'env(safe-area-inset-bottom, 0)' }}>
+        <div
+          className="space-y-1"
+          style={{ paddingBottom: 'env(safe-area-inset-bottom, 0)' }}
+        >
           {morePages.map((item) => {
             const isActive = location.pathname === item.href;
             return (
               <button
                 key={item.name}
+                type="button"
                 onClick={() => {
                   navigate(item.href);
                   setMoreOpen(false);
                 }}
                 className={`
                   w-full flex items-center gap-4 px-4 py-3
-                  min-h-[48px] rounded-lg
-                  touch-manipulation transition-colors
+                  min-h-[48px] rounded-sm
+                  touch-manipulation animate-press
+                  transition-colors duration-200
                   ${isActive
-                    ? 'bg-[color-mix(in_srgb,var(--color-accent)_10%,transparent)] text-accent'
-                    : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
+                    ? 'bg-[var(--color-accent-light)] text-[var(--color-accent)]'
+                    : 'text-theme-secondary hover:bg-[var(--color-bg-tertiary)] hover:text-theme'
                   }
                 `}
               >
-                <item.icon className="w-5 h-5 flex-shrink-0" />
+                <item.icon className="w-5 h-5 flex-shrink-0" aria-hidden="true" />
                 <span className="text-sm font-medium">{item.name}</span>
                 {isActive && (
                   <span className="ml-auto w-2 h-2 rounded-full bg-[var(--color-accent)]" />

--- a/client/src/components/onboarding/FeatureTour.tsx
+++ b/client/src/components/onboarding/FeatureTour.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import { X, ChevronLeft, ChevronRight, Check } from 'lucide-react';
-import { Button } from '@/components/shared/Button';
 
 interface TourStep {
   id: string;
@@ -87,7 +86,7 @@ export function FeatureTour({ isActive, onComplete, onSkip }: FeatureTourProps) 
 
     // Calculate tooltip position
     const tooltipWidth = 320;
-    const tooltipHeight = 180;
+    const tooltipHeight = 200;
     const padding = 16;
 
     let top = 0;
@@ -161,7 +160,7 @@ export function FeatureTour({ isActive, onComplete, onSkip }: FeatureTourProps) 
       {/* Backdrop with spotlight */}
       <div className="fixed inset-0 z-40 pointer-events-none">
         {/* Dark overlay */}
-        <div className="absolute inset-0 bg-black/60" />
+        <div className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fade-in" />
 
         {/* Spotlight cutout */}
         {highlightRect && (
@@ -182,84 +181,97 @@ export function FeatureTour({ isActive, onComplete, onSkip }: FeatureTourProps) 
       {/* Highlight ring */}
       {highlightRect && (
         <div
-          className="fixed z-50 pointer-events-none border-2 border-[var(--color-info)] rounded-xl animate-pulse-subtle"
+          className="fixed z-50 pointer-events-none border-2 border-[var(--color-accent)] rounded-xl animate-pulse-subtle"
           style={{
             top: highlightRect.top - 8,
             left: highlightRect.left - 8,
             width: highlightRect.width + 16,
             height: highlightRect.height + 16,
+            boxShadow: '0 0 40px rgba(123,44,255,0.4)',
           }}
         />
       )}
 
       {/* Tooltip */}
       <div
-        className="fixed z-50 w-80 bg-[var(--color-bg)] rounded-xl shadow-2xl animate-scale-in"
+        className="glass-modal fixed z-50 w-80 rounded-2xl overflow-hidden animate-enter shadow-[0_30px_80px_-20px_rgba(123,44,255,0.45)]"
         style={{
           top: tooltipPosition.top,
           left: tooltipPosition.left,
         }}
+        role="dialog"
+        aria-modal="true"
+        aria-label={step.title}
       >
+        {/* Sovereign top rail */}
+        <div className="sovereign-bar absolute top-0 left-0 right-0" />
+
         {/* Skip button */}
         <button
           onClick={onSkip}
-          className="absolute top-3 right-3 p-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors"
+          className="absolute top-3 right-3 p-1.5 text-theme-muted hover:text-theme rounded-lg transition-colors animate-press"
           aria-label="Skip tour"
         >
           <X className="w-4 h-4" />
         </button>
 
         <div className="p-5">
-          {/* Progress */}
-          <div className="flex items-center gap-1.5 mb-3">
+          {/* Kicker */}
+          <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-3">
+            ONBOARDING · Step {currentStep + 1} / {tourSteps.length}
+          </p>
+
+          {/* Progress dots */}
+          <div className="flex items-center gap-1.5 mb-4" aria-hidden="true">
             {tourSteps.map((_, index) => (
               <div
                 key={index}
-                className={`h-1.5 rounded-full transition-all ${
+                className="h-1.5 rounded-full transition-[width,background] duration-200"
+                style={
                   index <= currentStep
-                    ? 'w-6 bg-[var(--color-info)]'
-                    : 'w-1.5 bg-[var(--color-border)]'
-                }`}
+                    ? {
+                        width: '24px',
+                        background: 'var(--gradient-sovereign)',
+                      }
+                    : {
+                        width: '6px',
+                        background: 'var(--color-bg-tertiary)',
+                      }
+                }
               />
             ))}
           </div>
 
           {/* Content */}
-          <h3 className="text-lg font-semibold text-[var(--color-text)] mb-2">
+          <h3 className="text-lg font-bold text-theme mb-2">
             {step.title}
           </h3>
-          <p className="text-[var(--color-text-secondary)] text-sm mb-4">
+          <p className="text-theme-secondary text-sm leading-relaxed mb-5">
             {step.content}
           </p>
 
           {/* Navigation */}
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-2">
             <button
               onClick={handlePrev}
               disabled={currentStep === 0}
-              className="flex items-center gap-1 text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] disabled:opacity-50 disabled:cursor-not-allowed"
+              className="flex items-center gap-1 text-sm text-theme-muted hover:text-theme disabled:opacity-40 disabled:cursor-not-allowed animate-press px-2 py-1.5 rounded-md"
             >
               <ChevronLeft className="w-4 h-4" />
               Back
             </button>
 
-            <span className="text-xs text-[var(--color-text-muted)]">
-              {currentStep + 1} of {tourSteps.length}
-            </span>
-
-            <Button
+            <button
               onClick={handleNext}
-              size="sm"
-              rightIcon={
-                currentStep === tourSteps.length - 1 ? (
-                  <Check className="w-4 h-4" />
-                ) : (
-                  <ChevronRight className="w-4 h-4" />
-                )
-              }
+              className="flex items-center justify-center gap-1.5 px-4 py-2 rounded-lg bg-[image:var(--gradient-sovereign)] text-white text-sm font-medium animate-press animate-lift shadow-[0_4px_24px_rgba(123,44,255,0.35)] hover:brightness-110"
             >
               {currentStep === tourSteps.length - 1 ? 'Done' : 'Next'}
-            </Button>
+              {currentStep === tourSteps.length - 1 ? (
+                <Check className="w-4 h-4" />
+              ) : (
+                <ChevronRight className="w-4 h-4" />
+              )}
+            </button>
           </div>
         </div>
       </div>

--- a/client/src/components/onboarding/WelcomeModal.tsx
+++ b/client/src/components/onboarding/WelcomeModal.tsx
@@ -1,5 +1,4 @@
 import { X, ArrowRight, TrendingUp, BarChart2, Bell, Zap } from 'lucide-react';
-import { Button } from '@/components/shared/Button';
 
 interface WelcomeModalProps {
   isOpen: boolean;
@@ -48,75 +47,98 @@ export function WelcomeModal({ isOpen, onClose, onStartTour, onTryDemo }: Welcom
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
       {/* Backdrop */}
       <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-fade-in"
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
         onClick={onClose}
+        aria-hidden="true"
       />
 
       {/* Modal */}
-      <div className="relative bg-[var(--color-bg)] rounded-2xl shadow-2xl max-w-lg w-full overflow-hidden animate-scale-in">
+      <div
+        className="glass-modal relative max-w-lg w-full rounded-2xl overflow-hidden animate-enter shadow-[0_30px_80px_-20px_rgba(123,44,255,0.45)]"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Welcome to Frontier Alpha"
+      >
+        {/* Sovereign top rail */}
+        <div className="sovereign-bar absolute top-0 left-0 right-0" />
+
         {/* Close button */}
         <button
           onClick={onClose}
-          className="absolute top-4 right-4 p-2 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors z-10"
+          className="absolute top-4 right-4 p-2 text-white/80 hover:text-white rounded-lg transition-colors animate-press z-10"
           aria-label="Close"
         >
           <X className="w-5 h-5" />
         </button>
 
-        {/* Header with gradient */}
-        <div className="px-8 py-10 text-white" style={{ background: 'linear-gradient(to bottom right, var(--color-accent), var(--color-info))' }}>
-          <div className="flex items-center gap-3 mb-4">
-            <div className="w-12 h-12 bg-[var(--color-bg)]/20 rounded-xl flex items-center justify-center">
-              <TrendingUp className="w-6 h-6" />
+        {/* Header — sovereign gradient field */}
+        <div
+          className="relative px-8 py-10 text-white overflow-hidden"
+          style={{ background: 'var(--gradient-sovereign)' }}
+        >
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 opacity-40 pointer-events-none"
+            style={{
+              background:
+                'radial-gradient(circle at 20% 0%, rgba(255,255,255,0.4), transparent 60%)',
+            }}
+          />
+          <div className="relative">
+            <p className="text-[10px] mono tracking-[0.3em] uppercase text-white/80 mb-3">
+              ONBOARDING · Welcome
+            </p>
+            <div className="flex items-center gap-3 mb-4">
+              <div className="w-12 h-12 bg-white/15 backdrop-blur-sm rounded-xl flex items-center justify-center">
+                <TrendingUp className="w-6 h-6" />
+              </div>
+              <span className="text-lg font-semibold">Frontier Alpha</span>
             </div>
-            <span className="text-lg font-semibold">Frontier Alpha</span>
+            <h1 className="text-2xl font-bold mb-2">
+              Institutional-grade intelligence
+            </h1>
+            <p className="text-white/90 leading-relaxed">
+              See what the quants see. Understand what they will not explain.
+            </p>
           </div>
-          <h1 className="text-2xl font-bold mb-2">
-            Welcome to Institutional-Grade Intelligence
-          </h1>
-          <p className="text-[var(--color-info)]">
-            See what the quants see. Understand what they won't explain.
-          </p>
         </div>
 
         {/* Features */}
         <div className="p-6">
-          <h2 className="text-sm font-semibold text-[var(--color-text-muted)] uppercase tracking-wide mb-4">
-            What you'll get
-          </h2>
-          <div className="grid grid-cols-2 gap-4 mb-6">
-            {features.map((feature, index) => (
+          <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-4">
+            What you will get
+          </p>
+          <div className="grid grid-cols-2 gap-3 mb-6 animate-stagger">
+            {features.map((feature) => (
               <div
                 key={feature.title}
-                className="p-4 bg-[var(--color-bg-tertiary)] rounded-xl hover:bg-[var(--color-bg-secondary)] transition-colors animate-fade-in-up"
-                style={{ animationDelay: `${index * 100}ms` }}
+                className="glass-slab rounded-2xl p-4 animate-enter"
               >
-                <feature.icon className="w-6 h-6 text-[var(--color-info)] mb-2" />
-                <h3 className="font-semibold text-[var(--color-text)] text-sm">{feature.title}</h3>
-                <p className="text-xs text-[var(--color-text-muted)] mt-1">{feature.description}</p>
+                <feature.icon className="w-6 h-6 text-[var(--color-accent)] mb-2" aria-hidden="true" />
+                <h3 className="font-semibold text-theme text-sm">{feature.title}</h3>
+                <p className="text-xs text-theme-secondary leading-relaxed mt-1">{feature.description}</p>
               </div>
             ))}
           </div>
 
           {/* Actions */}
           <div className="space-y-3">
-            <Button
+            <button
               onClick={handleTryDemo}
-              fullWidth
-              rightIcon={<ArrowRight className="w-4 h-4" />}
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg bg-[image:var(--gradient-sovereign)] text-white font-medium animate-press animate-lift shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:brightness-110 hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)]"
             >
               Try with Demo Portfolio
-            </Button>
-            <Button
+              <ArrowRight className="w-4 h-4" />
+            </button>
+            <button
               onClick={handleStartTour}
-              variant="outline"
-              fullWidth
+              className="glass-slab w-full flex items-center justify-center gap-2 px-4 py-3 rounded-lg text-theme animate-press animate-lift hover:border-[color:var(--color-border-hover)]"
             >
               Take a Quick Tour
-            </Button>
+            </button>
             <button
               onClick={onClose}
-              className="w-full text-sm text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] py-2"
+              className="w-full text-sm text-theme-muted hover:text-theme py-2 animate-press"
             >
               Skip for now
             </button>

--- a/client/src/components/portfolio/PortfolioOverview.tsx
+++ b/client/src/components/portfolio/PortfolioOverview.tsx
@@ -1,6 +1,5 @@
 import React, { useMemo, useEffect, useRef } from 'react';
 import { TrendingUp, TrendingDown } from 'lucide-react';
-import { Card } from '@/components/shared/Card';
 import type { Portfolio } from '@/types';
 
 interface PortfolioOverviewProps {
@@ -66,19 +65,35 @@ function StatCard({
 
   return (
     <div
-      className="flex items-center gap-3 p-4 rounded-xl bg-[var(--color-bg-tertiary)] animate-fade-in-up"
+      className="glass-slab rounded-xl p-4 flex items-center gap-3 animate-enter transition-[transform,box-shadow] duration-200"
       style={{ animationDelay: `${delay}ms`, animationFillMode: 'both' }}
     >
-      <div className="p-3 rounded-lg flex-shrink-0" style={ICON_BG_STYLES[iconBg] ?? {}}>
+      <div
+        className="p-3 rounded-lg flex-shrink-0"
+        style={ICON_BG_STYLES[iconBg] ?? {}}
+        aria-hidden="true"
+      >
         {icon}
       </div>
       <div className="min-w-0">
-        <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">{label}</p>
+        <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+          {label}
+        </p>
         <p
-          className="text-xl font-bold mt-0.5"
-          style={{ color: isPositive ? 'var(--color-positive)' : value === 0 ? 'var(--color-text)' : 'var(--color-negative)' }}
+          className="text-xl font-bold tabular-nums mt-1"
+          style={{
+            color:
+              isPositive
+                ? 'var(--color-positive)'
+                : value === 0
+                ? 'var(--color-text)'
+                : 'var(--color-negative)',
+          }}
         >
-          {prefix}{value < 0 ? '-' : ''}<span ref={countRef}>0</span>{suffix}
+          {prefix}
+          {value < 0 ? '-' : ''}
+          <span ref={countRef}>0</span>
+          {suffix}
         </p>
       </div>
     </div>
@@ -99,35 +114,68 @@ export function PortfolioOverview({ portfolio }: PortfolioOverviewProps) {
   }, [portfolio]);
 
   const heroCountRef = useCountUp(stats.totalValue, 1000);
+  const isUp = stats.dailyChange >= 0;
+  const deltaColor = isUp ? 'var(--color-positive)' : 'var(--color-negative)';
+  const deltaBg = `color-mix(in srgb, ${deltaColor} 10%, transparent)`;
 
   return (
-    <Card title="Portfolio Overview">
-      {/* Hero Value — full width, prominent */}
-      <div className="gradient-brand-subtle rounded-xl p-6 mb-5 border border-[var(--color-border-light)]">
-        <p className="text-xs font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-2">Total Value</p>
+    <section
+      className="glass-slab rounded-2xl p-6 sm:p-8 animate-enter"
+      aria-label="Portfolio Overview"
+    >
+      {/* Kicker */}
+      <div className="flex items-center justify-between mb-4">
+        <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+          Portfolio
+        </p>
+        <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+          Live
+        </p>
+      </div>
+
+      {/* Hero metric */}
+      <div className="gradient-brand-subtle rounded-xl p-5 sm:p-6 mb-5 border border-theme-light">
+        <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-2">
+          Total Value
+        </p>
         <div className="flex items-baseline gap-3 flex-wrap">
-          <p className="text-4xl lg:text-5xl font-bold text-[var(--color-text)] tracking-tight holo-pulse">
+          <p className="text-4xl sm:text-5xl font-black text-gradient-brand tabular-nums tracking-tight holo-pulse">
             $<span ref={heroCountRef}>0</span>
           </p>
+
+          {/* Daily change pill — type-rail pattern */}
           <span
-            className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-semibold"
+            className="glass-slab-floating relative inline-flex items-center gap-1.5 pl-4 pr-3 py-1 rounded-full text-xs font-semibold tabular-nums overflow-hidden before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px]"
             style={{
-              backgroundColor: stats.dailyChange >= 0 ? 'color-mix(in srgb, var(--color-positive) 12%, transparent)' : 'color-mix(in srgb, var(--color-negative) 12%, transparent)',
-              color: stats.dailyChange >= 0 ? 'var(--color-positive)' : 'var(--color-negative)',
+              backgroundColor: deltaBg,
+              color: deltaColor,
+              ['--rail-color' as string]: deltaColor,
             }}
           >
-            {stats.dailyChange >= 0 ? (
+            <span
+              aria-hidden="true"
+              className="absolute left-0 top-0 bottom-0 w-[3px]"
+              style={{ backgroundColor: deltaColor }}
+            />
+            {isUp ? (
               <TrendingUp className="w-3.5 h-3.5 flex-shrink-0" />
             ) : (
               <TrendingDown className="w-3.5 h-3.5 flex-shrink-0" />
             )}
-            {stats.dailyChange >= 0 ? '+' : ''}${Math.abs(stats.dailyChange).toLocaleString(undefined, { maximumFractionDigits: 0 })} ({stats.dailyChangePercent >= 0 ? '+' : ''}{stats.dailyChangePercent.toFixed(2)}%) today
+            <span className="mono tracking-[0.1em]">
+              {isUp ? '+' : ''}$
+              {Math.abs(stats.dailyChange).toLocaleString(undefined, {
+                maximumFractionDigits: 0,
+              })}{' '}
+              ({stats.dailyChangePercent >= 0 ? '+' : ''}
+              {stats.dailyChangePercent.toFixed(2)}%) Today
+            </span>
           </span>
         </div>
       </div>
 
-      {/* Supporting metrics — 2 column with card backgrounds */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {/* Supporting metrics */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 animate-stagger">
         <StatCard
           label="Unrealized P&L"
           value={stats.totalPnL}
@@ -161,6 +209,6 @@ export function PortfolioOverview({ portfolio }: PortfolioOverviewProps) {
           delay={160}
         />
       </div>
-    </Card>
+    </section>
   );
 }

--- a/client/src/components/shared/BottomSheet.tsx
+++ b/client/src/components/shared/BottomSheet.tsx
@@ -6,6 +6,7 @@ interface BottomSheetProps {
   isOpen: boolean;
   onClose: () => void;
   title?: string;
+  kicker?: string;
   children: ReactNode;
   height?: 'auto' | 'half' | 'full';
   showHandle?: boolean;
@@ -16,12 +17,14 @@ export function BottomSheet({
   isOpen,
   onClose,
   title,
+  kicker,
   children,
   height = 'auto',
   showHandle = true,
   showCloseButton = true,
 }: BottomSheetProps) {
   const [isClosing, setIsClosing] = useState(false);
+  const [isEntering, setIsEntering] = useState(true);
   const [dragY, setDragY] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
 
@@ -30,7 +33,7 @@ export function BottomSheet({
   const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const heightClasses = {
-    auto: 'max-h-[85vh]',
+    auto: 'max-h-[80vh]',
     half: 'h-[50vh]',
     full: 'h-[90vh]',
   };
@@ -49,6 +52,9 @@ export function BottomSheet({
   useEffect(() => {
     if (isOpen) {
       previousFocusRef.current = document.activeElement as HTMLElement;
+      // Slide-in: start translated, then release on next frame
+      setIsEntering(true);
+      const raf = requestAnimationFrame(() => setIsEntering(false));
       // Focus the sheet itself (or first focusable child) after render
       const timer = setTimeout(() => {
         const focusable = sheetRef.current?.querySelector<HTMLElement>(
@@ -56,7 +62,10 @@ export function BottomSheet({
         );
         (focusable ?? sheetRef.current)?.focus();
       }, 50);
-      return () => clearTimeout(timer);
+      return () => {
+        cancelAnimationFrame(raf);
+        clearTimeout(timer);
+      };
     }
   }, [isOpen]);
 
@@ -164,16 +173,27 @@ export function BottomSheet({
 
   if (!isOpen && !isClosing) return null;
 
+  // Compute transform: enter from below, exit below, drag follows finger
+  let transform: string | undefined;
+  if (isDragging) {
+    transform = `translateY(${dragY}px)`;
+  } else if (isClosing || isEntering) {
+    transform = 'translateY(100%)';
+  } else {
+    transform = 'translateY(0)';
+  }
+
   return (
-    <div className="fixed inset-0 z-50">
+    <div className="fixed inset-0 z-50" role="presentation">
       {/* Backdrop */}
       <div
         className={`
-          absolute inset-0 bg-black/50 backdrop-blur-sm
+          absolute inset-0 bg-black/60 backdrop-blur-sm
           transition-opacity duration-300
-          ${isClosing ? 'opacity-0' : 'opacity-100'}
+          ${isClosing || isEntering ? 'opacity-0' : 'opacity-100 animate-fade-in'}
         `}
         onClick={handleClose}
+        aria-hidden="true"
       />
 
       {/* Sheet */}
@@ -181,46 +201,55 @@ export function BottomSheet({
         ref={sheetRef}
         className={`
           absolute bottom-0 left-0 right-0
-          bg-[var(--color-bg)] rounded-t-2xl shadow-2xl
+          glass-modal rounded-t-3xl
+          shadow-[0_-20px_60px_-15px_rgba(0,0,0,0.4)]
           flex flex-col
-          transition-transform duration-300 ease-out
           ${heightClasses[height]}
-          ${isClosing ? 'translate-y-full' : 'translate-y-0'}
         `}
         style={{
-          transform: isDragging ? `translateY(${dragY}px)` : undefined,
-          transition: isDragging ? 'none' : undefined,
+          transform,
+          transition: isDragging
+            ? 'none'
+            : 'transform var(--motion-duration-slow) var(--motion-ease-out)',
         }}
         role="dialog"
         aria-modal="true"
         aria-labelledby={title ? 'sheet-title' : undefined}
         tabIndex={-1}
       >
-        {/* Handle */}
+        {/* Drag handle */}
         {showHandle && (
           <div
             data-sheet-handle
-            className="flex-shrink-0 py-3 cursor-grab active:cursor-grabbing"
+            className="flex-shrink-0 pt-3 pb-2 cursor-grab active:cursor-grabbing"
           >
-            <div className="w-10 h-1 bg-[var(--color-border)] rounded-full mx-auto" />
+            <div className="mx-auto h-1 w-12 rounded-full bg-theme-tertiary" />
           </div>
         )}
 
         {/* Header */}
         {(title || showCloseButton) && (
-          <div className="flex-shrink-0 flex items-center justify-between px-6 pb-4 border-b border-[var(--color-border-light)]">
-            {title && (
-              <h2
-                id="sheet-title"
-                className="text-lg font-semibold text-[var(--color-text)]"
-              >
-                {title}
-              </h2>
-            )}
+          <div className="flex-shrink-0 flex items-start justify-between gap-3 px-6 pt-2 pb-4 border-b border-theme">
+            <div className="min-w-0">
+              {kicker && (
+                <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted mb-1">
+                  {kicker}
+                </p>
+              )}
+              {title && (
+                <h2
+                  id="sheet-title"
+                  className="text-lg font-semibold text-theme"
+                >
+                  {title}
+                </h2>
+              )}
+            </div>
             {showCloseButton && (
               <button
+                type="button"
                 onClick={handleClose}
-                className="p-2.5 -mr-2 min-w-[44px] min-h-[44px] text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] transition-colors flex items-center justify-center touch-manipulation"
+                className="flex-shrink-0 p-2.5 -mr-2 min-w-[44px] min-h-[44px] rounded-sm text-theme-muted hover:text-theme transition-colors duration-200 flex items-center justify-center touch-manipulation animate-press focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-inset"
                 aria-label="Close"
               >
                 <X className="w-5 h-5" />
@@ -230,7 +259,7 @@ export function BottomSheet({
         )}
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto overscroll-contain px-6 py-4">
+        <div className="flex-1 overflow-y-auto overscroll-contain px-6 py-4 max-h-[80vh]">
           {children}
         </div>
       </div>

--- a/client/src/components/shared/CommandPalette.tsx
+++ b/client/src/components/shared/CommandPalette.tsx
@@ -140,39 +140,52 @@ export function CommandPalette() {
   return (
     <div
       role="dialog"
+      aria-modal="true"
       aria-label="Command palette"
       className="fixed inset-0 z-[100] flex items-start justify-center pt-[12vh] px-4"
       onClick={close}
     >
-      <div className="absolute inset-0 bg-[color-mix(in_srgb,var(--color-bg)_70%,black_30%)] backdrop-blur-sm" />
+      {/* Backdrop */}
       <div
-        className="relative w-full max-w-xl rounded-sm border border-[var(--color-border)] bg-[var(--color-bg-secondary)] shadow-2xl animate-enter"
+        className="absolute inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
+        aria-hidden="true"
+      />
+
+      {/* Modal shell */}
+      <div
+        className="relative w-full max-w-xl glass-modal rounded-2xl overflow-hidden animate-enter"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-[var(--color-border-light)]">
-          <Search className="w-4 h-4 text-[var(--color-text-muted)] shrink-0" />
+        {/* Sovereign 3px gradient rail */}
+        <div className="sovereign-bar" aria-hidden="true" />
+
+        {/* Search input */}
+        <div className="flex items-center gap-3 px-6 py-5 border-b border-theme">
+          <Search className="w-4 h-4 text-theme-muted shrink-0" aria-hidden="true" />
           <input
             ref={inputRef}
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Jump to page, run command…"
-            className="flex-1 bg-transparent outline-none text-[var(--color-text)] placeholder-[var(--color-text-muted)] text-sm"
+            aria-label="Command palette search"
+            className="flex-1 bg-transparent outline-none text-theme placeholder-theme-muted text-lg mono"
           />
-          <kbd className="hidden sm:inline text-[9px] mono tracking-[0.2em] uppercase px-2 py-0.5 rounded-sm bg-[var(--color-bg-tertiary)] text-[var(--color-text-muted)]">
+          <kbd className="hidden sm:inline glass-slab rounded px-2 py-0.5 mono text-[10px] tracking-[0.2em] uppercase text-theme-muted">
             Esc
           </kbd>
         </div>
 
+        {/* Results */}
         <div ref={listRef} className="max-h-[50vh] overflow-y-auto py-1">
           {filtered.length === 0 ? (
-            <div className="px-4 py-10 text-center text-[var(--color-text-muted)] text-sm">
+            <div className="px-6 py-10 text-center text-theme-muted text-sm">
               No matches
             </div>
           ) : (
             Object.entries(grouped).map(([group, items]) => (
               <div key={group} className="py-1">
-                <div className="px-4 pt-2 pb-1 text-[9px] mono tracking-[0.35em] uppercase text-[var(--color-text-muted)]">
+                <div className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted px-6 pt-4 pb-2">
                   {group}
                 </div>
                 {items.map((item) => {
@@ -184,18 +197,22 @@ export function CommandPalette() {
                       type="button"
                       onClick={() => item.perform()}
                       onMouseMove={() => setActive(idx)}
-                      className={`w-full flex items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors ${
-                        isActive
-                          ? 'bg-[color-mix(in_srgb,var(--brand-amethyst)_14%,transparent)] text-[var(--color-text)]'
-                          : 'text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)]'
-                      }`}
+                      className={`
+                        w-full flex items-center gap-3 px-6 py-3 text-left text-sm
+                        transition-colors duration-150 animate-press
+                        focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)] focus-visible:ring-inset
+                        ${isActive
+                          ? 'bg-[var(--color-accent-light)] text-theme'
+                          : 'text-theme-secondary hover:text-theme'
+                        }
+                      `}
                     >
-                      <span className="shrink-0 text-[var(--color-text-muted)]">
+                      <span className="shrink-0 text-theme-muted">
                         {item.icon ?? <ArrowRight className="w-4 h-4" />}
                       </span>
                       <span className="flex-1 min-w-0 truncate">{item.label}</span>
                       {isActive && (
-                        <kbd className="text-[9px] mono tracking-[0.2em] uppercase px-2 py-0.5 rounded-sm bg-[var(--color-bg-tertiary)] text-[var(--color-text-muted)]">
+                        <kbd className="glass-slab rounded px-2 py-0.5 mono text-[10px] tracking-[0.2em] uppercase text-theme-muted">
                           ↵
                         </kbd>
                       )}
@@ -207,12 +224,17 @@ export function CommandPalette() {
           )}
         </div>
 
-        <div className="flex items-center justify-between gap-3 px-4 py-2 border-t border-[var(--color-border-light)] text-[9px] mono tracking-[0.2em] uppercase text-[var(--color-text-muted)]">
+        {/* Footer hints */}
+        <div className="flex items-center justify-between gap-3 px-6 py-3 border-t border-theme mono text-[10px] tracking-[0.2em] uppercase text-theme-muted">
           <span className="flex items-center gap-2">
-            <CommandIcon className="w-3 h-3" />
-            Cmd / Ctrl + K to open anywhere
+            <CommandIcon className="w-3 h-3" aria-hidden="true" />
+            <span>Cmd / Ctrl + K to open anywhere</span>
           </span>
-          <span>↑ ↓ Enter</span>
+          <span className="flex items-center gap-2">
+            <kbd className="glass-slab rounded px-2 py-0.5 mono text-[10px] text-theme-muted">↑</kbd>
+            <kbd className="glass-slab rounded px-2 py-0.5 mono text-[10px] text-theme-muted">↓</kbd>
+            <kbd className="glass-slab rounded px-2 py-0.5 mono text-[10px] text-theme-muted">↵</kbd>
+          </span>
         </div>
       </div>
     </div>

--- a/client/src/components/shared/ConnectionStatus.tsx
+++ b/client/src/components/shared/ConnectionStatus.tsx
@@ -51,35 +51,52 @@ export function ConnectionStatus() {
   const transportLabel = transport === 'websocket' ? 'WS' : transport === 'sse' ? 'SSE' : transport === 'polling' ? 'Poll' : null;
   const countdownSec = countdownMs !== null ? Math.ceil(countdownMs / 1000) : null;
 
+  const isReconnecting = state === 'reconnecting';
+  const railClass = isReconnecting
+    ? 'before:bg-[var(--color-warning)]'
+    : 'before:bg-[var(--color-negative)]';
+  const textClass = isReconnecting
+    ? 'text-[var(--color-warning)]'
+    : 'text-[var(--color-negative)]';
+  const glowClass = isReconnecting
+    ? 'shadow-[0_18px_60px_-20px_rgba(245,158,11,0.45)]'
+    : 'shadow-[0_18px_60px_-20px_rgba(239,68,68,0.45)]';
+  const dotClass = isReconnecting
+    ? 'bg-[var(--color-warning)] animate-pulse-subtle'
+    : 'bg-[var(--color-negative)]';
+
   return (
     <div
       role="status"
       aria-live="polite"
       className={`
-        flex items-center gap-2 px-4 py-2 text-xs font-medium transition-all duration-300
-        ${state === 'reconnecting'
-          ? 'bg-[var(--color-warning)]/10 text-[var(--color-warning)] border-b border-[var(--color-warning)]/20'
-          : 'bg-[var(--color-danger)]/10 text-[var(--color-danger)] border-b border-[var(--color-danger)]/20'
-        }
+        glass-slab-floating fixed top-20 right-4 z-40
+        rounded-full pl-4 pr-3 py-2 flex items-center gap-2
+        before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:rounded-l-full
+        ${railClass} ${glowClass} ${textClass}
+        transition-[opacity,transform] duration-300
       `}
     >
-      {state === 'reconnecting' ? (
+      <span
+        className={`inline-block w-1.5 h-1.5 rounded-full ${dotClass}`}
+        aria-hidden="true"
+      />
+      {isReconnecting ? (
         <>
-          <Wifi className="w-3.5 h-3.5 animate-pulse-subtle" />
-          <span>
-            Live feed disconnected. Reconnecting
-            {attempt > 0 && ` (attempt ${attempt})`}
-            {countdownSec !== null && countdownSec > 0 && ` in ${countdownSec}s`}
-            {transportLabel && <span className="ml-1 opacity-70">via {transportLabel}</span>}
-            ...
+          <Wifi className="w-3.5 h-3.5" aria-hidden="true" />
+          <span className="mono text-[10px] tracking-[0.25em] uppercase font-medium">
+            Reconnecting
+            {attempt > 0 && ` · ${attempt}`}
+            {countdownSec !== null && countdownSec > 0 && ` · ${countdownSec}s`}
+            {transportLabel && <span className="ml-1 opacity-70">· {transportLabel}</span>}
           </span>
         </>
       ) : (
         <>
-          <WifiOff className="w-3.5 h-3.5" />
-          <span>
-            Live feed disconnected. Data may be stale.
-            {transportLabel && <span className="ml-1 opacity-70">[{transportLabel}]</span>}
+          <WifiOff className="w-3.5 h-3.5" aria-hidden="true" />
+          <span className="mono text-[10px] tracking-[0.25em] uppercase font-medium">
+            Offline · Data Stale
+            {transportLabel && <span className="ml-1 opacity-70">· {transportLabel}</span>}
           </span>
         </>
       )}

--- a/client/src/components/shared/KeyboardHelpModal.tsx
+++ b/client/src/components/shared/KeyboardHelpModal.tsx
@@ -44,9 +44,9 @@ export function KeyboardHelpModal({ isOpen, onClose }: KeyboardHelpModalProps) {
 
   return (
     <div className="fixed inset-0 z-[60]" role="presentation">
-      {/* Backdrop */}
+      {/* Backdrop — family pattern */}
       <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm animate-fade-in"
+        className="fixed inset-0 bg-black/60 backdrop-blur-sm animate-fade-in"
         onClick={onClose}
         aria-hidden="true"
       />
@@ -55,20 +55,33 @@ export function KeyboardHelpModal({ isOpen, onClose }: KeyboardHelpModalProps) {
       <div className="absolute inset-0 flex items-center justify-center p-4">
         <div
           ref={modalRef}
-          className="relative w-full max-w-md bg-[var(--color-bg)] border border-[var(--color-border)] rounded-2xl shadow-2xl animate-fade-in-up"
+          className="glass-modal relative w-full max-w-md rounded-2xl overflow-hidden animate-enter shadow-[0_30px_80px_-20px_rgba(123,44,255,0.35)]"
           role="dialog"
           aria-modal="true"
           aria-label="Keyboard shortcuts"
         >
+          {/* Sovereign top rail */}
+          <div className="sovereign-bar absolute top-0 left-0 right-0" />
+
           {/* Header */}
-          <div className="flex items-center justify-between px-6 py-4 border-b border-[var(--color-border)]">
+          <div className="flex items-center justify-between px-6 py-5 border-b border-theme">
             <div className="flex items-center gap-3">
-              <Keyboard className="w-5 h-5 text-[var(--color-accent)]" aria-hidden="true" />
-              <h2 className="text-lg font-semibold text-[var(--color-text)]">Keyboard Shortcuts</h2>
+              <div
+                className="p-2 rounded-lg shrink-0"
+                style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 12%, transparent)' }}
+              >
+                <Keyboard className="w-5 h-5 text-[var(--color-accent)]" aria-hidden="true" />
+              </div>
+              <div>
+                <p className="text-[10px] mono tracking-[0.3em] uppercase text-theme-muted">
+                  HELP · Shortcuts
+                </p>
+                <h2 className="text-lg font-bold text-theme mt-0.5">Keyboard Shortcuts</h2>
+              </div>
             </div>
             <button
               onClick={onClose}
-              className="p-2 text-[var(--color-text-muted)] hover:text-[var(--color-text-secondary)] hover:bg-[var(--color-bg-tertiary)] rounded-lg transition-colors"
+              className="p-2 text-theme-muted hover:text-theme rounded-lg transition-colors animate-press"
               aria-label="Close keyboard shortcuts"
             >
               <X className="w-5 h-5" />
@@ -77,16 +90,16 @@ export function KeyboardHelpModal({ isOpen, onClose }: KeyboardHelpModalProps) {
 
           {/* Shortcuts list */}
           <div className="px-6 py-4 max-h-[60vh] overflow-y-auto">
-            <div className="space-y-1">
+            <div className="space-y-1 animate-stagger">
               {ALL_SHORTCUTS.map((shortcut) => (
                 <div
                   key={shortcut.key}
-                  className="flex items-center justify-between py-2 px-2 rounded-lg hover:bg-[var(--color-bg-tertiary)] transition-colors"
+                  className="flex items-center justify-between py-2 px-2 rounded-lg hover:bg-[var(--color-bg-tertiary)] transition-colors animate-enter"
                 >
-                  <span className="text-sm text-[var(--color-text-secondary)]">
+                  <span className="text-sm text-theme-secondary leading-relaxed">
                     {shortcut.description}
                   </span>
-                  <kbd className="inline-flex items-center justify-center min-w-[28px] h-7 px-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-md text-xs font-mono font-medium text-[var(--color-text)] shadow-sm">
+                  <kbd className="glass-slab inline-flex items-center justify-center min-w-[28px] h-7 px-2 rounded mono text-[11px] text-theme-secondary border border-theme">
                     {shortcut.key}
                   </kbd>
                 </div>
@@ -95,9 +108,9 @@ export function KeyboardHelpModal({ isOpen, onClose }: KeyboardHelpModalProps) {
           </div>
 
           {/* Footer */}
-          <div className="px-6 py-3 border-t border-[var(--color-border)] bg-[var(--color-bg-tertiary)] rounded-b-2xl">
-            <p className="text-xs text-[var(--color-text-muted)] text-center">
-              Shortcuts are disabled when a text field is focused
+          <div className="px-6 py-3 border-t border-theme bg-[var(--color-bg-tertiary)]">
+            <p className="text-[10px] mono tracking-[0.2em] uppercase text-theme-muted text-center">
+              Disabled while a text field is focused
             </p>
           </div>
         </div>

--- a/client/src/components/shared/MockDataBanner.tsx
+++ b/client/src/components/shared/MockDataBanner.tsx
@@ -53,18 +53,18 @@ export function MockDataBanner() {
   return (
     <div
       role="alert"
-      className="flex items-center gap-3 px-4 py-2.5 bg-[var(--color-warning)]/10 border-b border-[var(--color-warning)]/20"
+      className="glass-slab-floating relative overflow-hidden rounded-none border-y border-theme pl-5 pr-4 py-2 flex items-center justify-center gap-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-warning)] shadow-[0_2px_20px_-5px_rgba(245,158,11,0.3)]"
     >
-      <AlertTriangle className="w-4 h-4 text-[var(--color-warning)] shrink-0" />
-      <p className="text-xs sm:text-sm text-[var(--color-warning)] font-medium flex-1">
-        Demo Mode — Using simulated data. Connect API keys for live market data.
+      <AlertTriangle className="w-3.5 h-3.5 text-[var(--color-warning)] shrink-0" aria-hidden="true" />
+      <p className="mono text-[10px] sm:text-xs tracking-[0.25em] uppercase text-[var(--color-warning)] font-medium">
+        Demo Mode <span className="opacity-60">·</span> Simulated Data <span className="opacity-60">·</span> Connect API Keys for Live Market Data
       </p>
       <button
         onClick={() => setDismissed(true)}
-        className="p-1 text-[var(--color-warning)] hover:opacity-70 transition-opacity shrink-0"
+        className="p-1 text-[var(--color-warning)] hover:bg-[var(--color-bg-tertiary)] hover:opacity-80 animate-press rounded-sm transition-[opacity,background-color] duration-200 shrink-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-warning)]"
         aria-label="Dismiss mock data banner"
       >
-        <X className="w-4 h-4" />
+        <X className="w-3.5 h-3.5" />
       </button>
     </div>
   );

--- a/client/src/components/shared/PullToRefresh.tsx
+++ b/client/src/components/shared/PullToRefresh.tsx
@@ -27,6 +27,7 @@ export function PullToRefresh({
 
   const progress = Math.min(pullDistance / threshold, 1);
   const rotation = progress * 360;
+  const ready = progress >= 1;
 
   useEffect(() => {
     const container = containerRef.current;
@@ -100,29 +101,35 @@ export function PullToRefresh({
       <div
         className={`
           absolute top-0 left-0 right-0 flex items-center justify-center
+          pointer-events-none
           transition-opacity duration-200
-          ${pullDistance > 0 ? 'opacity-100' : 'opacity-0'}
+          ${pullDistance > 0 || isRefreshing ? 'opacity-100' : 'opacity-0'}
         `}
         style={{
           height: pullDistance,
           transform: `translateY(-${Math.max(0, threshold * 0.6 - pullDistance)}px)`,
         }}
+        aria-live="polite"
+        aria-label={isRefreshing ? 'Refreshing' : ready ? 'Release to refresh' : 'Pull to refresh'}
       >
         <div
           className={`
-            w-10 h-10 rounded-full bg-[var(--color-bg)] shadow-lg
-            flex items-center justify-center
+            glass-slab-floating rounded-full p-3
+            shadow-[0_8px_30px_-10px_rgba(123,44,255,0.4)]
             transition-transform duration-200
-            ${isRefreshing ? 'animate-spin' : ''}
           `}
           style={{
             transform: isRefreshing ? undefined : `rotate(${rotation}deg)`,
           }}
         >
           <RefreshCw
-            className={`w-5 h-5 ${
-              progress >= 1 ? 'text-[var(--color-info)]' : 'text-[var(--color-text-muted)]'
-            }`}
+            className={`
+              w-5 h-5
+              ${isRefreshing ? 'animate-spin text-[var(--color-accent)]' : ''}
+              ${!isRefreshing && ready ? 'text-[var(--color-accent)]' : ''}
+              ${!isRefreshing && !ready ? 'text-theme-muted' : ''}
+            `}
+            aria-hidden="true"
           />
         </div>
       </div>
@@ -131,7 +138,9 @@ export function PullToRefresh({
       <div
         style={{
           transform: `translateY(${pullDistance}px)`,
-          transition: isPulling ? 'none' : 'transform 0.3s ease-out',
+          transition: isPulling
+            ? 'none'
+            : 'transform var(--motion-duration-slow) var(--motion-ease-out)',
         }}
       >
         {children}

--- a/client/src/pages/Backtest.tsx
+++ b/client/src/pages/Backtest.tsx
@@ -3,6 +3,10 @@
  *
  * Walk-forward backtesting interface with equity curve visualization,
  * episode performance breakdown, and factor attribution.
+ *
+ * Layout-wrapped (see App.tsx) — page chrome (grid bg, sovereign bar)
+ * is provided by the parent Layout. This page contributes the section
+ * shell, hero, run controls, and result surfaces.
  */
 
 import { useState } from 'react';
@@ -70,6 +74,16 @@ interface BacktestResult {
 
 const DEFAULT_SYMBOLS = ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'AMZN', 'META', 'TSLA', 'JPM'];
 
+// Canonical input class — matches Settings/LoginForm pattern.
+const inputClass =
+  'block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm';
+
+const labelClass =
+  'block mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted mb-2';
+
+const kickerClass =
+  'mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted mb-2';
+
 function useRunBacktest() {
   const { toastSuccess, toastError } = useToast();
   return useMutation({
@@ -97,14 +111,17 @@ interface MetricCardProps {
 
 function MetricCard({ label, value, subtitle, icon, color = 'text-[var(--color-text)]' }: MetricCardProps) {
   return (
-    <div className="flex items-center gap-3 p-4 rounded-xl bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)]">
-      <div className="p-2.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 8%, transparent)' }}>
+    <div className="glass-slab rounded-xl p-4 flex items-center gap-3 animate-enter">
+      <div
+        className="p-2.5 rounded-lg flex-shrink-0"
+        style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 8%, transparent)' }}
+      >
         <span className="text-[var(--color-accent)]">{icon}</span>
       </div>
       <div className="min-w-0">
-        <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">{label}</p>
-        <p className={`text-xl font-bold mt-0.5 ${color}`}>{value}</p>
-        {subtitle && <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{subtitle}</p>}
+        <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">{label}</p>
+        <p className={`text-xl font-bold mt-0.5 tabular-nums ${color}`}>{value}</p>
+        {subtitle && <p className="text-xs text-theme-muted mt-0.5">{subtitle}</p>}
       </div>
     </div>
   );
@@ -138,208 +155,228 @@ export function Backtest() {
   };
 
   return (
-    <div className="min-h-screen bg-[var(--color-bg-tertiary)]">
-      {/* Header */}
+    <div className="space-y-6 max-w-7xl mx-auto">
+      {/* ── Header ──────────────────────────────────────────────────────── */}
       <div
-        className="bg-[var(--color-bg)] border-b border-[var(--color-border)] px-4 sm:px-6 py-4 animate-fade-in-up"
-        style={{ animationFillMode: 'both' }}
+        className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 animate-fade-in-up"
+        style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
-        <div className="max-w-7xl mx-auto flex flex-col sm:flex-row sm:items-center justify-between gap-3">
-          <div className="flex items-center gap-3">
-            <div
-              className="w-10 h-10 rounded-xl flex items-center justify-center shrink-0"
-              style={{ backgroundColor: 'var(--color-accent)' }}
-            >
-              <BarChart3 className="w-6 h-6 text-white" />
-            </div>
-            <div>
-              <h1 className="text-lg sm:text-xl font-bold text-[var(--color-text)]">Walk-Forward Backtest</h1>
-              <p className="text-sm text-[var(--color-text-muted)]">
-                CVRF-integrated historical validation
-              </p>
-            </div>
-          </div>
-          <button
-            onClick={() => setShowConfig(!showConfig)}
-            className="px-4 py-2 min-h-[44px] text-sm text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-bg-secondary)] rounded-lg flex items-center gap-2 transition-colors"
-          >
-            <Settings2 className="w-4 h-4" />
-            {showConfig ? 'Hide Config' : 'Show Config'}
-          </button>
+        <div>
+          <p className={kickerClass}>
+            Backtest · <span className="text-[color:var(--color-accent-secondary)]">Walk-Forward Validation</span>
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-black tracking-tight">
+            <span className="text-gradient-brand">Historical</span>{' '}
+            <span className="text-theme">Conviction</span>
+          </h1>
+          <p className="mt-3 text-sm sm:text-base text-theme-secondary leading-relaxed max-w-2xl">
+            CVRF-integrated walk-forward engine. Fold-by-fold out-of-sample returns,
+            overfit ratio, and factor attribution for any strategy across any window.
+          </p>
         </div>
+
+        <button
+          onClick={() => setShowConfig(!showConfig)}
+          aria-pressed={showConfig}
+          aria-label={showConfig ? 'Hide configuration panel' : 'Show configuration panel'}
+          className="inline-flex items-center gap-2 px-4 py-2.5 min-h-[44px] rounded-sm glass-slab text-theme-secondary hover:text-theme mono text-[10px] tracking-[0.3em] uppercase animate-press transition-colors duration-200"
+        >
+          <Settings2 className="w-4 h-4" aria-hidden="true" />
+          {showConfig ? 'Hide Config' : 'Show Config'}
+        </button>
       </div>
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 py-6 space-y-6">
-        {/* Configuration Panel */}
-        {showConfig && (
-          <div
-            className="bg-[var(--color-bg)] rounded-xl border border-[var(--color-border)] p-6 hover:shadow-sm transition-shadow animate-fade-in-up"
-            style={{ animationDelay: '50ms' }}
-          >
-            <h3 className="text-lg font-semibold text-[var(--color-text)] mb-4">
-              Backtest Configuration
-            </h3>
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {/* Symbols */}
-              <div className="lg:col-span-3">
-                <label className="block text-sm text-[var(--color-text-secondary)] mb-1">
-                  Symbols (comma-separated)
-                </label>
-                <input
-                  type="text"
-                  value={symbolInput}
-                  onChange={(e) => setSymbolInput(e.target.value)}
-                  className="w-full p-2 min-h-[44px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg text-sm text-[var(--color-text)]"
-                  placeholder="AAPL, MSFT, NVDA..."
-                />
-              </div>
-
-              {/* Start Date */}
-              <div>
-                <label className="block text-sm text-[var(--color-text-secondary)] mb-1">
-                  Start Date
-                </label>
-                <input
-                  type="date"
-                  value={config.startDate}
-                  onChange={(e) => setConfig({ ...config, startDate: e.target.value })}
-                  className="w-full p-2 min-h-[44px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg text-sm text-[var(--color-text)]"
-                />
-              </div>
-
-              {/* End Date */}
-              <div>
-                <label className="block text-sm text-[var(--color-text-secondary)] mb-1">
-                  End Date
-                </label>
-                <input
-                  type="date"
-                  value={config.endDate}
-                  onChange={(e) => setConfig({ ...config, endDate: e.target.value })}
-                  className="w-full p-2 min-h-[44px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg text-sm text-[var(--color-text)]"
-                />
-              </div>
-
-              {/* Initial Capital */}
-              <div>
-                <label className="block text-sm text-[var(--color-text-secondary)] mb-1">
-                  Initial Capital ($)
-                </label>
-                <input
-                  type="number"
-                  value={config.initialCapital}
-                  onChange={(e) => setConfig({ ...config, initialCapital: Number(e.target.value) })}
-                  className="w-full p-2 min-h-[44px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg text-sm text-[var(--color-text)]"
-                />
-              </div>
-
-              {/* Strategy */}
-              <div>
-                <label className="block text-sm text-[var(--color-text-secondary)] mb-1">
-                  Strategy
-                </label>
-                <select
-                  value={config.strategy}
-                  onChange={(e) =>
-                    setConfig({ ...config, strategy: e.target.value as BacktestRunConfig['strategy'] })
-                  }
-                  className="w-full p-2 min-h-[44px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg text-sm text-[var(--color-text)]"
-                >
-                  <option value="max_sharpe">Max Sharpe</option>
-                  <option value="min_volatility">Min Volatility</option>
-                  <option value="risk_parity">Risk Parity</option>
-                </select>
-              </div>
-
-              {/* Rebalance Frequency */}
-              <div>
-                <label className="block text-sm text-[var(--color-text-secondary)] mb-1">
-                  Rebalance
-                </label>
-                <select
-                  value={config.rebalanceFrequency}
-                  onChange={(e) =>
-                    setConfig({
-                      ...config,
-                      rebalanceFrequency: e.target.value as BacktestRunConfig['rebalanceFrequency'],
-                    })
-                  }
-                  className="w-full p-2 min-h-[44px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg text-sm text-[var(--color-text)]"
-                >
-                  <option value="daily">Daily</option>
-                  <option value="weekly">Weekly</option>
-                  <option value="monthly">Monthly</option>
-                </select>
-              </div>
-
-              {/* Episode Length */}
-              <div>
-                <label className="block text-sm text-[var(--color-text-secondary)] mb-1">
-                  Episode Length (days)
-                </label>
-                <input
-                  type="number"
-                  value={config.episodeLengthDays}
-                  onChange={(e) => setConfig({ ...config, episodeLengthDays: Number(e.target.value) })}
-                  className="w-full p-2 min-h-[44px] bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded-lg text-sm text-[var(--color-text)]"
-                />
-              </div>
-            </div>
-
-            {/* Run Button */}
-            <div className="mt-6 flex items-center gap-4">
-              <button
-                onClick={handleRun}
-                disabled={isPending}
-                className="px-6 py-2.5 min-h-[44px] text-white rounded-lg flex items-center gap-2 transition-colors disabled:opacity-50 hover:opacity-90"
-                style={{ backgroundColor: 'var(--color-accent)' }}
-              >
-                {isPending ? (
-                  <>
-                    <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                    Running...
-                  </>
-                ) : (
-                  <>
-                    <Play className="w-4 h-4" />
-                    Run Backtest
-                  </>
-                )}
-              </button>
-              {isPending && (
-                <span className="text-sm text-[var(--color-text-muted)]">
-                  This may take a few minutes...
-                </span>
-              )}
-            </div>
-          </div>
-        )}
-
-        {/* Error */}
-        {error && (
-          <div
-            className="rounded-xl p-4 flex items-center gap-2 border"
-            style={{
-              backgroundColor: 'color-mix(in srgb, var(--color-negative) 10%, transparent)',
-              borderColor: 'color-mix(in srgb, var(--color-negative) 20%, transparent)',
-              color: 'var(--color-negative)',
-            }}
-          >
-            <AlertTriangle className="w-5 h-5 shrink-0" />
-            <span className="text-sm">
-              Backtest failed: {(error as Error).message}
-            </span>
-          </div>
-        )}
-
-        {/* Results */}
-        {result && (
-          <>
-            {/* Metrics Row */}
+      {/* ── Configuration Panel ─────────────────────────────────────────── */}
+      {showConfig && (
+        <section
+          className="glass-slab rounded-2xl p-6 sm:p-8 animate-fade-in-up"
+          style={{ animationDelay: '50ms', animationFillMode: 'both' }}
+        >
+          <header className="flex items-start gap-4 mb-6">
             <div
-              className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 animate-fade-in-up"
-              style={{ animationDelay: '100ms' }}
+              className="p-2.5 rounded-lg shrink-0"
+              style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
             >
+              <Settings2 className="w-5 h-5" style={{ color: 'var(--color-accent)' }} aria-hidden="true" />
+            </div>
+            <div className="min-w-0">
+              <p className={kickerClass}>Inputs</p>
+              <h2 className="text-lg font-bold text-theme mt-1">Backtest Configuration</h2>
+              <p className="text-sm text-theme-secondary mt-1">
+                Universe, date range, strategy, and rebalance cadence
+              </p>
+            </div>
+          </header>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
+            {/* Symbols */}
+            <div className="lg:col-span-3">
+              <label htmlFor="bt-symbols" className={labelClass}>
+                Symbols (comma-separated)
+              </label>
+              <input
+                id="bt-symbols"
+                type="text"
+                value={symbolInput}
+                onChange={(e) => setSymbolInput(e.target.value)}
+                className={inputClass}
+                placeholder="AAPL, MSFT, NVDA..."
+              />
+            </div>
+
+            {/* Start Date */}
+            <div>
+              <label htmlFor="bt-start" className={labelClass}>
+                Start Date
+              </label>
+              <input
+                id="bt-start"
+                type="date"
+                value={config.startDate}
+                onChange={(e) => setConfig({ ...config, startDate: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+
+            {/* End Date */}
+            <div>
+              <label htmlFor="bt-end" className={labelClass}>
+                End Date
+              </label>
+              <input
+                id="bt-end"
+                type="date"
+                value={config.endDate}
+                onChange={(e) => setConfig({ ...config, endDate: e.target.value })}
+                className={inputClass}
+              />
+            </div>
+
+            {/* Initial Capital */}
+            <div>
+              <label htmlFor="bt-capital" className={labelClass}>
+                Initial Capital ($)
+              </label>
+              <input
+                id="bt-capital"
+                type="number"
+                value={config.initialCapital}
+                onChange={(e) => setConfig({ ...config, initialCapital: Number(e.target.value) })}
+                className={`${inputClass} tabular-nums`}
+              />
+            </div>
+
+            {/* Strategy */}
+            <div>
+              <label htmlFor="bt-strategy" className={labelClass}>
+                Strategy
+              </label>
+              <select
+                id="bt-strategy"
+                value={config.strategy}
+                onChange={(e) =>
+                  setConfig({ ...config, strategy: e.target.value as BacktestRunConfig['strategy'] })
+                }
+                className={inputClass}
+              >
+                <option value="max_sharpe">Max Sharpe</option>
+                <option value="min_volatility">Min Volatility</option>
+                <option value="risk_parity">Risk Parity</option>
+              </select>
+            </div>
+
+            {/* Rebalance Frequency */}
+            <div>
+              <label htmlFor="bt-rebalance" className={labelClass}>
+                Rebalance
+              </label>
+              <select
+                id="bt-rebalance"
+                value={config.rebalanceFrequency}
+                onChange={(e) =>
+                  setConfig({
+                    ...config,
+                    rebalanceFrequency: e.target.value as BacktestRunConfig['rebalanceFrequency'],
+                  })
+                }
+                className={inputClass}
+              >
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+              </select>
+            </div>
+
+            {/* Episode Length */}
+            <div>
+              <label htmlFor="bt-episode" className={labelClass}>
+                Episode Length (days)
+              </label>
+              <input
+                id="bt-episode"
+                type="number"
+                value={config.episodeLengthDays}
+                onChange={(e) => setConfig({ ...config, episodeLengthDays: Number(e.target.value) })}
+                className={`${inputClass} tabular-nums`}
+              />
+            </div>
+          </div>
+
+          {/* Run Button */}
+          <div className="mt-7 flex flex-col sm:flex-row sm:items-center gap-4">
+            <button
+              onClick={handleRun}
+              disabled={isPending}
+              aria-label="Run backtest"
+              className="inline-flex items-center justify-center gap-2 px-6 py-3 min-h-[44px] rounded-sm bg-[image:var(--gradient-sovereign)] text-white mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:brightness-110 hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)] disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:shadow-[0_4px_30px_rgba(123,44,255,0.35)] transition-[filter,box-shadow] duration-200"
+            >
+              {isPending ? (
+                <>
+                  <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" aria-hidden="true" />
+                  Running…
+                </>
+              ) : (
+                <>
+                  <Play className="w-4 h-4" aria-hidden="true" />
+                  Run Backtest
+                </>
+              )}
+            </button>
+            {isPending && (
+              <span className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">
+                Folding walk-forward windows…
+              </span>
+            )}
+          </div>
+        </section>
+      )}
+
+      {/* ── Error Banner ────────────────────────────────────────────────── */}
+      {error && (
+        <div
+          className="glass-slab-floating relative overflow-hidden rounded-xl pl-5 pr-4 py-4 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-negative)] shadow-[0_18px_60px_-20px_rgba(239,68,68,0.45)] animate-fade-in-up"
+          role="alert"
+        >
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5 text-[var(--color-negative)]" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <p className="text-sm font-semibold text-theme">Backtest failed</p>
+              <p className="text-sm mt-1 text-theme-secondary leading-relaxed">{(error as Error).message}</p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* ── Results ─────────────────────────────────────────────────────── */}
+      {result && (
+        <>
+          {/* Metrics Row */}
+          <section
+            className="animate-fade-in-up"
+            style={{ animationDelay: '100ms', animationFillMode: 'both' }}
+          >
+            <p className={kickerClass}>Results · Walk-Forward</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-4 animate-stagger">
               <MetricCard
                 label="Total Return"
                 value={`${(result.walkForward.totalReturn * 100).toFixed(2)}%`}
@@ -378,201 +415,217 @@ export function Backtest() {
                 icon={<Clock className="w-4 h-4" />}
               />
             </div>
+          </section>
 
-            {/* Equity Curve */}
-            {result.equityCurve.length > 0 && (
-              <div
-                className="bg-[var(--color-bg)] rounded-xl border border-[var(--color-border)] p-6 animate-fade-in-up"
-                style={{ animationDelay: '150ms' }}
-              >
-                <h3 className="text-lg font-semibold text-[var(--color-text)] mb-4 flex items-center gap-2">
-                  <TrendingUp className="w-5 h-5 text-[var(--color-accent)]" />
-                  Equity Curve
-                </h3>
-                <div className="h-80">
-                  <ResponsiveContainer width="100%" height="100%">
-                    <ComposedChart data={result.equityCurve} margin={{ top: 5, right: 20, bottom: 5, left: 10 }}>
-                      <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light, var(--color-border))" />
-                      <XAxis
-                        dataKey="date"
-                        tick={{ fill: 'var(--color-text-muted, var(--color-text-muted))', fontSize: 11 }}
-                        tickFormatter={(d) => new Date(d).toLocaleDateString('en-US', { month: 'short', year: '2-digit' })}
-                      />
-                      <YAxis
-                        tick={{ fill: 'var(--color-text-muted, var(--color-text-muted))', fontSize: 11 }}
-                        tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`}
-                      />
-                      <Tooltip
-                        contentStyle={rechartsTooltipStyle}
-                        formatter={(value: number | undefined) => [`$${(value ?? 0).toLocaleString()}`, 'Portfolio Value']}
-                        labelFormatter={(label) => new Date(label).toLocaleDateString()}
-                      />
-                      <Area
-                        type="monotone"
-                        dataKey="value"
-                        stroke="var(--color-accent)"
-                        fill="var(--color-accent)"
-                        fillOpacity={0.1}
-                        strokeWidth={2}
-                      />
-                      <ReferenceLine
-                        y={config.initialCapital}
-                        stroke="var(--color-text-muted)"
-                        strokeDasharray="3 3"
-                        label={{ value: 'Initial', position: 'left', fill: 'var(--color-text-muted)', fontSize: 11 }}
-                      />
-                    </ComposedChart>
-                  </ResponsiveContainer>
-                </div>
-              </div>
-            )}
-
-            {/* Episode Returns + Factor Attribution */}
-            <div
-              className="grid grid-cols-12 gap-6 animate-fade-in-up"
-              style={{ animationDelay: '200ms' }}
+          {/* Equity Curve */}
+          {result.equityCurve.length > 0 && (
+            <section
+              className="glass-slab rounded-2xl p-6 sm:p-8 animate-fade-in-up"
+              style={{ animationDelay: '150ms', animationFillMode: 'both' }}
             >
-              {/* Episode Returns */}
-              <div className="col-span-12 lg:col-span-7">
-                <div className="bg-[var(--color-bg)] rounded-xl border border-[var(--color-border)] p-6">
-                  <h3 className="text-lg font-semibold text-[var(--color-text)] mb-4">
-                    Episode Returns
-                  </h3>
-                  <div className="h-64">
-                    <ResponsiveContainer width="100%" height="100%">
-                      <ComposedChart data={result.episodeReturns} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
-                        <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light, var(--color-border))" />
-                        <XAxis
-                          dataKey="episode"
-                          tick={{ fill: 'var(--color-text-muted, var(--color-text-muted))', fontSize: 11 }}
-                          label={{ value: 'Episode', position: 'bottom', offset: -5 }}
-                        />
-                        <YAxis
-                          tick={{ fill: 'var(--color-text-muted, var(--color-text-muted))', fontSize: 11 }}
-                          tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
-                        />
-                        <Tooltip
-                          formatter={(value: number | undefined, name?: string) => [
-                            name === 'return' ? `${((value ?? 0) * 100).toFixed(2)}%` : (value ?? 0).toFixed(2),
-                            name === 'return' ? 'OOS Return' : 'Sharpe',
-                          ]}
-                        />
-                        <ReferenceLine y={0} stroke="var(--color-text-muted)" strokeDasharray="2 2" />
-                        <Bar dataKey="return" fill="var(--color-accent)" opacity={0.6} radius={[4, 4, 0, 0]} />
-                        <Line type="monotone" dataKey="sharpe" stroke="var(--color-warning)" strokeWidth={2} dot={false} yAxisId="right" />
-                        <YAxis yAxisId="right" orientation="right" tick={{ fill: 'var(--color-warning)', fontSize: 11 }} />
-                      </ComposedChart>
-                    </ResponsiveContainer>
-                  </div>
+              <header className="flex items-start gap-4 mb-6">
+                <div
+                  className="p-2.5 rounded-lg shrink-0"
+                  style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
+                >
+                  <TrendingUp className="w-5 h-5" style={{ color: 'var(--color-accent)' }} aria-hidden="true" />
                 </div>
+                <div className="min-w-0">
+                  <p className={kickerClass}>Time Series</p>
+                  <h3 className="text-lg font-bold text-theme mt-1">Equity Curve</h3>
+                </div>
+              </header>
+              <div className="h-80 min-h-[320px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={result.equityCurve} margin={{ top: 5, right: 20, bottom: 5, left: 10 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light, var(--color-border))" />
+                    <XAxis
+                      dataKey="date"
+                      tick={{ fill: 'var(--color-text-muted, var(--color-text-muted))', fontSize: 11 }}
+                      tickFormatter={(d) => new Date(d).toLocaleDateString('en-US', { month: 'short', year: '2-digit' })}
+                    />
+                    <YAxis
+                      tick={{ fill: 'var(--color-text-muted, var(--color-text-muted))', fontSize: 11 }}
+                      tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`}
+                    />
+                    <Tooltip
+                      contentStyle={rechartsTooltipStyle}
+                      formatter={(value: number | undefined) => [`$${(value ?? 0).toLocaleString()}`, 'Portfolio Value']}
+                      labelFormatter={(label) => new Date(label).toLocaleDateString()}
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="value"
+                      stroke="var(--color-accent)"
+                      fill="var(--color-accent)"
+                      fillOpacity={0.1}
+                      strokeWidth={2}
+                    />
+                    <ReferenceLine
+                      y={config.initialCapital}
+                      stroke="var(--color-text-muted)"
+                      strokeDasharray="3 3"
+                      label={{ value: 'Initial', position: 'left', fill: 'var(--color-text-muted)', fontSize: 11 }}
+                    />
+                  </ComposedChart>
+                </ResponsiveContainer>
               </div>
+            </section>
+          )}
 
-              {/* Factor Attribution */}
-              <div className="col-span-12 lg:col-span-5">
-                <div className="bg-[var(--color-bg)] rounded-xl border border-[var(--color-border)] p-6">
-                  <h3 className="text-lg font-semibold text-[var(--color-text)] mb-4">
-                    Factor Attribution
-                  </h3>
-                  <div className="space-y-3">
-                    {result.factorExposures.map((factor) => (
+          {/* Episode Returns + Factor Attribution */}
+          <div
+            className="grid grid-cols-12 gap-6 animate-fade-in-up"
+            style={{ animationDelay: '200ms', animationFillMode: 'both' }}
+          >
+            {/* Episode Returns */}
+            <section className="col-span-12 lg:col-span-7 glass-slab rounded-2xl p-6 sm:p-8">
+              <header className="mb-5">
+                <p className={kickerClass}>Out-Of-Sample</p>
+                <h3 className="text-lg font-bold text-theme">Episode Returns</h3>
+              </header>
+              <div className="h-64 min-h-[256px]">
+                <ResponsiveContainer width="100%" height="100%">
+                  <ComposedChart data={result.episodeReturns} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="var(--color-border-light, var(--color-border))" />
+                    <XAxis
+                      dataKey="episode"
+                      tick={{ fill: 'var(--color-text-muted, var(--color-text-muted))', fontSize: 11 }}
+                      label={{ value: 'Episode', position: 'bottom', offset: -5 }}
+                    />
+                    <YAxis
+                      tick={{ fill: 'var(--color-text-muted, var(--color-text-muted))', fontSize: 11 }}
+                      tickFormatter={(v) => `${(v * 100).toFixed(0)}%`}
+                    />
+                    <Tooltip
+                      formatter={(value: number | undefined, name?: string) => [
+                        name === 'return' ? `${((value ?? 0) * 100).toFixed(2)}%` : (value ?? 0).toFixed(2),
+                        name === 'return' ? 'OOS Return' : 'Sharpe',
+                      ]}
+                    />
+                    <ReferenceLine y={0} stroke="var(--color-text-muted)" strokeDasharray="2 2" />
+                    <Bar dataKey="return" fill="var(--color-accent)" opacity={0.6} radius={[4, 4, 0, 0]} />
+                    <Line type="monotone" dataKey="sharpe" stroke="var(--color-warning)" strokeWidth={2} dot={false} yAxisId="right" />
+                    <YAxis yAxisId="right" orientation="right" tick={{ fill: 'var(--color-warning)', fontSize: 11 }} />
+                  </ComposedChart>
+                </ResponsiveContainer>
+              </div>
+            </section>
+
+            {/* Factor Attribution */}
+            <section className="col-span-12 lg:col-span-5 glass-slab rounded-2xl p-6 sm:p-8">
+              <header className="mb-5">
+                <p className={kickerClass}>Decomposition</p>
+                <h3 className="text-lg font-bold text-theme">Factor Attribution</h3>
+              </header>
+              <div className="space-y-3">
+                {result.factorExposures.map((factor) => (
+                  <div
+                    key={factor.factor}
+                    className="flex items-center justify-between hover:bg-theme-secondary rounded-lg px-2 -mx-2 transition-colors duration-150"
+                  >
+                    <div className="flex items-center gap-2">
                       <div
-                        key={factor.factor}
-                        className="flex items-center justify-between hover:bg-[var(--color-bg-secondary)] rounded-lg px-2 -mx-2 transition-colors duration-150"
-                      >
-                        <div className="flex items-center gap-2">
-                          <div
-                            className="w-2 h-8 rounded-full"
-                            style={{
-                              backgroundColor: factor.contribution >= 0
-                                ? 'var(--color-positive)'
-                                : 'var(--color-negative)',
-                            }}
-                          />
-                          <div>
-                            <div className="text-sm font-medium text-[var(--color-text)] capitalize">
-                              {factor.factor.replace(/_/g, ' ')}
-                            </div>
-                            <div className="text-xs text-[var(--color-text-muted)]">
-                              Avg exposure: {(factor.avgExposure * 100).toFixed(1)}%
-                            </div>
-                          </div>
+                        className="w-2 h-8 rounded-full"
+                        style={{
+                          backgroundColor: factor.contribution >= 0
+                            ? 'var(--color-positive)'
+                            : 'var(--color-negative)',
+                        }}
+                        aria-hidden="true"
+                      />
+                      <div>
+                        <div className="text-sm font-medium text-theme capitalize">
+                          {factor.factor.replace(/_/g, ' ')}
                         </div>
-                        <div
-                          className={`font-mono text-sm font-bold ${
-                            factor.contribution >= 0
-                              ? 'text-[var(--color-positive)]'
-                              : 'text-[var(--color-negative)]'
-                          }`}
-                        >
-                          {factor.contribution >= 0 ? '+' : ''}
-                          {(factor.contribution * 100).toFixed(2)}%
+                        <div className="text-xs text-theme-muted tabular-nums">
+                          Avg exposure: {(factor.avgExposure * 100).toFixed(1)}%
                         </div>
                       </div>
-                    ))}
+                    </div>
+                    <div
+                      className={`mono text-sm font-bold tabular-nums ${
+                        factor.contribution >= 0
+                          ? 'text-[var(--color-positive)]'
+                          : 'text-[var(--color-negative)]'
+                      }`}
+                    >
+                      {factor.contribution >= 0 ? '+' : ''}
+                      {(factor.contribution * 100).toFixed(2)}%
+                    </div>
                   </div>
-                </div>
+                ))}
               </div>
-            </div>
-
-            {/* Overfit Analysis */}
-            <div
-              className="bg-[var(--color-bg)] rounded-xl border border-[var(--color-border)] p-6 animate-fade-in-up"
-              style={{ animationDelay: '250ms' }}
-            >
-              <h3 className="text-lg font-semibold text-[var(--color-text)] mb-3">Overfit Analysis</h3>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <div className="p-3 bg-[var(--color-bg-tertiary)] rounded-lg text-center">
-                  <div className="text-xs text-[var(--color-text-muted)]">Overfit Ratio</div>
-                  <div
-                    className={`text-xl font-bold ${
-                      result.walkForward.overfitRatio < 1.5
-                        ? 'text-[var(--color-positive)]'
-                        : 'text-[var(--color-negative)]'
-                    }`}
-                  >
-                    {result.walkForward.overfitRatio.toFixed(2)}x
-                  </div>
-                  <div className="text-xs text-[var(--color-text-muted)]">
-                    {result.walkForward.overfitRatio < 1.5 ? 'Healthy' : 'High overfit risk'}
-                  </div>
-                </div>
-                <div className="p-3 bg-[var(--color-bg-tertiary)] rounded-lg text-center">
-                  <div className="text-xs text-[var(--color-text-muted)]">Benchmark Return</div>
-                  <div className="text-xl font-bold text-[var(--color-text)]">
-                    {(result.benchmark.totalReturn * 100).toFixed(2)}%
-                  </div>
-                </div>
-                <div className="p-3 bg-[var(--color-bg-tertiary)] rounded-lg text-center">
-                  <div className="text-xs text-[var(--color-text-muted)]">Strategy Alpha</div>
-                  <div
-                    className={`text-xl font-bold ${result.alpha >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}
-                  >
-                    {result.alpha >= 0 ? '+' : ''}
-                    {(result.alpha * 100).toFixed(2)}%
-                  </div>
-                </div>
-              </div>
-            </div>
-          </>
-        )}
-
-        {/* Empty State */}
-        {!result && !isPending && !error && (
-          <div
-            className="text-center py-16 animate-fade-in-up"
-            style={{ animationDelay: '100ms' }}
-          >
-            <BarChart3 className="w-16 h-16 text-[var(--color-text-muted)] mx-auto mb-4" />
-            <h3 className="text-lg font-semibold text-[var(--color-text)] mb-2">
-              Configure and run a backtest
-            </h3>
-            <p className="text-sm text-[var(--color-text-muted)] max-w-md mx-auto">
-              Walk-forward backtesting validates your CVRF strategy against historical data.
-              Select symbols, date range, and strategy to get started.
-            </p>
+            </section>
           </div>
-        )}
-      </div>
+
+          {/* Overfit Analysis */}
+          <section
+            className="glass-slab rounded-2xl p-6 sm:p-8 animate-fade-in-up"
+            style={{ animationDelay: '250ms', animationFillMode: 'both' }}
+          >
+            <header className="mb-5">
+              <p className={kickerClass}>Robustness</p>
+              <h3 className="text-lg font-bold text-theme">Overfit Analysis</h3>
+            </header>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+              <div className="p-4 rounded-lg bg-theme-tertiary border border-theme-light text-center">
+                <div className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Overfit Ratio</div>
+                <div
+                  className={`text-2xl font-bold tabular-nums mt-1 ${
+                    result.walkForward.overfitRatio < 1.5
+                      ? 'text-[var(--color-positive)]'
+                      : 'text-[var(--color-negative)]'
+                  }`}
+                >
+                  {result.walkForward.overfitRatio.toFixed(2)}x
+                </div>
+                <div className="text-xs text-theme-muted mt-1">
+                  {result.walkForward.overfitRatio < 1.5 ? 'Healthy' : 'High overfit risk'}
+                </div>
+              </div>
+              <div className="p-4 rounded-lg bg-theme-tertiary border border-theme-light text-center">
+                <div className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Benchmark Return</div>
+                <div className="text-2xl font-bold text-theme tabular-nums mt-1">
+                  {(result.benchmark.totalReturn * 100).toFixed(2)}%
+                </div>
+              </div>
+              <div className="p-4 rounded-lg bg-theme-tertiary border border-theme-light text-center">
+                <div className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Strategy Alpha</div>
+                <div
+                  className={`text-2xl font-bold tabular-nums mt-1 ${
+                    result.alpha >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'
+                  }`}
+                >
+                  {result.alpha >= 0 ? '+' : ''}
+                  {(result.alpha * 100).toFixed(2)}%
+                </div>
+              </div>
+            </div>
+          </section>
+        </>
+      )}
+
+      {/* ── Empty State ─────────────────────────────────────────────────── */}
+      {!result && !isPending && !error && (
+        <div
+          className="glass-slab rounded-2xl p-10 sm:p-16 text-center animate-fade-in-up"
+          style={{ animationDelay: '100ms', animationFillMode: 'both' }}
+        >
+          <div
+            className="w-16 h-16 mx-auto mb-5 rounded-2xl flex items-center justify-center"
+            style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
+          >
+            <BarChart3 className="w-8 h-8" style={{ color: 'var(--color-accent)' }} aria-hidden="true" />
+          </div>
+          <p className={`${kickerClass} mb-2`}>Ready</p>
+          <h3 className="text-xl font-bold text-theme mb-3">Configure and run a backtest</h3>
+          <p className="text-sm text-theme-secondary max-w-md mx-auto leading-relaxed">
+            Walk-forward backtesting validates your CVRF strategy against historical data.
+            Select symbols, date range, and strategy to get started.
+          </p>
+        </div>
+      )}
     </div>
   );
 }

--- a/client/src/pages/CVRF.tsx
+++ b/client/src/pages/CVRF.tsx
@@ -1,13 +1,63 @@
 /**
  * CVRF Page
  *
- * Conceptual Verbal Reinforcement Framework Dashboard
+ * Conceptual Verbal Reinforcement Framework Dashboard.
+ *
+ * Standalone shell (no Layout wrapper — see App.tsx). Provides the
+ * sovereign page chrome (grid background, sovereign bar, hero header)
+ * around the existing CVRFDashboard. Visualization internals live
+ * inside `client/src/components/cvrf/` and are intentionally untouched.
  */
 
 import { CVRFDashboard } from '@/components/cvrf';
 
 export function CVRF() {
-  return <CVRFDashboard />;
+  return (
+    <div className="min-h-screen bg-theme grid-bg">
+      {/* Sovereign rail — fixed page-top accent for standalone routes */}
+      <div className="sovereign-bar fixed top-0 left-0 right-0 z-50" aria-hidden="true" />
+
+      {/* ── Hero ─────────────────────────────────────────────────────────── */}
+      <section className="relative isolate overflow-hidden">
+        <div
+          className="absolute inset-0 gradient-brand-subtle pointer-events-none"
+          aria-hidden="true"
+        />
+
+        <div className="relative z-10 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pt-16 pb-8 sm:pt-20 sm:pb-10">
+          <div
+            className="max-w-3xl animate-enter"
+            style={{ animationFillMode: 'both' }}
+          >
+            <p className="mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted mb-2">
+              CVRF · <span className="text-[color:var(--color-accent-secondary)]">Cognitive Variance Reduction Framework</span>
+            </p>
+
+            <h1 className="text-3xl sm:text-4xl lg:text-5xl font-black leading-[1.05] tracking-tight">
+              <span className="text-gradient-brand holo-pulse">Episodic Belief</span>{' '}
+              <span className="text-theme">Learning</span>
+            </h1>
+
+            <p className="mt-5 text-base sm:text-lg text-theme-secondary leading-relaxed max-w-2xl">
+              Each episode updates the system's beliefs about which factors carry signal.
+              Confidence rises with corroboration, decays with surprise — explainable and persistent.
+            </p>
+
+            <p className="mt-4 mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">
+              Episodes · Belief Updates · Confidence Decay
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Dashboard slab ──────────────────────────────────────────────── */}
+      <section className="px-4 sm:px-6 lg:px-8 pb-16 sm:pb-20">
+        <div className="max-w-7xl mx-auto">
+          <CVRFDashboard />
+        </div>
+      </section>
+    </div>
+  );
 }
 
 export default CVRF;

--- a/client/src/pages/Earnings.tsx
+++ b/client/src/pages/Earnings.tsx
@@ -80,78 +80,105 @@ export function Earnings() {
   const content = (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 animate-fade-in-up" style={{ animationFillMode: 'both' }}>
+      <div
+        className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 animate-fade-in-up"
+        style={{ animationFillMode: 'both' }}
+      >
         <div>
-          <h1 className="text-2xl lg:text-3xl font-bold text-[var(--color-text)]">Earnings Calendar</h1>
-          <p className="text-[var(--color-text-muted)] mt-1">
+          <p className="mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted mb-2">
+            Execution · Earnings
+          </p>
+          <h1 className="text-2xl lg:text-3xl font-bold text-theme">
+            <span className="text-gradient-brand">Earnings Calendar</span>
+          </h1>
+          <p className="text-sm text-theme-secondary mt-1">
             Track upcoming earnings and their expected impact on your portfolio
           </p>
         </div>
-        <select
-          value={daysAhead}
-          onChange={(e) => setDaysAhead(Number(e.target.value))}
-          className="px-4 py-2.5 min-h-[44px] border rounded-lg bg-[var(--color-bg)] text-[var(--color-text-secondary)] text-base"
-        >
-          <option value={7}>Next 7 days</option>
-          <option value={14}>Next 14 days</option>
-          <option value={30}>Next 30 days</option>
-          <option value={60}>Next 60 days</option>
-          <option value={90}>Next 90 days</option>
-        </select>
+        <div>
+          <label htmlFor="earnings-days-ahead" className="sr-only">Days ahead</label>
+          <select
+            id="earnings-days-ahead"
+            value={daysAhead}
+            onChange={(e) => setDaysAhead(Number(e.target.value))}
+            className="block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm"
+          >
+            <option value={7}>Next 7 days</option>
+            <option value={14}>Next 14 days</option>
+            <option value={30}>Next 30 days</option>
+            <option value={60}>Next 60 days</option>
+            <option value={90}>Next 90 days</option>
+          </select>
+        </div>
       </div>
 
       {/* Stats Bar */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-fade-in-up" style={{ animationDelay: '50ms', animationFillMode: 'both' }}>
-        <div className="flex items-center gap-3 p-4 rounded-xl bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)]">
-          <div className="p-2.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 8%, transparent)' }}>
-            <Calendar className="w-5 h-5" style={{ color: 'var(--color-accent)' }} />
+      <div
+        className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-stagger animate-fade-in-up"
+        style={{ animationDelay: '50ms', animationFillMode: 'both' }}
+      >
+        <div className="glass-slab rounded-xl p-4 sm:p-6 flex items-center gap-3 animate-enter">
+          <div
+            className="p-2.5 rounded-lg flex-shrink-0"
+            style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
+          >
+            <Calendar className="w-5 h-5 text-[var(--color-accent)]" />
           </div>
           <div className="min-w-0">
-            <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">Total Upcoming</p>
-            <p className="text-xl font-bold text-[var(--color-text)] mt-0.5">{earnings.length}</p>
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Total Upcoming</p>
+            <p className="mono tabular-nums text-xl font-bold text-theme mt-1">{earnings.length}</p>
           </div>
         </div>
         <div
-          className="flex items-center gap-3 p-4 rounded-xl border"
-          style={{
-            backgroundColor: earningsToday > 0 ? 'color-mix(in srgb, var(--color-negative) 8%, transparent)' : 'var(--color-bg-tertiary)',
-            borderColor: earningsToday > 0 ? 'color-mix(in srgb, var(--color-negative) 20%, transparent)' : 'var(--color-border-light)',
-          }}
+          className={`glass-slab rounded-xl p-4 sm:p-6 flex items-center gap-3 animate-enter relative overflow-hidden ${
+            earningsToday > 0
+              ? "before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-negative)]"
+              : ''
+          }`}
         >
-          <div className="p-2.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'color-mix(in srgb, var(--color-negative) 10%, transparent)' }}>
-            <AlertCircle className="w-5 h-5" style={{ color: 'var(--color-negative)' }} />
+          <div
+            className="p-2.5 rounded-lg flex-shrink-0"
+            style={{ backgroundColor: 'color-mix(in srgb, var(--color-negative) 10%, transparent)' }}
+          >
+            <AlertCircle className="w-5 h-5 text-[var(--color-negative)]" />
           </div>
           <div className="min-w-0">
-            <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">Reporting Today</p>
-            <p className={`text-xl font-bold mt-0.5 ${earningsToday > 0 ? 'text-[var(--color-negative)]' : 'text-[var(--color-text)]'}`}>
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Reporting Today</p>
+            <p className={`mono tabular-nums text-xl font-bold mt-1 ${earningsToday > 0 ? 'text-[var(--color-negative)]' : 'text-theme'}`}>
               {earningsToday}
             </p>
           </div>
         </div>
         <div
-          className="flex items-center gap-3 p-4 rounded-xl border"
-          style={{
-            backgroundColor: earningsThisWeek > 0 ? 'color-mix(in srgb, var(--color-warning) 8%, transparent)' : 'var(--color-bg-tertiary)',
-            borderColor: earningsThisWeek > 0 ? 'color-mix(in srgb, var(--color-warning) 20%, transparent)' : 'var(--color-border-light)',
-          }}
+          className={`glass-slab rounded-xl p-4 sm:p-6 flex items-center gap-3 animate-enter relative overflow-hidden ${
+            earningsThisWeek > 0
+              ? "before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-warning)]"
+              : ''
+          }`}
         >
-          <div className="p-2.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}>
-            <Calendar className="w-5 h-5" style={{ color: 'var(--color-warning)' }} />
+          <div
+            className="p-2.5 rounded-lg flex-shrink-0"
+            style={{ backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
+          >
+            <Calendar className="w-5 h-5 text-[var(--color-warning)]" />
           </div>
           <div className="min-w-0">
-            <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">This Week</p>
-            <p className={`text-xl font-bold mt-0.5 ${earningsThisWeek > 0 ? 'text-[var(--color-warning)]' : 'text-[var(--color-text)]'}`}>
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">This Week</p>
+            <p className={`mono tabular-nums text-xl font-bold mt-1 ${earningsThisWeek > 0 ? 'text-[var(--color-warning)]' : 'text-theme'}`}>
               {earningsThisWeek}
             </p>
           </div>
         </div>
-        <div className="flex items-center gap-3 p-4 rounded-xl bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)]">
-          <div className="p-2.5 rounded-lg flex-shrink-0" style={{ backgroundColor: 'color-mix(in srgb, var(--color-info) 10%, transparent)' }}>
-            <Calendar className="w-5 h-5" style={{ color: 'var(--color-info)' }} />
+        <div className="glass-slab rounded-xl p-4 sm:p-6 flex items-center gap-3 animate-enter">
+          <div
+            className="p-2.5 rounded-lg flex-shrink-0"
+            style={{ backgroundColor: 'color-mix(in srgb, var(--color-info) 10%, transparent)' }}
+          >
+            <Calendar className="w-5 h-5 text-[var(--color-info)]" />
           </div>
           <div className="min-w-0">
-            <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">Positions Tracked</p>
-            <p className="text-xl font-bold text-[var(--color-text)] mt-0.5">{symbols.length}</p>
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Positions Tracked</p>
+            <p className="mono tabular-nums text-xl font-bold text-theme mt-1">{symbols.length}</p>
           </div>
         </div>
       </div>
@@ -159,15 +186,15 @@ export function Earnings() {
       {/* Alert for imminent earnings */}
       {earningsToday > 0 && (
         <div
-          className="flex items-center gap-3 p-4 rounded-lg border animate-fade-in-up"
-          style={{ backgroundColor: 'color-mix(in srgb, var(--color-negative) 10%, transparent)', borderColor: 'color-mix(in srgb, var(--color-negative) 20%, transparent)', animationDelay: '100ms' }}
+          className="glass-slab-floating relative overflow-hidden rounded-xl pl-5 pr-4 py-4 flex items-start gap-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-negative)] shadow-[0_18px_60px_-20px_rgba(239,68,68,0.45)] animate-fade-in-up"
+          style={{ animationDelay: '100ms', animationFillMode: 'both' }}
         >
-          <AlertCircle className="w-5 h-5 text-[var(--color-negative)] flex-shrink-0" />
+          <AlertCircle className="w-5 h-5 text-[var(--color-negative)] flex-shrink-0 mt-0.5" />
           <div>
-            <p className="font-medium text-[var(--color-negative)]">
+            <p className="mono text-[10px] tracking-[0.3em] uppercase font-semibold text-[var(--color-negative)]">
               {earningsToday} position{earningsToday > 1 ? 's' : ''} reporting today
             </p>
-            <p className="text-sm text-[var(--color-negative)]">
+            <p className="text-sm mt-1 text-theme-secondary">
               Review forecasts and consider adjusting positions before market close
             </p>
           </div>
@@ -176,10 +203,10 @@ export function Earnings() {
 
       {/* Empty State */}
       {!isLoading && symbols.length === 0 && (
-        <div className="bg-[var(--color-bg)] p-12 rounded-lg border text-center">
-          <Calendar className="w-12 h-12 mx-auto mb-4 text-[var(--color-text-muted)]" />
-          <h3 className="text-lg font-medium text-[var(--color-text)] mb-2">No positions to track</h3>
-          <p className="text-[var(--color-text-muted)]">
+        <div className="glass-slab rounded-2xl p-12 text-center">
+          <Calendar className="w-12 h-12 mx-auto mb-4 text-theme-muted" />
+          <h3 className="text-lg font-bold text-theme mb-2">No positions to track</h3>
+          <p className="text-sm text-theme-secondary">
             Add positions to your portfolio to see their upcoming earnings
           </p>
         </div>
@@ -187,7 +214,7 @@ export function Earnings() {
 
       {/* Heatmap */}
       {symbols.length > 0 && earnings.length > 0 && (
-        <div className="animate-fade-in-up" style={{ animationDelay: '150ms' }}>
+        <div className="animate-fade-in-up" style={{ animationDelay: '150ms', animationFillMode: 'both' }}>
           <EarningsHeatmap
             earnings={earnings}
             onSelect={setSelectedSymbol}
@@ -198,7 +225,10 @@ export function Earnings() {
 
       {/* Main Content - Calendar + Forecast */}
       {symbols.length > 0 && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 animate-fade-in-up" style={{ animationDelay: '200ms' }}>
+        <div
+          className="grid grid-cols-1 lg:grid-cols-2 gap-6 animate-fade-in-up"
+          style={{ animationDelay: '200ms', animationFillMode: 'both' }}
+        >
           <EarningsCalendar
             earnings={earnings}
             isLoading={isLoading}
@@ -217,7 +247,7 @@ export function Earnings() {
 
       {/* CVRF Belief Impact */}
       {symbols.length > 0 && (
-        <div className="animate-fade-in-up" style={{ animationDelay: '250ms' }}>
+        <div className="animate-fade-in-up" style={{ animationDelay: '250ms', animationFillMode: 'both' }}>
           <BeliefImpactPanel
             earnings={earnings}
             selectedSymbol={selectedSymbol}
@@ -227,11 +257,8 @@ export function Earnings() {
 
       {/* No upcoming earnings message */}
       {!isLoading && symbols.length > 0 && earnings.length === 0 && (
-        <div
-          className="p-4 rounded-lg border"
-          style={{ backgroundColor: 'color-mix(in srgb, var(--color-info) 10%, transparent)', borderColor: 'color-mix(in srgb, var(--color-info) 20%, transparent)' }}
-        >
-          <p className="text-[var(--color-info)]">
+        <div className="glass-slab-floating relative overflow-hidden rounded-xl pl-5 pr-4 py-4 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[image:var(--gradient-sovereign)]">
+          <p className="text-sm text-theme-secondary">
             None of your {symbols.length} positions have earnings scheduled in the next {daysAhead} days.
           </p>
         </div>

--- a/client/src/pages/Help.tsx
+++ b/client/src/pages/Help.tsx
@@ -17,8 +17,8 @@ import {
   Mail,
   ExternalLink,
   HelpCircle,
+  Keyboard,
 } from 'lucide-react';
-import { Card } from '@/components/shared/Card';
 import {
   helpSections,
   faqs,
@@ -38,6 +38,9 @@ const sectionIcons: Record<string, typeof Rocket> = {
   'earnings-oracle': Calendar,
   'alerts': Bell,
 };
+
+const kickerClass =
+  'text-[10px] mono tracking-[0.3em] uppercase text-theme-muted';
 
 export function Help() {
   const location = useLocation();
@@ -109,6 +112,11 @@ export function Help() {
     navigate('/help', { replace: true });
   };
 
+  const openShortcutsModal = () => {
+    // Trigger '?' keyboard shortcut to open the modal handled at Layout level
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', shiftKey: true }));
+  };
+
   // Group FAQs by category
   const faqsByCategory = faqs.reduce((acc, faq) => {
     if (!acc[faq.category]) {
@@ -120,77 +128,85 @@ export function Help() {
 
   const markdownComponents = {
     h2: ({ children }: { children?: React.ReactNode }) => (
-      <h2 className="text-2xl font-bold text-[var(--color-text)] mt-8 mb-4 first:mt-0">{children}</h2>
+      <h2 className="text-2xl font-bold text-theme mt-8 mb-4 first:mt-0">{children}</h2>
     ),
     h3: ({ children }: { children?: React.ReactNode }) => (
-      <h3 className="text-xl font-semibold text-[var(--color-text)] mt-6 mb-3">{children}</h3>
+      <h3 className="text-xl font-semibold text-theme mt-6 mb-3">{children}</h3>
     ),
     p: ({ children }: { children?: React.ReactNode }) => (
-      <p className="text-[var(--color-text-secondary)] mb-4 leading-relaxed">{children}</p>
+      <p className="text-theme-secondary mb-4 leading-relaxed">{children}</p>
     ),
     strong: ({ children }: { children?: React.ReactNode }) => (
-      <strong className="font-semibold text-[var(--color-text)]">{children}</strong>
+      <strong className="font-semibold text-theme">{children}</strong>
     ),
     ul: ({ children }: { children?: React.ReactNode }) => (
-      <ul className="list-disc list-inside space-y-1 mb-4 text-[var(--color-text-secondary)] ml-4">{children}</ul>
+      <ul className="list-disc list-inside space-y-1 mb-4 text-theme-secondary ml-4">{children}</ul>
     ),
     li: ({ children }: { children?: React.ReactNode }) => <li>{children}</li>,
-    hr: () => <hr className="my-8 border-[var(--color-border)]" />,
+    hr: () => <hr className="my-8 border-theme" />,
   };
 
   return (
     <div className="max-w-5xl mx-auto">
-      {/* Header */}
-      <div className="mb-8 animate-fade-in-up" style={{ animationDelay: '0ms', animationFillMode: 'both' }}>
-        <div className="flex items-center gap-3 mb-2">
-          <BookOpen className="w-8 h-8 text-[var(--color-info)]" />
-          <h1 className="text-3xl font-bold text-[var(--color-text)]">Help Center</h1>
-        </div>
-        <p className="text-[var(--color-text-muted)]">
-          Learn how to use Frontier Alpha to analyze your portfolio and make better investment decisions
+      {/* Page header — family pattern */}
+      <header
+        className="mb-8 animate-fade-in-up"
+        style={{ animationDelay: '0ms', animationFillMode: 'both' }}
+      >
+        <p className={kickerClass}>HELP · Documentation</p>
+        <h1 className="text-3xl lg:text-4xl font-bold text-gradient-brand mt-2">
+          Help Center
+        </h1>
+        <p className="text-theme-secondary mt-2 leading-relaxed max-w-2xl">
+          Learn how to use Frontier Alpha to analyze your portfolio and make better investment decisions.
         </p>
-      </div>
+      </header>
 
       {/* Search */}
-      <div className="mb-8 animate-fade-in-up" style={{ animationDelay: '50ms', animationFillMode: 'both' }}>
+      <div
+        className="mb-8 animate-fade-in-up"
+        style={{ animationDelay: '50ms', animationFillMode: 'both' }}
+      >
         <div className="relative max-w-xl">
-          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--color-text-muted)]" />
+          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-theme-muted" aria-hidden="true" />
           <input
             type="text"
             placeholder="Search help topics, metrics, or features..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-12 pr-4 py-3 text-lg border border-[var(--color-border)] rounded-xl focus:ring-2 focus:ring-[var(--color-info)] focus:border-[var(--color-info)] shadow-sm"
+            className="block w-full pl-12 pr-4 py-3 bg-[var(--color-bg-tertiary)] border border-theme rounded-xl text-theme placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] mono text-sm transition-[border-color,box-shadow] duration-200"
+            aria-label="Search help topics"
           />
         </div>
       </div>
 
       {/* Search Results */}
       {searchQuery && (
-        <div className="mb-8">
+        <div className="mb-8 animate-fade-in">
           {hasSearchResults ? (
-            <Card className="p-6">
-              <h2 className="text-lg font-semibold text-[var(--color-text)] mb-4">
-                Search Results for "{searchQuery}"
+            <div className="glass-slab rounded-2xl p-6">
+              <p className={kickerClass}>SEARCH</p>
+              <h2 className="text-lg font-bold text-theme mt-1 mb-5">
+                Results for "{searchQuery}"
               </h2>
 
               {searchResults.topics.length > 0 && (
                 <div className="mb-6">
-                  <h3 className="text-sm font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">
+                  <h3 className={`${kickerClass} mb-3`}>
                     Topics ({searchResults.topics.length})
                   </h3>
-                  <div className="space-y-2">
+                  <div className="space-y-2 animate-stagger">
                     {searchResults.topics.map((topic) => (
                       <button
                         key={topic.id}
                         onClick={() => selectTopic(topic)}
-                        className="w-full flex items-center gap-3 p-4 bg-[var(--color-bg-tertiary)] rounded-lg hover:bg-[color-mix(in_srgb,var(--color-info)_10%,transparent)] hover:border-[color-mix(in_srgb,var(--color-info)_20%,transparent)] border border-transparent transition text-left"
+                        className="glass-slab w-full flex items-center gap-3 p-4 rounded-2xl hover:border-[color:var(--color-border-hover)] text-left animate-enter animate-press animate-lift"
                       >
-                        <div className="flex-1">
-                          <p className="font-medium text-[var(--color-text)]">{topic.title}</p>
-                          <p className="text-sm text-[var(--color-text-muted)]">{topic.summary}</p>
+                        <div className="flex-1 min-w-0">
+                          <p className="font-semibold text-theme">{topic.title}</p>
+                          <p className="text-sm text-theme-secondary leading-relaxed">{topic.summary}</p>
                         </div>
-                        <ChevronRight className="w-5 h-5 text-[var(--color-text-muted)]" />
+                        <ChevronRight className="w-5 h-5 text-theme-muted flex-shrink-0" />
                       </button>
                     ))}
                   </div>
@@ -199,46 +215,47 @@ export function Help() {
 
               {searchResults.faqs.length > 0 && (
                 <div>
-                  <h3 className="text-sm font-medium text-[var(--color-text-muted)] uppercase tracking-wider mb-3">
+                  <h3 className={`${kickerClass} mb-3`}>
                     FAQ ({searchResults.faqs.length})
                   </h3>
-                  <div className="space-y-3">
+                  <div className="space-y-3 animate-stagger">
                     {searchResults.faqs.map((faq, index) => (
-                      <div key={index} className="p-4 bg-[var(--color-bg-tertiary)] rounded-lg">
-                        <p className="font-medium text-[var(--color-text)] mb-2">{faq.question}</p>
-                        <p className="text-[var(--color-text-secondary)]">{faq.answer}</p>
+                      <div key={index} className="glass-slab rounded-2xl p-4 animate-enter">
+                        <p className="font-semibold text-theme mb-2">{faq.question}</p>
+                        <p className="text-theme-secondary leading-relaxed">{faq.answer}</p>
                       </div>
                     ))}
                   </div>
                 </div>
               )}
-            </Card>
+            </div>
           ) : (
-            <Card className="p-8 text-center">
-              <HelpCircle className="w-12 h-12 text-[var(--color-text-muted)] mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-[var(--color-text)] mb-2">No results found</h3>
-              <p className="text-[var(--color-text-muted)]">
+            <div className="glass-slab rounded-2xl p-8 text-center">
+              <HelpCircle className="w-12 h-12 text-theme-muted mx-auto mb-4" aria-hidden="true" />
+              <h3 className="text-lg font-semibold text-theme mb-2">No results found</h3>
+              <p className="text-theme-secondary leading-relaxed">
                 We could not find anything matching "{searchQuery}". Try different keywords or browse the topics below.
               </p>
-            </Card>
+            </div>
           )}
         </div>
       )}
 
       {/* Topic Detail View */}
       {selectedTopic && !searchQuery && (
-        <div className="mb-8">
+        <div className="mb-8 animate-fade-in">
           <button
             onClick={clearTopic}
-            className="flex items-center gap-2 text-[var(--color-info)] hover:text-[var(--color-info)] mb-4"
+            className="flex items-center gap-2 text-[var(--color-accent)] hover:brightness-125 mb-4 animate-press"
           >
             <ChevronRight className="w-4 h-4 rotate-180" />
             Back to all topics
           </button>
 
-          <Card className="p-8">
-            <h1 className="text-2xl font-bold text-[var(--color-text)] mb-2">{selectedTopic.title}</h1>
-            <p className="text-[var(--color-text-muted)] mb-6">{selectedTopic.summary}</p>
+          <div className="glass-slab rounded-2xl p-8">
+            <p className={kickerClass}>TOPIC</p>
+            <h1 className="text-2xl font-bold text-theme mt-1 mb-2">{selectedTopic.title}</h1>
+            <p className="text-theme-secondary leading-relaxed mb-6">{selectedTopic.summary}</p>
 
             <div className="prose prose-gray max-w-none">
               <ReactMarkdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
@@ -248,9 +265,9 @@ export function Help() {
 
             {/* Related Topics */}
             {selectedTopic.relatedTopics && selectedTopic.relatedTopics.length > 0 && (
-              <div className="mt-8 pt-6 border-t">
-                <h3 className="text-lg font-semibold text-[var(--color-text)] mb-4">Related Topics</h3>
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              <div className="mt-8 pt-6 border-t border-theme">
+                <h3 className={`${kickerClass} mb-4`}>Related Topics</h3>
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3 animate-stagger">
                   {selectedTopic.relatedTopics.map((topicId) => {
                     const result = getTopicById(topicId);
                     if (!result) return null;
@@ -259,20 +276,20 @@ export function Help() {
                       <button
                         key={topicId}
                         onClick={() => selectTopic(result.topic)}
-                        className="flex items-center gap-3 p-4 bg-[var(--color-bg-tertiary)] rounded-lg hover:bg-[color-mix(in_srgb,var(--color-info)_10%,transparent)] transition text-left"
+                        className="glass-slab flex items-center gap-3 p-4 rounded-2xl hover:border-[color:var(--color-border-hover)] text-left animate-enter animate-press animate-lift"
                       >
-                        <div className="flex-1">
-                          <p className="font-medium text-[var(--color-text)]">{result.topic.title}</p>
-                          <p className="text-sm text-[var(--color-text-muted)]">{result.topic.summary}</p>
+                        <div className="flex-1 min-w-0">
+                          <p className="font-semibold text-theme">{result.topic.title}</p>
+                          <p className="text-sm text-theme-secondary leading-relaxed">{result.topic.summary}</p>
                         </div>
-                        <ChevronRight className="w-4 h-4 text-[var(--color-text-muted)]" />
+                        <ChevronRight className="w-4 h-4 text-theme-muted flex-shrink-0" />
                       </button>
                     );
                   })}
                 </div>
               </div>
             )}
-          </Card>
+          </div>
         </div>
       )}
 
@@ -280,7 +297,10 @@ export function Help() {
       {!searchQuery && !selectedTopic && (
         <>
           {/* Quick Start Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-8 animate-fade-in-up" style={{ animationDelay: '100ms', animationFillMode: 'both' }}>
+          <div
+            className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-10 animate-stagger"
+            style={{ animationDelay: '100ms', animationFillMode: 'both' }}
+          >
             <QuickStartCard
               icon={Rocket}
               title="Getting Started"
@@ -311,100 +331,119 @@ export function Help() {
           </div>
 
           {/* Help Sections */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-8 animate-fade-in-up" style={{ animationDelay: '150ms', animationFillMode: 'both' }}>
+          <div
+            className="grid grid-cols-1 lg:grid-cols-3 gap-8 animate-fade-in-up"
+            style={{ animationDelay: '150ms', animationFillMode: 'both' }}
+          >
             {/* Left Column - Topics */}
             <div className="lg:col-span-2 space-y-4" id="topics">
-              <h2 className="text-xl font-bold text-[var(--color-text)] mb-4">Help Topics</h2>
+              <div className="mb-2">
+                <p className={kickerClass}>BROWSE</p>
+                <h2 className="text-xl font-bold text-theme mt-1">Help Topics</h2>
+              </div>
 
-              {helpSections.map((section) => {
-                const Icon = sectionIcons[section.id] || BookOpen;
-                const isExpanded = expandedSections.has(section.id);
+              <div className="space-y-3 animate-stagger">
+                {helpSections.map((section) => {
+                  const Icon = sectionIcons[section.id] || BookOpen;
+                  const isExpanded = expandedSections.has(section.id);
 
-                return (
-                  <Card key={section.id} className="overflow-hidden">
-                    <button
-                      onClick={() => toggleSection(section.id)}
-                      className="w-full flex items-center gap-4 p-5 hover:bg-[var(--color-bg-tertiary)] transition text-left"
-                    >
-                      <div className="w-12 h-12 bg-[var(--color-bg-tertiary)] rounded-xl flex items-center justify-center flex-shrink-0">
-                        <Icon className="w-6 h-6 text-[var(--color-info)]" />
-                      </div>
-                      <div className="flex-1">
-                        <h3 className="font-semibold text-[var(--color-text)]">{section.title}</h3>
-                        <p className="text-sm text-[var(--color-text-muted)]">{section.description}</p>
-                      </div>
-                      {isExpanded ? (
-                        <ChevronDown className="w-5 h-5 text-[var(--color-text-muted)]" />
-                      ) : (
-                        <ChevronRight className="w-5 h-5 text-[var(--color-text-muted)]" />
+                  return (
+                    <div key={section.id} className="glass-slab rounded-2xl overflow-hidden animate-enter">
+                      <button
+                        onClick={() => toggleSection(section.id)}
+                        className="w-full flex items-center gap-4 p-5 hover:bg-[var(--color-bg-tertiary)] text-left animate-press"
+                        aria-expanded={isExpanded}
+                      >
+                        <div
+                          className="w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0"
+                          style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
+                        >
+                          <Icon className="w-6 h-6 text-[var(--color-accent)]" aria-hidden="true" />
+                        </div>
+                        <div className="flex-1 min-w-0">
+                          <h3 className="font-semibold text-theme">{section.title}</h3>
+                          <p className="text-sm text-theme-secondary leading-relaxed">{section.description}</p>
+                        </div>
+                        {isExpanded ? (
+                          <ChevronDown className="w-5 h-5 text-theme-muted" />
+                        ) : (
+                          <ChevronRight className="w-5 h-5 text-theme-muted" />
+                        )}
+                      </button>
+
+                      {isExpanded && (
+                        <div className="border-t border-theme bg-[var(--color-bg-tertiary)] divide-y divide-[var(--color-border-light)]">
+                          {section.topics.map((topic) => (
+                            <button
+                              key={topic.id}
+                              onClick={() => selectTopic(topic)}
+                              className="w-full flex items-center gap-3 p-4 pl-8 hover:bg-[var(--color-bg-secondary)] text-left animate-press"
+                            >
+                              <div className="flex-1 min-w-0">
+                                <p className="font-medium text-theme">{topic.title}</p>
+                                <p className="text-sm text-theme-secondary leading-relaxed">{topic.summary}</p>
+                              </div>
+                              <ChevronRight className="w-4 h-4 text-theme-muted flex-shrink-0" />
+                            </button>
+                          ))}
+                        </div>
                       )}
-                    </button>
-
-                    {isExpanded && (
-                      <div className="border-t bg-[var(--color-bg-tertiary)] divide-y divide-[var(--color-border-light)]">
-                        {section.topics.map((topic) => (
-                          <button
-                            key={topic.id}
-                            onClick={() => selectTopic(topic)}
-                            className="w-full flex items-center gap-3 p-4 pl-8 hover:bg-[var(--color-bg-secondary)] transition text-left"
-                          >
-                            <div className="flex-1">
-                              <p className="font-medium text-[var(--color-text)]">{topic.title}</p>
-                              <p className="text-sm text-[var(--color-text-muted)]">{topic.summary}</p>
-                            </div>
-                            <ChevronRight className="w-4 h-4 text-[var(--color-text-muted)]" />
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </Card>
-                );
-              })}
+                    </div>
+                  );
+                })}
+              </div>
             </div>
 
             {/* Right Column - FAQ & Glossary */}
             <div className="space-y-6">
               {/* FAQ Section */}
               <div id="faq">
-                <h2 className="text-xl font-bold text-[var(--color-text)] mb-4">FAQ</h2>
-                <Card className="divide-y">
+                <div className="mb-3">
+                  <p className={kickerClass}>QUESTIONS</p>
+                  <h2 className="text-xl font-bold text-theme mt-1">FAQ</h2>
+                </div>
+                <div className="glass-slab rounded-2xl divide-y divide-[var(--color-border-light)] overflow-hidden">
                   {Object.entries(faqsByCategory).map(([category, categoryFaqs]) => (
                     <div key={category}>
                       <button
                         onClick={() => toggleFaqCategory(category)}
-                        className="w-full flex items-center justify-between p-4 hover:bg-[var(--color-bg-tertiary)] transition"
+                        className="w-full flex items-center justify-between p-4 hover:bg-[var(--color-bg-tertiary)] animate-press"
+                        aria-expanded={expandedFaqCategories.has(category)}
                       >
-                        <span className="font-medium text-[var(--color-text)] capitalize">{category}</span>
+                        <span className="font-medium text-theme capitalize">{category}</span>
                         {expandedFaqCategories.has(category) ? (
-                          <ChevronDown className="w-4 h-4 text-[var(--color-text-muted)]" />
+                          <ChevronDown className="w-4 h-4 text-theme-muted" />
                         ) : (
-                          <ChevronRight className="w-4 h-4 text-[var(--color-text-muted)]" />
+                          <ChevronRight className="w-4 h-4 text-theme-muted" />
                         )}
                       </button>
                       {expandedFaqCategories.has(category) && (
                         <div className="px-4 pb-4 space-y-4">
                           {categoryFaqs.map((faq, index) => (
                             <div key={index}>
-                              <p className="font-medium text-[var(--color-text)] text-sm">{faq.question}</p>
-                              <p className="text-sm text-[var(--color-text-muted)] mt-1">{faq.answer}</p>
+                              <p className="font-medium text-theme text-sm">{faq.question}</p>
+                              <p className="text-sm text-theme-secondary leading-relaxed mt-1">{faq.answer}</p>
                             </div>
                           ))}
                         </div>
                       )}
                     </div>
                   ))}
-                </Card>
+                </div>
               </div>
 
               {/* Metric Glossary */}
               <div id="glossary">
-                <h2 className="text-xl font-bold text-[var(--color-text)] mb-4">Metric Glossary</h2>
-                <Card className="p-4">
+                <div className="mb-3">
+                  <p className={kickerClass}>REFERENCE</p>
+                  <h2 className="text-xl font-bold text-theme mt-1">Metric Glossary</h2>
+                </div>
+                <div className="glass-slab rounded-2xl p-4">
                   <div className="space-y-3">
                     {Object.entries(metricExplanations).slice(0, 6).map(([key, metric]) => (
                       <div key={key} className="pb-3 border-b border-[var(--color-border-light)] last:border-0 last:pb-0">
-                        <p className="font-medium text-[var(--color-text)] text-sm">{metric.title}</p>
-                        <p className="text-xs text-[var(--color-text-muted)] mt-1 line-clamp-2">{metric.explanation}</p>
+                        <p className="font-medium text-theme text-sm">{metric.title}</p>
+                        <p className="text-xs text-theme-secondary leading-relaxed mt-1 line-clamp-2">{metric.explanation}</p>
                       </div>
                     ))}
                   </div>
@@ -413,22 +452,25 @@ export function Help() {
                       const result = getTopicById('sharpe-volatility');
                       if (result) selectTopic(result.topic);
                     }}
-                    className="w-full mt-4 text-sm text-[var(--color-info)] hover:text-[var(--color-info)] font-medium"
+                    className="w-full mt-4 text-sm text-[var(--color-accent)] hover:brightness-125 font-medium animate-press"
                   >
                     View all metrics
                   </button>
-                </Card>
+                </div>
               </div>
 
               {/* Factor Categories */}
               <div id="factors">
-                <h2 className="text-xl font-bold text-[var(--color-text)] mb-4">Factor Categories</h2>
-                <Card className="p-4">
+                <div className="mb-3">
+                  <p className={kickerClass}>FACTORS</p>
+                  <h2 className="text-xl font-bold text-theme mt-1">Categories</h2>
+                </div>
+                <div className="glass-slab rounded-2xl p-4">
                   <div className="space-y-3">
                     {Object.entries(factorCategories).map(([key, category]) => (
                       <div key={key} className="pb-3 border-b border-[var(--color-border-light)] last:border-0 last:pb-0">
-                        <p className="font-medium text-[var(--color-text)] text-sm">{category.name}</p>
-                        <p className="text-xs text-[var(--color-text-muted)] mt-1">{category.description}</p>
+                        <p className="font-medium text-theme text-sm">{category.name}</p>
+                        <p className="text-xs text-theme-secondary leading-relaxed mt-1">{category.description}</p>
                       </div>
                     ))}
                   </div>
@@ -437,55 +479,84 @@ export function Help() {
                       const result = getTopicById('what-are-factors');
                       if (result) selectTopic(result.topic);
                     }}
-                    className="w-full mt-4 text-sm text-[var(--color-info)] hover:text-[var(--color-info)] font-medium"
+                    className="w-full mt-4 text-sm text-[var(--color-accent)] hover:brightness-125 font-medium animate-press"
                   >
                     Learn about factors
                   </button>
-                </Card>
+                </div>
               </div>
             </div>
           </div>
 
           {/* Contact Section */}
-          <div className="mt-12 mb-8 animate-fade-in-up" style={{ animationDelay: '200ms', animationFillMode: 'both' }} id="contact">
-            <Card className="p-8 border-[color-mix(in_srgb,var(--color-accent)_20%,transparent)]" style={{ background: 'linear-gradient(to right, color-mix(in srgb, var(--color-accent) 6%, transparent), color-mix(in srgb, var(--color-info) 6%, transparent))' }}>
+          <div
+            className="mt-12 mb-8 animate-fade-in-up"
+            style={{ animationDelay: '200ms', animationFillMode: 'both' }}
+            id="contact"
+          >
+            <div className="glass-slab-floating relative overflow-hidden rounded-2xl p-8 shadow-[0_18px_60px_-20px_rgba(123,44,255,0.45)]">
+              <div className="sovereign-bar absolute top-0 left-0 right-0" />
               <div className="text-center max-w-xl mx-auto">
-                <MessageCircle className="w-12 h-12 text-[var(--color-info)] mx-auto mb-4" />
-                <h2 className="text-2xl font-bold text-[var(--color-text)] mb-2">Still need help?</h2>
-                <p className="text-[var(--color-text-secondary)] mb-6">
+                <div
+                  className="w-12 h-12 rounded-xl flex items-center justify-center mx-auto mb-4"
+                  style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 12%, transparent)' }}
+                >
+                  <MessageCircle className="w-6 h-6 text-[var(--color-accent)]" aria-hidden="true" />
+                </div>
+                <p className={kickerClass}>SUPPORT</p>
+                <h2 className="text-2xl font-bold text-gradient-brand mt-1 mb-2">Still need help?</h2>
+                <p className="text-theme-secondary leading-relaxed mb-6">
                   Our support team is here to help. Reach out and we will get back to you as soon as possible.
                 </p>
                 <div className="flex flex-col sm:flex-row gap-3 justify-center">
                   <a
                     href="mailto:support@frontieralpha.com"
-                    className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[var(--color-info)] text-white rounded-lg hover:bg-[var(--color-info)] transition"
+                    className="inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg bg-[image:var(--gradient-sovereign)] text-white font-medium animate-press animate-lift shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:brightness-110"
                   >
-                    <Mail className="w-5 h-5" />
+                    <Mail className="w-5 h-5" aria-hidden="true" />
                     Email Support
                   </a>
                   <a
                     href="https://twitter.com/frontieralpha"
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center justify-center gap-2 px-6 py-3 bg-[var(--color-bg)] border border-[var(--color-border)] text-[var(--color-text-secondary)] rounded-lg hover:bg-[var(--color-bg-tertiary)] transition"
+                    className="glass-slab inline-flex items-center justify-center gap-2 px-6 py-3 rounded-lg text-theme animate-press animate-lift hover:border-[color:var(--color-border-hover)]"
                   >
-                    <ExternalLink className="w-5 h-5" />
+                    <ExternalLink className="w-5 h-5" aria-hidden="true" />
                     Twitter / X
                   </a>
                 </div>
               </div>
-            </Card>
+            </div>
           </div>
 
           {/* Keyboard Shortcuts */}
-          <Card className="p-6 mb-8 animate-fade-in-up" style={{ animationDelay: '250ms', animationFillMode: 'both' }}>
-            <h2 className="text-lg font-semibold text-[var(--color-text)] mb-4">Keyboard Shortcuts</h2>
+          <section
+            className="glass-slab rounded-2xl p-6 mb-8 animate-fade-in-up"
+            style={{ animationDelay: '250ms', animationFillMode: 'both' }}
+          >
+            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-5">
+              <div>
+                <p className={kickerClass}>SHORTCUTS</p>
+                <h2 className="text-lg font-bold text-theme mt-1">Keyboard Shortcuts</h2>
+                <p className="text-sm text-theme-secondary leading-relaxed mt-1">
+                  A few quick keys to move faster.
+                </p>
+              </div>
+              <button
+                onClick={openShortcutsModal}
+                className="glass-slab inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm text-theme animate-press animate-lift hover:border-[color:var(--color-border-hover)] self-start"
+              >
+                <Keyboard className="w-4 h-4 text-[var(--color-accent)]" aria-hidden="true" />
+                Open keyboard shortcuts
+              </button>
+            </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-              <KeyboardShortcut keys={['?']} description="Open/close help panel" />
+              <KeyboardShortcut keys={['?']} description="Open keyboard shortcuts" />
               <KeyboardShortcut keys={['Esc']} description="Close dialogs and panels" />
               <KeyboardShortcut keys={['/']} description="Focus search (coming soon)" />
             </div>
-          </Card>
+          </section>
         </>
       )}
     </div>
@@ -507,13 +578,16 @@ function QuickStartCard({
   return (
     <button
       onClick={onClick}
-      className="p-6 bg-[var(--color-bg)] rounded-xl border border-[var(--color-border)] hover:border-[color-mix(in_srgb,var(--color-info)_30%,transparent)] hover:shadow-lg transition-all text-left group"
+      className="glass-slab rounded-2xl p-6 text-left animate-enter animate-press animate-lift hover:border-[color:var(--color-border-hover)]"
     >
-      <div className="w-12 h-12 bg-[var(--color-bg-tertiary)] rounded-xl flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
-        <Icon className="w-6 h-6 text-[var(--color-info)]" />
+      <div
+        className="w-12 h-12 rounded-xl flex items-center justify-center mb-4"
+        style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 12%, transparent)' }}
+      >
+        <Icon className="w-6 h-6 text-[var(--color-accent)]" aria-hidden="true" />
       </div>
-      <h3 className="font-semibold text-[var(--color-text)] mb-1">{title}</h3>
-      <p className="text-sm text-[var(--color-text-muted)]">{description}</p>
+      <h3 className="font-semibold text-theme mb-1">{title}</h3>
+      <p className="text-sm text-theme-secondary leading-relaxed">{description}</p>
     </button>
   );
 }
@@ -526,13 +600,13 @@ function KeyboardShortcut({ keys, description }: { keys: string[]; description: 
         {keys.map((key, index) => (
           <kbd
             key={index}
-            className="px-2 py-1 bg-[var(--color-bg-secondary)] border border-[var(--color-border)] rounded text-sm font-mono text-[var(--color-text-secondary)]"
+            className="glass-slab rounded px-2 py-0.5 mono text-[11px] text-theme-secondary border border-theme"
           >
             {key}
           </kbd>
         ))}
       </div>
-      <span className="text-sm text-[var(--color-text-secondary)]">{description}</span>
+      <span className="text-sm text-theme-secondary">{description}</span>
     </div>
   );
 }

--- a/client/src/pages/ML.tsx
+++ b/client/src/pages/ML.tsx
@@ -3,9 +3,14 @@
  *
  * Orchestrator showing current market regime, model performance
  * metrics, training history, and factor attribution waterfall chart.
+ *
+ * Layout-wrapped (see App.tsx) — page chrome (grid bg, sovereign bar)
+ * is provided by the parent Layout. This page contributes the hero,
+ * stats bar, status banner, and section grid. The visualization
+ * subcomponents under `components/ml/` are intentionally untouched.
  */
 
-import { Activity, TrendingUp, Target, Clock, RefreshCw } from 'lucide-react';
+import { Activity, TrendingUp, Target, Clock, RefreshCw, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/shared/Button';
 import { RegimeDetector, REGIME_CONFIG } from '@/components/ml/RegimeDetector';
 import type { RegimeState } from '@/components/ml/RegimeDetector';
@@ -13,6 +18,11 @@ import { ModelVersions } from '@/components/ml/ModelVersions';
 import type { ModelVersion } from '@/components/ml/ModelVersions';
 import { FactorAttribution } from '@/components/ml/FactorAttribution';
 import type { WaterfallBar, AttributionDriver } from '@/components/ml/FactorAttribution';
+
+// ── Tokens ──────────────────────────────────────────────────────
+
+const kickerClass =
+  'mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted mb-2';
 
 // ── MetricCard ──────────────────────────────────────────────────
 
@@ -27,14 +37,74 @@ interface MetricCardProps {
 function MetricCard({ label, value, subtitle, icon, color }: MetricCardProps) {
   const resolvedColor = color ?? 'var(--color-text)';
   return (
-    <div className="flex items-center gap-3 p-4 rounded-xl bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)]">
-      <div className="p-2.5 rounded-lg flex-shrink-0" style={{ backgroundColor: `color-mix(in srgb, ${resolvedColor} 12%, transparent)` }}>
+    <div className="glass-slab rounded-xl p-4 flex items-center gap-3 animate-enter">
+      <div
+        className="p-2.5 rounded-lg flex-shrink-0"
+        style={{ backgroundColor: `color-mix(in srgb, ${resolvedColor} 12%, transparent)` }}
+      >
         <span style={{ color: resolvedColor }}>{icon}</span>
       </div>
       <div className="min-w-0">
-        <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">{label}</p>
-        <p className="text-xl font-bold mt-0.5" style={{ color: resolvedColor }}>{value}</p>
-        {subtitle && <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{subtitle}</p>}
+        <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">{label}</p>
+        <p className="text-xl font-bold mt-0.5 tabular-nums" style={{ color: resolvedColor }}>{value}</p>
+        {subtitle && <p className="text-xs text-theme-muted mt-0.5">{subtitle}</p>}
+      </div>
+    </div>
+  );
+}
+
+// ── Status Banner ───────────────────────────────────────────────
+
+type ModelTrainingStatus = 'complete' | 'training' | 'failed';
+
+interface ModelStatusBannerProps {
+  status: ModelTrainingStatus;
+  title: string;
+  message: string;
+}
+
+const statusStyles: Record<
+  ModelTrainingStatus,
+  { rail: string; icon: string; glow: string; Icon: typeof CheckCircle2 }
+> = {
+  complete: {
+    rail: 'before:bg-[var(--color-positive)]',
+    icon: 'text-[var(--color-positive)]',
+    glow: 'shadow-[0_18px_60px_-20px_rgba(16,185,129,0.45)]',
+    Icon: CheckCircle2,
+  },
+  training: {
+    rail: 'before:bg-[var(--color-warning)]',
+    icon: 'text-[var(--color-warning)]',
+    glow: 'shadow-[0_18px_60px_-20px_rgba(245,158,11,0.45)]',
+    Icon: RefreshCw,
+  },
+  failed: {
+    rail: 'before:bg-[var(--color-negative)]',
+    icon: 'text-[var(--color-negative)]',
+    glow: 'shadow-[0_18px_60px_-20px_rgba(239,68,68,0.45)]',
+    Icon: Activity,
+  },
+};
+
+function ModelStatusBanner({ status, title, message }: ModelStatusBannerProps) {
+  const style = statusStyles[status];
+  const StatusIcon = style.Icon;
+  return (
+    <div
+      className={`glass-slab-floating relative overflow-hidden rounded-xl pl-5 pr-4 py-4 ${style.glow} before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] ${style.rail}`}
+      role="status"
+      aria-live="polite"
+    >
+      <div className="flex items-start gap-3">
+        <StatusIcon
+          className={`w-5 h-5 flex-shrink-0 mt-0.5 ${style.icon} ${status === 'training' ? 'animate-spin' : ''}`}
+          aria-hidden="true"
+        />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-theme">{title}</p>
+          <p className="text-sm mt-1 text-theme-secondary leading-relaxed">{message}</p>
+        </div>
       </div>
     </div>
   );
@@ -145,82 +215,100 @@ export function ML() {
     .map((m) => new Date(m.trainedAt).getTime())
     .reduce((a, b) => Math.max(a, b), 0);
 
+  const validatedCount = models.filter((m) => m.status === 'validated').length;
+  const bannerStatus: ModelTrainingStatus = 'complete';
+  const bannerTitle = validatedCount > 0
+    ? `${validatedCount} model${validatedCount === 1 ? '' : 's'} ready to deploy`
+    : 'All deployed models healthy';
+  const bannerMessage = validatedCount > 0
+    ? 'Validated against held-out folds. Promote to production from the Models card.'
+    : `${deployedModels.length} models in production · last trained ${new Date(lastTrained).toLocaleString('en-US', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}`;
+
   return (
-    <div className="space-y-6">
-      {/* Header */}
+    <div className="space-y-6 max-w-7xl mx-auto">
+      {/* ── Header ──────────────────────────────────────────────────────── */}
       <div
-        className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 animate-fade-in-up"
+        className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4 animate-fade-in-up"
         style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
         <div>
-          <h1 className="text-2xl font-bold text-[var(--color-text)]">Machine Learning</h1>
-          <p className="text-[var(--color-text-muted)] mt-1">
-            Regime detection, model performance &amp; factor attribution
+          <p className={kickerClass}>
+            Machine Learning · <span className="text-[color:var(--color-accent-secondary)]">Regime &amp; Attribution</span>
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-black tracking-tight">
+            <span className="text-gradient-brand">Adaptive</span>{' '}
+            <span className="text-theme">Models</span>
+          </h1>
+          <p className="mt-3 text-sm sm:text-base text-theme-secondary leading-relaxed max-w-2xl">
+            Regime detection, model performance, and factor attribution.
+            Every deployed model is fold-validated before it touches a portfolio.
           </p>
         </div>
-        <Button disabled>
-          <RefreshCw className="w-4 h-4 mr-2" />
+        <Button disabled aria-label="Retrain all models">
+          <RefreshCw className="w-4 h-4 mr-2" aria-hidden="true" />
           Retrain
         </Button>
       </div>
 
-      {/* Stats Bar */}
+      {/* ── Status Banner ───────────────────────────────────────────────── */}
       <div
-        className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-fade-in-up"
-        style={{ animationDelay: '50ms', animationFillMode: 'both' }}
+        className="animate-fade-in-up"
+        style={{ animationDelay: '40ms', animationFillMode: 'both' }}
       >
-        <MetricCard
-          label="Current Regime"
-          value={REGIME_CONFIG[regime.regime].label}
-          subtitle={`${Math.round(regime.confidence * 100)}% confidence`}
-          icon={<Activity className="w-4 h-4" />}
-          color={REGIME_CONFIG[regime.regime].color}
-        />
-        <MetricCard
-          label="Best Accuracy"
-          value={`${(bestAccuracy * 100).toFixed(1)}%`}
-          subtitle="Deployed model"
-          icon={<Target className="w-4 h-4" />}
-          color="var(--color-accent)"
-        />
-        <MetricCard
-          label="Sharpe Improvement"
-          value={`+${(avgSharpeImprovement * 100).toFixed(0)}%`}
-          subtitle="Avg deployed"
-          icon={<TrendingUp className="w-4 h-4" />}
-          color="var(--color-positive)"
-        />
-        <MetricCard
-          label="Last Trained"
-          value={new Date(lastTrained).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
-          subtitle={new Date(lastTrained).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}
-          icon={<Clock className="w-4 h-4" />}
-        />
+        <ModelStatusBanner status={bannerStatus} title={bannerTitle} message={bannerMessage} />
       </div>
 
-      {/* Three-section grid: Regime | Models | Attribution */}
-      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+      {/* ── Stats Bar ───────────────────────────────────────────────────── */}
+      <section
+        className="animate-fade-in-up"
+        style={{ animationDelay: '80ms', animationFillMode: 'both' }}
+      >
+        <p className={kickerClass}>Snapshot · Live</p>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-stagger">
+          <MetricCard
+            label="Current Regime"
+            value={REGIME_CONFIG[regime.regime].label}
+            subtitle={`${Math.round(regime.confidence * 100)}% confidence`}
+            icon={<Activity className="w-4 h-4" />}
+            color={REGIME_CONFIG[regime.regime].color}
+          />
+          <MetricCard
+            label="Best Accuracy"
+            value={`${(bestAccuracy * 100).toFixed(1)}%`}
+            subtitle="Deployed model"
+            icon={<Target className="w-4 h-4" />}
+            color="var(--color-accent)"
+          />
+          <MetricCard
+            label="Sharpe Improvement"
+            value={`+${(avgSharpeImprovement * 100).toFixed(0)}%`}
+            subtitle="Avg deployed"
+            icon={<TrendingUp className="w-4 h-4" />}
+            color="var(--color-positive)"
+          />
+          <MetricCard
+            label="Last Trained"
+            value={new Date(lastTrained).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+            subtitle={new Date(lastTrained).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' })}
+            icon={<Clock className="w-4 h-4" />}
+          />
+        </div>
+      </section>
+
+      {/* ── Three-section grid: Regime | Models | Attribution ───────────── */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 animate-stagger">
         {/* Regime Section */}
-        <div
-          className="lg:col-span-4 animate-fade-in-up"
-          style={{ animationDelay: '100ms', animationFillMode: 'both' }}
-        >
+        <div className="lg:col-span-4 animate-enter">
           <RegimeDetector regime={regime} />
         </div>
 
         {/* Models Section */}
-        <div
-          className="lg:col-span-4 animate-fade-in-up"
-          style={{ animationDelay: '150ms', animationFillMode: 'both' }}
-        >
+        <div className="lg:col-span-4 animate-enter">
           <ModelVersions models={models} />
         </div>
 
         {/* Attribution Section */}
-        <div
-          className="lg:col-span-4 animate-fade-in-up"
-          style={{ animationDelay: '200ms', animationFillMode: 'both' }}
-        >
+        <div className="lg:col-span-4 animate-enter">
           <FactorAttribution waterfall={waterfall} topDrivers={topDrivers} />
         </div>
       </div>

--- a/client/src/pages/Options.tsx
+++ b/client/src/pages/Options.tsx
@@ -60,7 +60,7 @@ function MetricCard({ label, value, subtitle, icon, color = 'text-[var(--color-t
   const cssColor = colorMatch ? `var(${colorMatch[1]})` : 'var(--color-text-muted)';
 
   return (
-    <div className="flex items-center gap-3 p-4 rounded-xl bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)] hover:shadow-lg transition-all duration-200 active:scale-[0.98]">
+    <div className="glass-slab rounded-xl p-4 sm:p-6 flex items-center gap-3 animate-enter animate-press transition-[border-color,box-shadow] duration-200">
       <div
         className="p-2.5 rounded-lg flex-shrink-0"
         style={{ backgroundColor: `color-mix(in srgb, ${cssColor} 12%, transparent)` }}
@@ -68,9 +68,9 @@ function MetricCard({ label, value, subtitle, icon, color = 'text-[var(--color-t
         <span style={{ color: cssColor }}>{icon}</span>
       </div>
       <div className="min-w-0">
-        <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">{label}</p>
-        <p className={`text-xl font-bold mt-0.5 ${color}`}>{value}</p>
-        {subtitle && <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{subtitle}</p>}
+        <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">{label}</p>
+        <p className={`mono tabular-nums text-xl font-bold mt-1 ${color}`}>{value}</p>
+        {subtitle && <p className="text-xs text-theme-muted mt-0.5">{subtitle}</p>}
       </div>
     </div>
   );
@@ -97,16 +97,21 @@ export function Options() {
         style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
         <div>
-          <h1 className="text-2xl lg:text-3xl font-bold text-[var(--color-text)]">Options</h1>
-          <p className="text-[var(--color-text-muted)] mt-1">
+          <p className="mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted mb-2">
+            Execution \u00B7 Options
+          </p>
+          <h1 className="text-2xl lg:text-3xl font-bold text-theme">
+            <span className="text-gradient-brand">Options</span>
+          </h1>
+          <p className="text-sm text-theme-secondary mt-1">
             Chain, Greeks, volatility surface &amp; strategy analysis
           </p>
         </div>
         <div className="flex items-center gap-3">
-          <div className="px-3 py-1.5 rounded-lg bg-[var(--color-bg-secondary)] border border-[var(--color-border)]">
-            <span className="text-xs text-[var(--color-text-muted)]">Underlying</span>
-            <span className="ml-2 text-sm font-bold text-[var(--color-text)]">{UNDERLYING_SYMBOL}</span>
-            <span className="ml-1 text-sm font-mono text-[var(--color-text-muted)]">${UNDERLYING_PRICE.toFixed(2)}</span>
+          <div className="glass-slab-floating rounded-xl px-4 py-2.5 flex items-center gap-2">
+            <span className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Underlying</span>
+            <span className="mono uppercase text-sm font-bold text-theme">{UNDERLYING_SYMBOL}</span>
+            <span className="mono tabular-nums text-sm text-theme-muted">${UNDERLYING_PRICE.toFixed(2)}</span>
           </div>
           <Button variant="outline" disabled>
             <RefreshCw className="w-4 h-4 mr-2" />
@@ -117,7 +122,7 @@ export function Options() {
 
       {/* Summary Stats */}
       <div
-        className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-fade-in-up"
+        className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-stagger animate-fade-in-up"
         style={{ animationDelay: '50ms', animationFillMode: 'both' }}
       >
         <MetricCard
@@ -147,26 +152,27 @@ export function Options() {
         />
       </div>
 
-      {/* Tab Navigation */}
+      {/* Tab Navigation \u2014 segmented control */}
       <div
-        className="flex overflow-x-auto border-b border-[var(--color-border)] animate-fade-in-up"
+        className="grid grid-cols-2 sm:grid-cols-4 gap-2 p-1 rounded-lg bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] animate-fade-in-up"
         style={{ animationDelay: '100ms', animationFillMode: 'both' }}
         role="tablist"
         aria-label="Options sections"
       >
         {TABS.map((tab) => {
           const Icon = tab.icon;
+          const isActive = activeTab === tab.id;
           return (
             <button
               key={tab.id}
               role="tab"
-              aria-selected={activeTab === tab.id}
+              aria-selected={isActive}
               aria-controls={`panel-${tab.id}`}
               onClick={() => setActiveTab(tab.id)}
-              className={`flex items-center gap-2 px-4 py-3 text-sm font-medium whitespace-nowrap border-b-2 transition-colors active:scale-[0.97] min-h-[44px] ${
-                activeTab === tab.id
-                  ? 'border-[var(--color-accent)] text-[var(--color-accent)]'
-                  : 'border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:border-[var(--color-border)]'
+              className={`flex items-center justify-center gap-2 px-3 py-2.5 rounded-md min-h-[44px] mono text-[11px] tracking-[0.2em] uppercase font-semibold animate-press transition-colors duration-200 ${
+                isActive
+                  ? 'bg-[var(--color-accent-light)] text-[var(--color-accent)]'
+                  : 'text-theme-secondary hover:text-theme'
               }`}
             >
               <Icon className="w-4 h-4" />

--- a/client/src/pages/Social.tsx
+++ b/client/src/pages/Social.tsx
@@ -22,8 +22,10 @@ import {
   Shield,
   Star,
 } from 'lucide-react';
-import { Card } from '@/components/shared/Card';
 import { Button } from '@/components/shared/Button';
+
+const kickerClass =
+  'text-[10px] mono tracking-[0.3em] uppercase text-theme-muted';
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -155,11 +157,14 @@ function UserProfileCard({ profile, onToggleFollow }: {
   onToggleFollow: (userId: string) => void;
 }) {
   return (
-    // SOC-003: hover shadow polish
-    <Card className="hover:shadow-lg transition-shadow duration-200">
+    // SOC-003: family-aesthetic glass slab
+    <div className="glass-slab rounded-2xl p-6 animate-enter animate-lift">
       <div className="flex flex-col sm:flex-row items-start gap-4">
         {/* Avatar */}
-        <div className="w-16 h-16 rounded-full bg-gradient-to-br from-brand-magenta to-brand-cyan flex items-center justify-center text-white text-xl font-bold flex-shrink-0">
+        <div
+          className="w-16 h-16 rounded-full flex items-center justify-center text-white text-xl font-bold flex-shrink-0 shadow-[0_8px_30px_-10px_rgba(123,44,255,0.45)]"
+          style={{ background: 'var(--gradient-sovereign)' }}
+        >
           {profile.display_name.charAt(0).toUpperCase()}
         </div>
 
@@ -167,10 +172,11 @@ function UserProfileCard({ profile, onToggleFollow }: {
           {/* Name + follow */}
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-2 mb-2">
             <div>
-              <h3 className="text-lg font-bold text-[var(--color-text)]">{profile.display_name}</h3>
-              <div className="flex items-center gap-3 text-sm text-[var(--color-text-muted)]">
-                <span><strong>{profile.follower_count}</strong> followers</span>
-                <span><strong>{profile.following_count}</strong> following</span>
+              <p className={kickerClass}>TRADER</p>
+              <h3 className="text-lg font-bold text-theme mt-0.5">{profile.display_name}</h3>
+              <div className="flex items-center gap-3 text-sm text-theme-secondary">
+                <span><strong className="text-theme">{profile.follower_count}</strong> followers</span>
+                <span><strong className="text-theme">{profile.following_count}</strong> following</span>
               </div>
             </div>
             <Button
@@ -180,6 +186,7 @@ function UserProfileCard({ profile, onToggleFollow }: {
                 ? <UserMinus className="w-4 h-4" aria-hidden="true" />
                 : <UserPlus className="w-4 h-4" aria-hidden="true" />}
               onClick={() => onToggleFollow(profile.user_id)}
+              className="animate-press"
               aria-label={profile.is_following ? `Unfollow ${profile.display_name}` : `Follow ${profile.display_name}`}
             >
               {profile.is_following ? 'Unfollow' : 'Follow'}
@@ -188,25 +195,25 @@ function UserProfileCard({ profile, onToggleFollow }: {
 
           {/* Bio */}
           {profile.bio && (
-            <p className="text-sm text-[var(--color-text-muted)] mb-3">{profile.bio}</p>
+            <p className="text-sm text-theme-secondary leading-relaxed mb-3">{profile.bio}</p>
           )}
 
           {/* Stats */}
           <div className="flex items-center gap-4 text-sm">
             <div className="flex items-center gap-1">
               <TrendingUp className="w-4 h-4 text-[var(--color-positive)]" aria-hidden="true" />
-              <span className="text-[var(--color-positive)] font-bold">{(profile.total_return * 100).toFixed(1)}%</span>
-              <span className="text-[var(--color-text-muted)]">return</span>
+              <span className="text-[var(--color-positive)] font-bold mono">{(profile.total_return * 100).toFixed(1)}%</span>
+              <span className="text-theme-muted">return</span>
             </div>
             <div className="flex items-center gap-1">
               <Shield className="w-4 h-4 text-[var(--color-accent)]" aria-hidden="true" />
-              <span className="text-[var(--color-accent)] font-bold">{profile.sharpe_ratio.toFixed(2)}</span>
-              <span className="text-[var(--color-text-muted)]">Sharpe</span>
+              <span className="text-[var(--color-accent)] font-bold mono">{profile.sharpe_ratio.toFixed(2)}</span>
+              <span className="text-theme-muted">Sharpe</span>
             </div>
           </div>
         </div>
       </div>
-    </Card>
+    </div>
   );
 }
 
@@ -241,19 +248,19 @@ function LeaderboardTab({ entries, onToggleFollow }: {
   }
 
   return (
-    <Card>
-      <div className="overflow-x-auto -mx-6">
+    <div className="glass-slab rounded-2xl p-6 animate-enter">
+      <div className="overflow-x-auto -mx-6 px-6">
         <table className="w-full text-sm min-w-[600px]">
           <thead>
-            <tr className="border-b border-[var(--color-border)]">
+            <tr className="border-b border-theme">
               {COLUMNS.map((col) => {
                 const isActive = col.sortable && col.key === sortMetric;
                 return (
                   <th
                     key={col.key}
-                    className={`px-4 py-3 text-left text-xs font-medium uppercase tracking-wider ${
-                      col.sortable ? 'cursor-pointer select-none hover:text-[var(--color-text)]' : ''
-                    } ${isActive ? 'text-[var(--color-accent)]' : 'text-[var(--color-text-muted)]'}`}
+                    className={`px-4 py-3 text-left text-[10px] mono tracking-[0.3em] font-medium uppercase ${
+                      col.sortable ? 'cursor-pointer select-none hover:text-theme animate-press' : ''
+                    } ${isActive ? 'text-[var(--color-accent)]' : 'text-theme-muted'}`}
                     onClick={() => handleSort(col)}
                     aria-sort={isActive ? (sortDir === 'desc' ? 'descending' : 'ascending') : undefined}
                   >
@@ -275,7 +282,7 @@ function LeaderboardTab({ entries, onToggleFollow }: {
             {sorted.map((entry) => (
               <tr
                 key={entry.user_id}
-                className="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-secondary)] transition-all duration-150"
+                className="border-b border-theme last:border-0 hover:bg-[var(--color-bg-secondary)] transition-colors duration-150"
               >
                 {/* Rank */}
                 <td className="px-4 py-3">
@@ -290,17 +297,20 @@ function LeaderboardTab({ entries, onToggleFollow }: {
                 {/* User */}
                 <td className="px-4 py-3">
                   <div className="flex items-center gap-2">
-                    <div className="w-8 h-8 rounded-full bg-gradient-to-br from-brand-magenta to-brand-cyan flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
+                    <div
+                      className="w-8 h-8 rounded-full flex items-center justify-center text-white text-xs font-bold flex-shrink-0"
+                      style={{ background: 'var(--gradient-sovereign)' }}
+                    >
                       {entry.display_name.charAt(0)}
                     </div>
                     <div className="flex items-center gap-2 min-w-0">
-                      <span className="font-medium text-[var(--color-text)] truncate">{entry.display_name}</span>
+                      <span className="font-medium text-theme truncate">{entry.display_name}</span>
                       <button
                         onClick={() => onToggleFollow(entry.user_id)}
-                        className={`flex-shrink-0 p-1 rounded-full transition-colors min-h-[28px] min-w-[28px] flex items-center justify-center ${
+                        className={`flex-shrink-0 p-1 rounded-full transition-colors min-h-[28px] min-w-[28px] flex items-center justify-center animate-press ${
                           entry.is_following
                             ? 'text-[var(--color-accent)] hover:text-[var(--color-negative)]'
-                            : 'text-[var(--color-text-muted)] hover:text-[var(--color-accent)]'
+                            : 'text-theme-muted hover:text-[var(--color-accent)]'
                         }`}
                         aria-label={entry.is_following ? `Unfollow ${entry.display_name}` : `Follow ${entry.display_name}`}
                       >
@@ -315,7 +325,7 @@ function LeaderboardTab({ entries, onToggleFollow }: {
                 {/* Return */}
                 <td className="px-4 py-3">
                   <span
-                    className="font-mono font-bold"
+                    className="mono font-bold"
                     style={{ color: entry.total_return >= 0 ? 'var(--color-positive)' : 'var(--color-negative)' }}
                   >
                     {COLUMNS[2].format!(entry.total_return)}
@@ -323,19 +333,19 @@ function LeaderboardTab({ entries, onToggleFollow }: {
                 </td>
 
                 {/* Sharpe */}
-                <td className="px-4 py-3 font-mono text-[var(--color-text)]">
+                <td className="px-4 py-3 mono text-theme">
                   {COLUMNS[3].format!(entry.sharpe_ratio)}
                 </td>
 
                 {/* Max DD */}
                 <td className="px-4 py-3">
-                  <span className="font-mono" style={{ color: 'var(--color-negative)' }}>
+                  <span className="mono" style={{ color: 'var(--color-negative)' }}>
                     {COLUMNS[4].format!(entry.max_drawdown)}
                   </span>
                 </td>
 
                 {/* Risk-Adjusted */}
-                <td className="px-4 py-3 font-mono text-[var(--color-text)]">
+                <td className="px-4 py-3 mono text-theme">
                   {COLUMNS[5].format!(entry.risk_adjusted_return)}
                 </td>
 
@@ -347,11 +357,11 @@ function LeaderboardTab({ entries, onToggleFollow }: {
                         className="h-full rounded-full"
                         style={{
                           width: `${entry.consistency_score * 100}%`,
-                          background: 'linear-gradient(to right, var(--color-accent), var(--chart-purple))',
+                          background: 'var(--gradient-sovereign)',
                         }}
                       />
                     </div>
-                    <span className="font-mono text-xs text-[var(--color-text-muted)]">
+                    <span className="mono text-xs text-theme-muted">
                       {COLUMNS[6].format!(entry.consistency_score)}
                     </span>
                   </div>
@@ -361,23 +371,37 @@ function LeaderboardTab({ entries, onToggleFollow }: {
           </tbody>
         </table>
       </div>
-    </Card>
+    </div>
   );
 }
 
 // ── Feed Tab ───────────────────────────────────────────────────
 
 function FeedTab({ items }: { items: FeedItem[] }) {
+  if (items.length === 0) {
+    return (
+      <div className="glass-slab-floating relative overflow-hidden rounded-2xl p-12 text-center shadow-[0_18px_60px_-20px_rgba(123,44,255,0.35)]">
+        <div className="sovereign-bar absolute top-0 left-0 right-0" />
+        <Users className="w-12 h-12 text-theme-muted mx-auto mb-4" aria-hidden="true" />
+        <p className={kickerClass}>FEED</p>
+        <h3 className="text-lg font-bold text-theme mt-1 mb-2">No activity yet</h3>
+        <p className="text-theme-secondary leading-relaxed max-w-md mx-auto">
+          Follow top traders to see their portfolio updates and milestones here.
+        </p>
+      </div>
+    );
+  }
+
   return (
-    <div className="space-y-4">
+    <div className="space-y-4 animate-stagger">
       {items.map((item) => {
         const config = FEED_EVENT_CONFIG[item.event_type];
         const EventIcon = config.icon;
         const relativeTime = formatRelativeTime(item.timestamp);
 
         return (
-          // SOC-003: hover shadow on feed cards
-          <Card key={item.id} className="hover:shadow-md transition-shadow duration-200">
+          // SOC-003: family glass slab card
+          <div key={item.id} className="glass-slab rounded-2xl p-5 animate-enter animate-lift">
             <div className="flex gap-3">
               {/* Event icon — SOC-001: bgColor and color applied via inline style */}
               <div
@@ -390,31 +414,34 @@ function FeedTab({ items }: { items: FeedItem[] }) {
               <div className="flex-1 min-w-0">
                 {/* Header: user + time */}
                 <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-1 mb-1">
-                  <div className="flex items-center gap-2">
-                    <div className="w-6 h-6 rounded-full bg-gradient-to-br from-brand-magenta to-brand-cyan flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0">
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <div
+                      className="w-6 h-6 rounded-full flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0"
+                      style={{ background: 'var(--gradient-sovereign)' }}
+                    >
                       {item.display_name.charAt(0)}
                     </div>
-                    <span className="font-semibold text-sm text-[var(--color-text)]">{item.display_name}</span>
-                    <span className="text-sm text-[var(--color-text-muted)]">{item.description}</span>
+                    <span className="font-semibold text-sm text-theme">{item.display_name}</span>
+                    <span className="text-sm text-theme-secondary">{item.description}</span>
                   </div>
-                  <div className="flex items-center gap-1 text-xs text-[var(--color-text-muted)]">
+                  <div className="flex items-center gap-1 text-xs text-theme-muted mono">
                     <Clock className="w-3 h-3" aria-hidden="true" />
                     {relativeTime}
                   </div>
                 </div>
 
                 {/* Detail */}
-                <p className="text-sm text-[var(--color-text-muted)]">{item.detail}</p>
+                <p className="text-sm text-theme-secondary leading-relaxed">{item.detail}</p>
 
                 {/* Symbols */}
                 {item.symbols && item.symbols.length > 0 && (
-                  <div className="flex items-center gap-2 mt-2">
-                    <Briefcase className="w-3 h-3 text-[var(--color-text-muted)]" aria-hidden="true" />
+                  <div className="flex items-center gap-2 mt-3">
+                    <Briefcase className="w-3 h-3 text-theme-muted" aria-hidden="true" />
                     <div className="flex flex-wrap gap-1">
                       {item.symbols.map((sym) => (
                         <span
                           key={sym}
-                          className="px-2 py-0.5 text-xs font-mono font-medium bg-[var(--color-bg-secondary)] text-[var(--color-text)] rounded-md border border-[var(--color-border)]"
+                          className="glass-slab px-2 py-0.5 text-[11px] mono font-medium text-theme rounded-md border border-theme"
                         >
                           {sym}
                         </span>
@@ -424,7 +451,7 @@ function FeedTab({ items }: { items: FeedItem[] }) {
                 )}
               </div>
             </div>
-          </Card>
+          </div>
         );
       })}
     </div>
@@ -491,22 +518,23 @@ export function Social() {
 
   return (
     <div className="space-y-6">
-      {/* Header — SOC-002: staggered entry animation delay 0ms */}
-      <div
-        className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 animate-fade-in-up"
+      {/* Header — SOC-002: staggered entry animation delay 0ms, family pattern */}
+      <header
+        className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 animate-fade-in-up"
         style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
         <div>
-          <h1 className="text-2xl lg:text-3xl font-bold text-[var(--color-text)]">Social</h1>
-          <p className="text-[var(--color-text-muted)] mt-1">
-            Top performers &amp; portfolio updates from the community
+          <p className={kickerClass}>SOCIAL · Community</p>
+          <h1 className="text-3xl lg:text-4xl font-bold text-gradient-brand mt-2">Social</h1>
+          <p className="text-theme-secondary mt-2 leading-relaxed">
+            Top performers and portfolio updates from the community.
           </p>
         </div>
-        <div className="flex items-center gap-2 text-sm text-[var(--color-text-muted)]">
-          <Users className="w-4 h-4" aria-hidden="true" />
-          <span>Following <strong className="text-[var(--color-text)]">{followingCount}</strong> traders</span>
+        <div className="glass-slab inline-flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-theme-secondary self-start sm:self-end">
+          <Users className="w-4 h-4 text-[var(--color-accent)]" aria-hidden="true" />
+          <span>Following <strong className="text-theme mono">{followingCount}</strong> traders</span>
         </div>
-      </div>
+      </header>
 
       {/* Featured Profile Card — SOC-002: staggered delay 50ms */}
       <div
@@ -525,7 +553,7 @@ export function Social() {
         className="animate-fade-in-up"
         style={{ animationDelay: '100ms', animationFillMode: 'both' }}
       >
-        <div className="flex gap-1 p-1 bg-[var(--color-bg-secondary)] rounded-lg w-fit" role="tablist" aria-label="Social tabs">
+        <div className="glass-slab flex gap-1 p-1 rounded-lg w-fit" role="tablist" aria-label="Social tabs">
           {tabs.map((tab) => {
             const TabIcon = tab.icon;
             const isActive = activeTab === tab.id;
@@ -536,10 +564,10 @@ export function Social() {
                 aria-selected={isActive}
                 aria-controls={`tabpanel-${tab.id}`}
                 onClick={() => setActiveTab(tab.id)}
-                className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-md transition-all min-h-[44px] ${
+                className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-md transition-[background,color,box-shadow] duration-150 min-h-[44px] animate-press ${
                   isActive
-                    ? 'bg-[var(--color-bg)] text-[var(--color-text)] shadow-sm'
-                    : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'
+                    ? 'bg-[var(--color-bg)] text-theme shadow-sm'
+                    : 'text-theme-muted hover:text-theme'
                 }`}
               >
                 <TabIcon className="w-4 h-4" aria-hidden="true" />

--- a/client/src/pages/Tax.tsx
+++ b/client/src/pages/Tax.tsx
@@ -24,7 +24,6 @@ import {
   ChevronUp,
   ArrowDownToLine,
 } from 'lucide-react';
-import { Card } from '@/components/shared/Card';
 import { Button } from '@/components/shared/Button';
 import { ScrollableTable } from '@/components/shared/ScrollableTable';
 
@@ -152,7 +151,7 @@ function MetricCard({ label, value, subtext, color, icon: Icon }: {
   const cssColor = colorMatch ? `var(${colorMatch[1]})` : 'var(--color-text-muted)';
 
   return (
-    <div className="flex items-center gap-3 p-4 rounded-xl bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)] hover:shadow-lg transition-shadow duration-200">
+    <div className="glass-slab rounded-xl p-4 sm:p-6 flex items-center gap-3 animate-enter transition-[border-color,box-shadow] duration-200">
       <div
         className="p-2.5 rounded-lg flex-shrink-0"
         style={{ backgroundColor: `color-mix(in srgb, ${cssColor} 12%, transparent)` }}
@@ -160,9 +159,9 @@ function MetricCard({ label, value, subtext, color, icon: Icon }: {
         <Icon className="w-5 h-5" style={{ color: cssColor }} aria-hidden="true" />
       </div>
       <div className="min-w-0">
-        <p className="text-xs text-[var(--color-text-muted)] uppercase tracking-wider">{label}</p>
-        <p className={`text-xl font-bold font-mono mt-0.5 ${color ?? 'text-[var(--color-text)]'}`}>{value}</p>
-        {subtext && <p className="text-xs text-[var(--color-text-muted)] mt-0.5">{subtext}</p>}
+        <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">{label}</p>
+        <p className={`mono tabular-nums text-xl font-bold mt-1 ${color ?? 'text-theme'}`}>{value}</p>
+        {subtext && <p className="text-xs text-theme-muted mt-0.5">{subtext}</p>}
       </div>
     </div>
   );
@@ -175,7 +174,7 @@ function SummarySection({ data }: { data: TaxSummaryData }) {
     <div className="space-y-6">
       {/* Top-line metrics */}
       <div
-        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 animate-fade-in-up"
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 animate-stagger animate-fade-in-up"
         style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
         <MetricCard
@@ -208,52 +207,54 @@ function SummarySection({ data }: { data: TaxSummaryData }) {
         />
       </div>
 
-      {/* Gains/Losses Breakdown */}
-      <div
-        className="animate-fade-in-up"
+      {/* Gains/Losses Breakdown — long vs short term, two-column block via table */}
+      <section
+        className="glass-slab rounded-2xl p-6 sm:p-8 animate-fade-in-up"
         style={{ animationDelay: '50ms', animationFillMode: 'both' }}
       >
-        <Card title="Gains & Losses Breakdown">
-          <ScrollableTable>
-            <table className="w-full text-sm min-w-[480px]">
-              <thead>
-                <tr className="border-b border-[var(--color-border)]">
-                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Category</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Gains</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Losses</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Net</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr className="border-b border-[var(--color-border)]">
-                  <td className="px-4 py-3 font-medium text-[var(--color-text)]">Short-Term</td>
-                  <td className="px-4 py-3 text-right font-mono text-[var(--color-positive)]">{formatCurrency(data.shortTermGains)}</td>
-                  <td className="px-4 py-3 text-right font-mono text-[var(--color-negative)]">{formatCurrency(data.shortTermLosses)}</td>
-                  <td className={`px-4 py-3 text-right font-mono font-bold ${data.netShortTerm >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}>
-                    {formatCurrency(data.netShortTerm, true)}
-                  </td>
-                </tr>
-                <tr className="border-b border-[var(--color-border)]">
-                  <td className="px-4 py-3 font-medium text-[var(--color-text)]">Long-Term</td>
-                  <td className="px-4 py-3 text-right font-mono text-[var(--color-positive)]">{formatCurrency(data.longTermGains)}</td>
-                  <td className="px-4 py-3 text-right font-mono text-[var(--color-negative)]">{formatCurrency(data.longTermLosses)}</td>
-                  <td className={`px-4 py-3 text-right font-mono font-bold ${data.netLongTerm >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}>
-                    {formatCurrency(data.netLongTerm, true)}
-                  </td>
-                </tr>
-                <tr>
-                  <td className="px-4 py-3 font-bold text-[var(--color-text)]">Total</td>
-                  <td className="px-4 py-3 text-right font-mono font-bold text-[var(--color-positive)]">{formatCurrency(data.shortTermGains + data.longTermGains)}</td>
-                  <td className="px-4 py-3 text-right font-mono font-bold text-[var(--color-negative)]">{formatCurrency(data.shortTermLosses + data.longTermLosses)}</td>
-                  <td className={`px-4 py-3 text-right font-mono font-bold text-lg ${data.totalRealizedGain >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}>
-                    {formatCurrency(data.totalRealizedGain, true)}
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </ScrollableTable>
-        </Card>
-      </div>
+        <header className="mb-6">
+          <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Realized P&amp;L</p>
+          <h2 className="text-lg font-bold text-theme mt-1">Gains &amp; Losses Breakdown</h2>
+        </header>
+        <ScrollableTable>
+          <table className="w-full text-sm min-w-[480px]">
+            <thead>
+              <tr className="border-b border-[var(--color-border)]">
+                <th className="px-4 py-3 text-left mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Category</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Gains</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Losses</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Net</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-b border-[var(--color-border-light)] hover:bg-[var(--color-bg-tertiary)] transition-colors duration-200">
+                <td className="px-4 py-3 mono uppercase text-[11px] tracking-[0.2em] font-semibold text-theme">Short-Term</td>
+                <td className="px-4 py-3 text-right mono tabular-nums text-[var(--color-positive)]">{formatCurrency(data.shortTermGains)}</td>
+                <td className="px-4 py-3 text-right mono tabular-nums text-[var(--color-negative)]">{formatCurrency(data.shortTermLosses)}</td>
+                <td className={`px-4 py-3 text-right mono tabular-nums font-bold ${data.netShortTerm >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}>
+                  {formatCurrency(data.netShortTerm, true)}
+                </td>
+              </tr>
+              <tr className="border-b border-[var(--color-border-light)] hover:bg-[var(--color-bg-tertiary)] transition-colors duration-200">
+                <td className="px-4 py-3 mono uppercase text-[11px] tracking-[0.2em] font-semibold text-theme">Long-Term</td>
+                <td className="px-4 py-3 text-right mono tabular-nums text-[var(--color-positive)]">{formatCurrency(data.longTermGains)}</td>
+                <td className="px-4 py-3 text-right mono tabular-nums text-[var(--color-negative)]">{formatCurrency(data.longTermLosses)}</td>
+                <td className={`px-4 py-3 text-right mono tabular-nums font-bold ${data.netLongTerm >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}>
+                  {formatCurrency(data.netLongTerm, true)}
+                </td>
+              </tr>
+              <tr className="bg-[var(--color-bg-tertiary)]">
+                <td className="px-4 py-3 mono uppercase text-[11px] tracking-[0.2em] font-bold text-theme">Total</td>
+                <td className="px-4 py-3 text-right mono tabular-nums font-bold text-[var(--color-positive)]">{formatCurrency(data.shortTermGains + data.longTermGains)}</td>
+                <td className="px-4 py-3 text-right mono tabular-nums font-bold text-[var(--color-negative)]">{formatCurrency(data.shortTermLosses + data.longTermLosses)}</td>
+                <td className={`px-4 py-3 text-right mono tabular-nums font-bold text-lg ${data.totalRealizedGain >= 0 ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'}`}>
+                  {formatCurrency(data.totalRealizedGain, true)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </ScrollableTable>
+      </section>
     </div>
   );
 }
@@ -280,99 +281,112 @@ function HarvestSection({ opportunities }: { opportunities: HarvestOpportunity[]
     <div className="space-y-4">
       {/* Summary banner */}
       <div
-        className="p-4 rounded-lg flex flex-col sm:flex-row sm:items-center justify-between gap-3 animate-fade-in-up"
-        style={{
-          backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)',
-          borderWidth: '1px',
-          borderStyle: 'solid',
-          borderColor: 'color-mix(in srgb, var(--color-accent) 20%, transparent)',
-          animationDelay: '0ms',
-          animationFillMode: 'both',
-        }}
+        className="glass-slab-floating relative overflow-hidden rounded-xl pl-5 pr-4 py-4 flex flex-col sm:flex-row sm:items-center justify-between gap-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[image:var(--gradient-sovereign)] shadow-[0_18px_60px_-20px_rgba(123,44,255,0.25)] animate-fade-in-up"
+        style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
-        <div className="flex items-center gap-2">
-          <Scissors className="w-5 h-5 text-[var(--color-accent)]" aria-hidden="true" />
+        <div className="flex items-center gap-3">
+          <div
+            className="p-2 rounded-lg shrink-0"
+            style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
+          >
+            <Scissors className="w-5 h-5 text-[var(--color-accent)]" aria-hidden="true" />
+          </div>
           <div>
-            <p className="font-medium text-[var(--color-text)]">{opportunities.length} harvesting opportunities</p>
-            <p className="text-sm text-[var(--color-text-muted)]">Total estimated savings: <span className="font-bold text-[var(--color-accent)] font-mono">{formatCurrency(totalSavings)}</span></p>
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">
+              {opportunities.length} harvesting opportunities
+            </p>
+            <p className="text-sm text-theme-secondary mt-1">
+              Total estimated savings:{' '}
+              <span className="mono tabular-nums font-bold text-[var(--color-accent)]">{formatCurrency(totalSavings)}</span>
+            </p>
           </div>
         </div>
       </div>
 
       {/* Opportunities table */}
-      <div
-        className="animate-fade-in-up"
+      <section
+        className="glass-slab rounded-2xl p-4 sm:p-6 animate-fade-in-up"
         style={{ animationDelay: '50ms', animationFillMode: 'both' }}
       >
-        <Card>
-          <ScrollableTable>
-            <table className="w-full text-sm min-w-[700px]">
-              <thead>
-                <tr className="border-b border-[var(--color-border)]">
-                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Symbol</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Shares</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Cost Basis</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Current</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Loss</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Tax Savings</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Replacements</th>
-                  <th className="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Action</th>
-                </tr>
-              </thead>
-              <tbody>
-                {opportunities.map((opp) => {
-                  const isHarvested = harvested.has(opp.id);
-                  return (
-                    <tr
-                      key={opp.id}
-                      className={`border-b border-[var(--color-border)] last:border-0 transition-all duration-200 ${
-                        isHarvested ? 'opacity-50' : 'hover:bg-[var(--color-bg-secondary)]'
-                      }`}
-                    >
-                      <td className="px-4 py-3">
-                        <div className="flex items-center gap-2">
-                          <span className="font-bold font-mono text-[var(--color-text)]">{opp.symbol}</span>
-                          <span
-                            className={`px-1.5 py-0.5 text-[10px] font-medium rounded text-[var(${opp.holdingPeriod === 'short_term' ? '--color-warning' : '--color-positive'})]`}
-                            style={{ backgroundColor: opp.holdingPeriod === 'short_term' ? 'color-mix(in srgb, var(--color-warning) 10%, transparent)' : 'color-mix(in srgb, var(--color-positive) 10%, transparent)' }}
-                          >
-                            {opp.holdingPeriod === 'short_term' ? 'ST' : 'LT'}
-                          </span>
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-right font-mono text-[var(--color-text)]">{opp.shares}</td>
-                      <td className="px-4 py-3 text-right font-mono text-[var(--color-text)]">${opp.costBasis.toFixed(2)}</td>
-                      <td className="px-4 py-3 text-right font-mono text-[var(--color-text)]">${opp.currentPrice.toFixed(2)}</td>
-                      <td className="px-4 py-3 text-right font-mono text-[var(--color-negative)] font-bold">{formatCurrency(opp.unrealizedLoss, true)}</td>
-                      <td className="px-4 py-3 text-right font-mono text-[var(--color-accent)] font-bold">{formatCurrency(opp.estimatedTaxSavings)}</td>
-                      <td className="px-4 py-3">
-                        <div className="flex flex-wrap gap-1">
-                          {opp.replacements.map((sym) => (
-                            <span key={sym} className="px-2 py-0.5 text-xs font-mono bg-[var(--color-bg-secondary)] text-[var(--color-text-muted)] rounded border border-[var(--color-border)] hover:border-[var(--color-accent)] transition-colors duration-200">
-                              {sym}
-                            </span>
-                          ))}
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-center">
-                        <Button
-                          size="sm"
-                          variant={isHarvested ? 'outline' : 'primary'}
-                          onClick={() => handleHarvest(opp.id)}
-                          disabled={isHarvested}
-                          aria-label={isHarvested ? `${opp.symbol} harvested` : `Harvest ${opp.symbol}`}
+        <ScrollableTable>
+          <table className="w-full text-sm min-w-[700px]">
+            <thead>
+              <tr className="border-b border-[var(--color-border)]">
+                <th className="px-4 py-3 text-left mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Symbol</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Shares</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Cost Basis</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Current</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Loss</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Tax Savings</th>
+                <th className="px-4 py-3 text-left mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Replacements</th>
+                <th className="px-4 py-3 text-center mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {opportunities.map((opp) => {
+                const isHarvested = harvested.has(opp.id);
+                return (
+                  <tr
+                    key={opp.id}
+                    className={`border-b border-[var(--color-border-light)] last:border-0 transition-colors duration-200 ${
+                      isHarvested ? 'opacity-50' : 'hover:bg-[var(--color-bg-tertiary)]'
+                    }`}
+                  >
+                    <td className="px-4 py-3">
+                      <div className="flex items-center gap-2">
+                        <span className="mono uppercase font-bold text-theme">{opp.symbol}</span>
+                        <span
+                          className={`mono text-[10px] tracking-[0.2em] uppercase px-1.5 py-0.5 rounded ${
+                            opp.holdingPeriod === 'short_term'
+                              ? 'text-[var(--color-warning)]'
+                              : 'text-[var(--color-positive)]'
+                          }`}
+                          style={{
+                            backgroundColor:
+                              opp.holdingPeriod === 'short_term'
+                                ? 'color-mix(in srgb, var(--color-warning) 10%, transparent)'
+                                : 'color-mix(in srgb, var(--color-positive) 10%, transparent)',
+                          }}
                         >
-                          {isHarvested ? 'Harvested' : 'Harvest'}
-                        </Button>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </ScrollableTable>
-        </Card>
-      </div>
+                          {opp.holdingPeriod === 'short_term' ? 'ST' : 'LT'}
+                        </span>
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-right mono tabular-nums text-theme">{opp.shares}</td>
+                    <td className="px-4 py-3 text-right mono tabular-nums text-theme">${opp.costBasis.toFixed(2)}</td>
+                    <td className="px-4 py-3 text-right mono tabular-nums text-theme">${opp.currentPrice.toFixed(2)}</td>
+                    <td className="px-4 py-3 text-right mono tabular-nums text-[var(--color-negative)] font-bold">{formatCurrency(opp.unrealizedLoss, true)}</td>
+                    <td className="px-4 py-3 text-right mono tabular-nums text-[var(--color-accent)] font-bold">{formatCurrency(opp.estimatedTaxSavings)}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex flex-wrap gap-1">
+                        {opp.replacements.map((sym) => (
+                          <span
+                            key={sym}
+                            className="mono uppercase px-2 py-0.5 text-[10px] tracking-[0.2em] bg-[var(--color-bg-tertiary)] text-theme-muted rounded border border-[var(--color-border-light)] hover:border-[var(--color-accent)] transition-colors duration-200"
+                          >
+                            {sym}
+                          </span>
+                        ))}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      <Button
+                        size="sm"
+                        variant={isHarvested ? 'outline' : 'primary'}
+                        onClick={() => handleHarvest(opp.id)}
+                        disabled={isHarvested}
+                        aria-label={isHarvested ? `${opp.symbol} harvested` : `Harvest ${opp.symbol}`}
+                      >
+                        {isHarvested ? 'Harvested' : 'Harvest'}
+                      </Button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </ScrollableTable>
+      </section>
     </div>
   );
 }
@@ -391,21 +405,14 @@ function WashSalesSection({ violations }: { violations: WashSaleEntry[] }) {
     <div className="space-y-4">
       {/* Explanation banner */}
       <div
-        className="p-4 rounded-lg animate-fade-in-up"
-        style={{
-          backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)',
-          borderWidth: '1px',
-          borderStyle: 'solid',
-          borderColor: 'color-mix(in srgb, var(--color-warning) 20%, transparent)',
-          animationDelay: '0ms',
-          animationFillMode: 'both',
-        }}
+        className="glass-slab-floating relative overflow-hidden rounded-xl pl-5 pr-4 py-4 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-warning)] shadow-[0_18px_60px_-20px_rgba(245,158,11,0.35)] animate-fade-in-up"
+        style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
         <div className="flex items-start gap-3">
           <Info className="w-5 h-5 text-[var(--color-warning)] flex-shrink-0 mt-0.5" aria-hidden="true" />
           <div>
-            <p className="font-medium text-[var(--color-text)]">What is a Wash Sale?</p>
-            <p className="text-sm text-[var(--color-text-muted)] mt-1">
+            <p className="mono text-[10px] tracking-[0.3em] uppercase font-semibold text-theme">What is a Wash Sale?</p>
+            <p className="text-sm text-theme-secondary mt-1">
               A wash sale occurs when you sell a security at a loss and repurchase the same or a
               &quot;substantially identical&quot; security within 30 days before or after the sale.
               The IRS disallows the loss deduction and adds it to the cost basis of the replacement shares.
@@ -419,94 +426,102 @@ function WashSalesSection({ violations }: { violations: WashSaleEntry[] }) {
         className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 px-1 animate-fade-in-up"
         style={{ animationDelay: '50ms', animationFillMode: 'both' }}
       >
-        <p className="text-sm text-[var(--color-text-muted)]">
-          <strong className="text-[var(--color-text)]">{violations.length}</strong> violations detected &middot;
-          Total disallowed: <span className="font-bold font-mono text-[var(--color-warning)]">{formatCurrency(totalDisallowed)}</span>
+        <p className="text-sm text-theme-secondary">
+          <strong className="mono tabular-nums text-theme">{violations.length}</strong> violations detected &middot;
+          Total disallowed:{' '}
+          <span className="mono tabular-nums font-bold text-[var(--color-warning)]">{formatCurrency(totalDisallowed)}</span>
         </p>
       </div>
 
       {/* Violations */}
-      <div className="space-y-3">
+      <div className="space-y-3 animate-stagger">
         {violations.map((v, index) => {
           const isExpanded = expandedId === v.id;
           return (
-            <div
+            <section
               key={v.id}
-              className="animate-fade-in-up"
+              className="glass-slab rounded-xl p-4 sm:p-6 animate-enter animate-fade-in-up"
               style={{ animationDelay: `${50 * index}ms`, animationFillMode: 'both' }}
             >
-              <Card>
-                <button
-                  className="w-full flex items-center justify-between gap-4 text-left min-h-[44px] hover:shadow-lg transition-shadow duration-200"
-                  onClick={() => setExpandedId(isExpanded ? null : v.id)}
-                  aria-expanded={isExpanded}
-                >
-                  <div className="flex items-center gap-3 min-w-0">
-                    <div
-                      className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
-                      style={{ backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
-                    >
-                      <AlertTriangle className="w-5 h-5 text-[var(--color-warning)]" aria-hidden="true" />
-                    </div>
-                    <div className="min-w-0">
-                      <div className="flex items-center gap-2 flex-wrap">
-                        <span className="font-bold font-mono text-[var(--color-text)]">{v.saleSymbol}</span>
-                        <span className="text-xs text-[var(--color-text-muted)]">{formatDate(v.saleDate)}</span>
-                        <span
-                          className={`px-1.5 py-0.5 text-[10px] font-medium rounded ${
+              <button
+                className="w-full flex items-center justify-between gap-4 text-left min-h-[44px] animate-press"
+                onClick={() => setExpandedId(isExpanded ? null : v.id)}
+                aria-expanded={isExpanded}
+              >
+                <div className="flex items-center gap-3 min-w-0">
+                  <div
+                    className="w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0"
+                    style={{ backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
+                  >
+                    <AlertTriangle className="w-5 h-5 text-[var(--color-warning)]" aria-hidden="true" />
+                  </div>
+                  <div className="min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="mono uppercase font-bold text-theme">{v.saleSymbol}</span>
+                      <span className="mono tabular-nums text-[11px] text-theme-muted">{formatDate(v.saleDate)}</span>
+                      <span
+                        className={`mono uppercase px-1.5 py-0.5 text-[10px] tracking-[0.2em] rounded ${
+                          v.matchType === 'same_ticker'
+                            ? 'text-[var(--color-warning)]'
+                            : 'text-[var(--color-accent)]'
+                        }`}
+                        style={{
+                          backgroundColor:
                             v.matchType === 'same_ticker'
-                              ? 'text-[var(--color-warning)]'
-                              : 'text-[var(--color-accent)]'
-                          }`}
-                          style={{
-                            backgroundColor: v.matchType === 'same_ticker'
                               ? 'color-mix(in srgb, var(--color-warning) 10%, transparent)'
                               : 'color-mix(in srgb, var(--color-accent) 10%, transparent)',
-                          }}
-                        >
-                          {v.matchType === 'same_ticker' ? 'Same Ticker' : 'Substantially Identical'}
-                        </span>
-                      </div>
-                      <p className="text-sm text-[var(--color-text-muted)]">
-                        Sold {v.saleShares} shares at <span className="text-[var(--color-negative)] font-mono">{formatCurrency(v.saleLoss)}</span> loss &middot;
-                        Disallowed: <span className="text-[var(--color-warning)] font-mono font-bold">{formatCurrency(v.disallowedLoss)}</span>
-                      </p>
+                        }}
+                      >
+                        {v.matchType === 'same_ticker' ? 'Same Ticker' : 'Substantially Identical'}
+                      </span>
                     </div>
+                    <p className="text-sm text-theme-secondary mt-1">
+                      Sold <span className="mono tabular-nums">{v.saleShares}</span> shares at{' '}
+                      <span className="mono tabular-nums text-[var(--color-negative)]">{formatCurrency(v.saleLoss)}</span> loss &middot;
+                      Disallowed:{' '}
+                      <span className="mono tabular-nums text-[var(--color-warning)] font-bold">{formatCurrency(v.disallowedLoss)}</span>
+                    </p>
                   </div>
-                  {isExpanded
-                    ? <ChevronUp className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" aria-hidden="true" />
-                    : <ChevronDown className="w-5 h-5 text-[var(--color-text-muted)] flex-shrink-0" aria-hidden="true" />}
-                </button>
+                </div>
+                {isExpanded
+                  ? <ChevronUp className="w-5 h-5 text-theme-muted flex-shrink-0" aria-hidden="true" />
+                  : <ChevronDown className="w-5 h-5 text-theme-muted flex-shrink-0" aria-hidden="true" />}
+              </button>
 
-                {isExpanded && (
-                  <div className="mt-4 pt-4 border-t border-[var(--color-border)] text-sm space-y-2">
-                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                      <div>
-                        <p className="text-[var(--color-text-muted)] text-xs uppercase tracking-wider mb-1">Sale</p>
-                        <p className="text-[var(--color-text)]">
-                          {v.saleShares} shares of <span className="font-mono font-bold">{v.saleSymbol}</span> on {formatDate(v.saleDate)}
-                        </p>
-                        <p className="text-[var(--color-negative)] font-mono">Loss: {formatCurrency(v.saleLoss)}</p>
-                      </div>
-                      <div>
-                        <p className="text-[var(--color-text-muted)] text-xs uppercase tracking-wider mb-1">Replacement Purchase</p>
-                        <p className="text-[var(--color-text)]">
-                          {v.replacementShares} shares of <span className="font-mono font-bold">{v.replacementSymbol}</span> on {formatDate(v.replacementDate)}
-                        </p>
-                        <p className="text-[var(--color-warning)] font-mono">Disallowed: {formatCurrency(v.disallowedLoss)}</p>
-                      </div>
-                    </div>
-                    <div className="p-3 bg-[var(--color-bg-secondary)] rounded-md">
-                      <p className="text-[var(--color-text-muted)]">
-                        <strong className="text-[var(--color-text)]">Impact:</strong> The {formatCurrency(v.disallowedLoss)} loss
-                        cannot be deducted this tax year. It has been added to the cost basis of the {v.replacementShares} replacement
-                        shares of {v.replacementSymbol}, which will reduce your taxable gain when those shares are eventually sold.
+              {isExpanded && (
+                <div className="mt-4 pt-4 border-t border-[var(--color-border-light)] text-sm space-y-3">
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted mb-1">Sale</p>
+                      <p className="text-theme">
+                        <span className="mono tabular-nums">{v.saleShares}</span> shares of{' '}
+                        <span className="mono uppercase font-bold">{v.saleSymbol}</span> on{' '}
+                        <span className="mono tabular-nums">{formatDate(v.saleDate)}</span>
                       </p>
+                      <p className="mono tabular-nums text-[var(--color-negative)] mt-1">Loss: {formatCurrency(v.saleLoss)}</p>
+                    </div>
+                    <div>
+                      <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted mb-1">Replacement Purchase</p>
+                      <p className="text-theme">
+                        <span className="mono tabular-nums">{v.replacementShares}</span> shares of{' '}
+                        <span className="mono uppercase font-bold">{v.replacementSymbol}</span> on{' '}
+                        <span className="mono tabular-nums">{formatDate(v.replacementDate)}</span>
+                      </p>
+                      <p className="mono tabular-nums text-[var(--color-warning)] mt-1">Disallowed: {formatCurrency(v.disallowedLoss)}</p>
                     </div>
                   </div>
-                )}
-              </Card>
-            </div>
+                  <div className="p-3 bg-[var(--color-bg-tertiary)] rounded-md border border-[var(--color-border-light)]">
+                    <p className="text-theme-secondary">
+                      <strong className="text-theme">Impact:</strong>{' '}
+                      The <span className="mono tabular-nums">{formatCurrency(v.disallowedLoss)}</span> loss
+                      cannot be deducted this tax year. It has been added to the cost basis of the{' '}
+                      <span className="mono tabular-nums">{v.replacementShares}</span> replacement
+                      shares of <span className="mono uppercase">{v.replacementSymbol}</span>, which will reduce your taxable gain when those shares are eventually sold.
+                    </p>
+                  </div>
+                </div>
+              )}
+            </section>
           );
         })}
       </div>
@@ -578,106 +593,120 @@ function ReportSection({ rows, summary }: { rows: ReportRow[]; summary: TaxSumma
         style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
         <div>
-          <h3 className="font-medium text-[var(--color-text)]">Annual Tax Report — {summary.taxYear}</h3>
-          <p className="text-sm text-[var(--color-text-muted)]">Form 8949 / Schedule D compatible</p>
+          <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Filing</p>
+          <h3 className="text-sm font-bold text-theme mt-1">Annual Tax Report — <span className="mono tabular-nums">{summary.taxYear}</span></h3>
+          <p className="text-xs text-theme-muted mt-0.5">Form 8949 / Schedule D compatible</p>
         </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            leftIcon={<Download className="w-4 h-4" aria-hidden="true" />}
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
             onClick={() => downloadReport('csv')}
             aria-label="Download report as CSV"
+            className="inline-flex items-center gap-2 px-5 py-3 rounded-sm bg-[image:var(--gradient-sovereign)] text-white mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift shadow-[0_4px_20px_rgba(123,44,255,0.35)] hover:brightness-110 transition-[box-shadow,transform] duration-200"
           >
+            <Download className="w-4 h-4" aria-hidden="true" />
             CSV
-          </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            leftIcon={<ArrowDownToLine className="w-4 h-4" aria-hidden="true" />}
+          </button>
+          <button
+            type="button"
             onClick={() => downloadReport('json')}
             aria-label="Download report as JSON"
+            className="glass-slab inline-flex items-center gap-2 px-5 py-3 rounded-sm text-theme mono text-[10px] font-bold tracking-[0.3em] uppercase animate-press animate-lift hover:border-[var(--color-border-hover)] transition-[border-color,box-shadow] duration-200"
           >
+            <ArrowDownToLine className="w-4 h-4" aria-hidden="true" />
             JSON
-          </Button>
+          </button>
         </div>
       </div>
 
       {/* Transaction table */}
-      <div
-        className="animate-fade-in-up"
+      <section
+        className="glass-slab rounded-2xl p-4 sm:p-6 animate-fade-in-up"
         style={{ animationDelay: '50ms', animationFillMode: 'both' }}
       >
-        <Card>
-          <ScrollableTable>
-            <table className="w-full text-sm min-w-[700px]">
-              <thead>
-                <tr className="border-b border-[var(--color-border)]">
-                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Description</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Acquired</th>
-                  <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Sold</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Proceeds</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Cost Basis</th>
-                  <th className="px-4 py-3 text-center text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Adj</th>
-                  <th className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">Gain/Loss</th>
-                </tr>
-              </thead>
-              <tbody>
-                {visibleRows.map((row, idx) => (
-                  <tr key={idx} className="border-b border-[var(--color-border)] last:border-0 hover:bg-[var(--color-bg-secondary)] transition-all duration-200">
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-2">
-                        <span className="text-[var(--color-text)]">{row.description}</span>
+        <ScrollableTable>
+          <table className="w-full text-sm min-w-[700px]">
+            <thead>
+              <tr className="border-b border-[var(--color-border)]">
+                <th className="px-4 py-3 text-left mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Description</th>
+                <th className="px-4 py-3 text-left mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Acquired</th>
+                <th className="px-4 py-3 text-left mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Sold</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Proceeds</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Cost Basis</th>
+                <th className="px-4 py-3 text-center mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Adj</th>
+                <th className="px-4 py-3 text-right mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Gain/Loss</th>
+              </tr>
+            </thead>
+            <tbody>
+              {visibleRows.map((row, idx) => (
+                <tr
+                  key={idx}
+                  className="border-b border-[var(--color-border-light)] last:border-0 hover:bg-[var(--color-bg-tertiary)] transition-colors duration-200"
+                >
+                  <td className="px-4 py-3">
+                    <div className="flex items-center gap-2">
+                      <span className="text-theme">{row.description}</span>
+                      <span
+                        className={`mono uppercase px-1.5 py-0.5 text-[10px] tracking-[0.2em] rounded ${
+                          row.isShortTerm ? 'text-[var(--color-warning)]' : 'text-[var(--color-positive)]'
+                        }`}
+                        style={{
+                          backgroundColor: row.isShortTerm
+                            ? 'color-mix(in srgb, var(--color-warning) 10%, transparent)'
+                            : 'color-mix(in srgb, var(--color-positive) 10%, transparent)',
+                        }}
+                      >
+                        {row.isShortTerm ? 'ST' : 'LT'}
+                      </span>
+                      {row.adjustmentCode === 'W' && (
                         <span
-                          className={`px-1.5 py-0.5 text-[10px] font-medium rounded text-[var(${row.isShortTerm ? '--color-warning' : '--color-positive'})]`}
-                          style={{ backgroundColor: row.isShortTerm ? 'color-mix(in srgb, var(--color-warning) 10%, transparent)' : 'color-mix(in srgb, var(--color-positive) 10%, transparent)' }}
+                          className="mono uppercase px-1.5 py-0.5 text-[10px] tracking-[0.2em] rounded text-[var(--color-warning)]"
+                          style={{ backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
                         >
-                          {row.isShortTerm ? 'ST' : 'LT'}
+                          W
                         </span>
-                        {row.adjustmentCode === 'W' && (
-                          <span
-                            className="px-1.5 py-0.5 text-[10px] font-medium rounded text-[var(--color-warning)]"
-                            style={{ backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
-                          >
-                            W
-                          </span>
-                        )}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 text-[var(--color-text-muted)] font-mono text-xs">{formatDate(row.dateAcquired)}</td>
-                    <td className="px-4 py-3 text-[var(--color-text-muted)] font-mono text-xs">{formatDate(row.dateSold)}</td>
-                    <td className="px-4 py-3 text-right font-mono text-[var(--color-text)]">{formatCurrency(row.proceeds)}</td>
-                    <td className="px-4 py-3 text-right font-mono text-[var(--color-text)]">{formatCurrency(row.costBasis)}</td>
-                    <td className="px-4 py-3 text-center font-mono">
-                      {row.adjustmentAmount > 0 ? (
-                        <span className="text-[var(--color-warning)]">{formatCurrency(row.adjustmentAmount)}</span>
-                      ) : (
-                        <span className="text-[var(--color-text-muted)]">—</span>
                       )}
-                    </td>
-                    <td className={`px-4 py-3 text-right font-mono font-bold ${
-                      row.gainOrLoss > 0 ? 'text-[var(--color-positive)]' : row.gainOrLoss < 0 ? 'text-[var(--color-negative)]' : 'text-[var(--color-text-muted)]'
-                    }`}>
-                      {formatCurrency(row.gainOrLoss, true)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </ScrollableTable>
+                    </div>
+                  </td>
+                  <td className="px-4 py-3 mono tabular-nums text-xs text-theme-muted">{formatDate(row.dateAcquired)}</td>
+                  <td className="px-4 py-3 mono tabular-nums text-xs text-theme-muted">{formatDate(row.dateSold)}</td>
+                  <td className="px-4 py-3 text-right mono tabular-nums text-theme">{formatCurrency(row.proceeds)}</td>
+                  <td className="px-4 py-3 text-right mono tabular-nums text-theme">{formatCurrency(row.costBasis)}</td>
+                  <td className="px-4 py-3 text-center mono tabular-nums">
+                    {row.adjustmentAmount > 0 ? (
+                      <span className="text-[var(--color-warning)]">{formatCurrency(row.adjustmentAmount)}</span>
+                    ) : (
+                      <span className="text-theme-muted">—</span>
+                    )}
+                  </td>
+                  <td
+                    className={`px-4 py-3 text-right mono tabular-nums font-bold ${
+                      row.gainOrLoss > 0
+                        ? 'text-[var(--color-positive)]'
+                        : row.gainOrLoss < 0
+                          ? 'text-[var(--color-negative)]'
+                          : 'text-theme-muted'
+                    }`}
+                  >
+                    {formatCurrency(row.gainOrLoss, true)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </ScrollableTable>
 
-          {rows.length > 5 && (
-            <div className="mt-4 text-center">
-              <button
-                onClick={() => setShowAll((prev) => !prev)}
-                className="text-sm text-[var(--color-accent)] hover:underline min-h-[44px]"
-              >
-                {showAll ? 'Show less' : `Show all ${rows.length} transactions`}
-              </button>
-            </div>
-          )}
-        </Card>
-      </div>
+        {rows.length > 5 && (
+          <div className="mt-4 text-center">
+            <button
+              onClick={() => setShowAll((prev) => !prev)}
+              className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-accent)] hover:underline min-h-[44px] animate-press"
+            >
+              {showAll ? 'Show less' : `Show all ${rows.length} transactions`}
+            </button>
+          </div>
+        )}
+      </section>
     </div>
   );
 }
@@ -702,20 +731,26 @@ export function Tax() {
         style={{ animationDelay: '0ms', animationFillMode: 'both' }}
       >
         <div>
-          <h1 className="text-2xl lg:text-3xl font-bold text-[var(--color-text)]">Tax Optimization</h1>
-          <p className="text-[var(--color-text-muted)] mt-1">
+          <p className="mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted mb-2">
+            Execution · Tax
+          </p>
+          <h1 className="text-2xl lg:text-3xl font-bold text-theme">
+            <span className="text-gradient-brand">Tax Optimization</span>
+          </h1>
+          <p className="text-sm text-theme-secondary mt-1">
             Harvesting opportunities, wash sale compliance &amp; annual reporting
           </p>
         </div>
-        <div className="flex items-center gap-2 text-sm text-[var(--color-text-muted)]">
-          <DollarSign className="w-4 h-4" aria-hidden="true" />
-          <span>Tax Year <strong className="text-[var(--color-text)]">{MOCK_SUMMARY.taxYear}</strong></span>
+        <div className="glass-slab-floating rounded-xl px-4 py-2.5 flex items-center gap-2">
+          <DollarSign className="w-4 h-4 text-[var(--color-accent)]" aria-hidden="true" />
+          <span className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Tax Year</span>
+          <strong className="mono tabular-nums text-sm font-bold text-theme">{MOCK_SUMMARY.taxYear}</strong>
         </div>
       </div>
 
-      {/* Tab Selector */}
+      {/* Tab Selector — segmented control */}
       <div
-        className="flex gap-1 p-1 bg-[var(--color-bg-secondary)] rounded-lg w-fit overflow-x-auto animate-fade-in-up"
+        className="grid grid-cols-2 sm:grid-cols-4 gap-2 p-1 rounded-lg bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] animate-fade-in-up"
         style={{ animationDelay: '50ms', animationFillMode: 'both' }}
         role="tablist"
         aria-label="Tax dashboard tabs"
@@ -730,10 +765,10 @@ export function Tax() {
               aria-selected={isActive}
               aria-controls={`tabpanel-tax-${tab.id}`}
               onClick={() => setActiveTab(tab.id)}
-              className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium rounded-md transition-all min-h-[44px] whitespace-nowrap ${
+              className={`flex items-center justify-center gap-2 px-3 py-2.5 rounded-md min-h-[44px] mono text-[11px] tracking-[0.2em] uppercase font-semibold animate-press transition-colors duration-200 whitespace-nowrap ${
                 isActive
-                  ? 'bg-[var(--color-bg)] text-[var(--color-text)] shadow-sm'
-                  : 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'
+                  ? 'bg-[var(--color-accent-light)] text-[var(--color-accent)]'
+                  : 'text-theme-secondary hover:text-theme'
               }`}
             >
               <TabIcon className="w-4 h-4" aria-hidden="true" />

--- a/client/src/pages/Trading.tsx
+++ b/client/src/pages/Trading.tsx
@@ -15,7 +15,6 @@ import {
   CheckCircle2,
   X,
 } from 'lucide-react';
-import { Card } from '@/components/shared/Card';
 import { Button } from '@/components/shared/Button';
 import { Badge } from '@/components/shared/Badge';
 import { TradeExecutor } from '@/components/trading/TradeExecutor';
@@ -136,9 +135,17 @@ export default function Trading() {
     <div className="min-h-screen bg-[var(--color-bg)]">
       <div className="max-w-7xl mx-auto px-4 py-8">
         {/* Header */}
-        <div className="mb-8 animate-fade-in-up" style={{ animationFillMode: 'both' }}>
-          <h1 className="text-2xl lg:text-3xl font-bold text-[var(--color-text)]">Trade</h1>
-          <p className="text-[var(--color-text-muted)] mt-1">
+        <div
+          className="mb-8 animate-fade-in-up"
+          style={{ animationFillMode: 'both' }}
+        >
+          <p className="mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-theme-muted mb-2">
+            Execution · Trading
+          </p>
+          <h1 className="text-2xl lg:text-3xl font-bold text-theme">
+            <span className="text-gradient-brand">Trade</span>
+          </h1>
+          <p className="text-sm text-theme-secondary mt-1">
             Execute orders and manage your positions
           </p>
         </div>
@@ -150,16 +157,12 @@ export default function Trading() {
         >
           {!brokerConnected ? (
             <div
-              className="mb-6 p-4 rounded-lg flex items-start gap-3 border"
-              style={{
-                backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)',
-                borderColor: 'color-mix(in srgb, var(--color-warning) 20%, transparent)',
-              }}
+              className="glass-slab-floating relative overflow-hidden mb-6 rounded-xl pl-5 pr-4 py-4 flex items-start gap-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-warning)] shadow-[0_18px_60px_-20px_rgba(245,158,11,0.45)]"
             >
               <AlertTriangle className="w-5 h-5 flex-shrink-0 mt-0.5 text-[var(--color-warning)]" />
               <div className="flex-1">
-                <p className="font-medium text-[var(--color-warning)]">No Broker Connected</p>
-                <p className="text-sm mt-1 text-[var(--color-warning)]" style={{ opacity: 0.8 }}>
+                <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-warning)]">No Broker Connected</p>
+                <p className="text-sm mt-1 text-theme-secondary">
                   Connect your Alpaca account to start trading, or use demo mode to practice.
                 </p>
                 <div className="flex gap-2 mt-3">
@@ -184,21 +187,17 @@ export default function Trading() {
             </div>
           ) : paperTrading ? (
             <div
-              className="mb-6 p-4 rounded-lg flex items-start gap-3 border"
-              style={{
-                backgroundColor: 'color-mix(in srgb, var(--color-info) 10%, transparent)',
-                borderColor: 'color-mix(in srgb, var(--color-info) 20%, transparent)',
-              }}
+              className="glass-slab-floating relative overflow-hidden mb-6 rounded-xl pl-5 pr-4 py-4 flex items-start gap-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[image:var(--gradient-sovereign)] shadow-[0_18px_60px_-20px_rgba(123,44,255,0.45)]"
             >
-              <Info className="w-5 h-5 flex-shrink-0 mt-0.5 text-[var(--color-info)]" />
+              <Info className="w-5 h-5 flex-shrink-0 mt-0.5 text-[var(--color-accent)]" />
               <div className="flex-1">
-                <div className="flex items-center gap-2">
-                  <p className="font-medium text-[var(--color-info)]">Paper Trading Mode</p>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-accent)]">Paper Trading Mode</p>
                   <Badge variant="info">
                     {brokerType === 'alpaca' ? 'Alpaca Paper' : 'Demo'}
                   </Badge>
                 </div>
-                <p className="text-sm mt-1 text-[var(--color-info)]" style={{ opacity: 0.8 }}>
+                <p className="text-sm mt-1 text-theme-secondary">
                   All trades are simulated with virtual money. No real funds will be used.
                 </p>
               </div>
@@ -206,25 +205,22 @@ export default function Trading() {
                 size="sm"
                 variant="ghost"
                 onClick={() => setShowConnectionSettings(true)}
+                aria-label="Open broker connection settings"
               >
                 <Settings className="w-4 h-4" />
               </Button>
             </div>
           ) : (
             <div
-              className="mb-6 p-4 rounded-lg flex items-start gap-3 border"
-              style={{
-                backgroundColor: 'color-mix(in srgb, var(--color-positive) 10%, transparent)',
-                borderColor: 'color-mix(in srgb, var(--color-positive) 20%, transparent)',
-              }}
+              className="glass-slab-floating relative overflow-hidden mb-6 rounded-xl pl-5 pr-4 py-4 flex items-start gap-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-warning)] shadow-[0_18px_60px_-20px_rgba(245,158,11,0.45)]"
             >
-              <Shield className="w-5 h-5 flex-shrink-0 mt-0.5 text-[var(--color-positive)]" />
+              <Shield className="w-5 h-5 flex-shrink-0 mt-0.5 text-[var(--color-warning)]" />
               <div className="flex-1">
-                <div className="flex items-center gap-2">
-                  <p className="font-medium text-[var(--color-positive)]">Live Trading</p>
+                <div className="flex items-center gap-2 flex-wrap">
+                  <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-warning)]">Live Trading</p>
                   <Badge variant="success">Alpaca Live</Badge>
                 </div>
-                <p className="text-sm mt-1 text-[var(--color-positive)]" style={{ opacity: 0.8 }}>
+                <p className="text-sm mt-1 text-theme-secondary">
                   You are connected to live trading. Real funds will be used for trades.
                 </p>
               </div>
@@ -232,6 +228,7 @@ export default function Trading() {
                 size="sm"
                 variant="ghost"
                 onClick={() => setShowConnectionSettings(true)}
+                aria-label="Open broker connection settings"
               >
                 <Settings className="w-4 h-4" />
               </Button>
@@ -260,18 +257,24 @@ export default function Trading() {
           {/* Sidebar */}
           <div className="space-y-6">
             {/* Market Status */}
-            <div
-              className="animate-fade-in-up"
+            <section
+              className="glass-slab rounded-xl p-4 sm:p-6 animate-fade-in-up"
               style={{ animationDelay: '200ms', animationFillMode: 'both' }}
             >
-              <Card className="p-4">
-                <div className="flex items-center gap-2 mb-4">
-                  <Clock className="w-5 h-5 text-[var(--color-accent)]" />
-                  <h3 className="font-semibold text-[var(--color-text)]">Market Status</h3>
+              <div className="flex items-center gap-3 mb-4">
+                <div
+                  className="p-2 rounded-lg shrink-0"
+                  style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
+                >
+                  <Clock className="w-4 h-4 text-[var(--color-accent)]" />
                 </div>
-                <MarketStatusDisplay clock={marketClock} />
-              </Card>
-            </div>
+                <div>
+                  <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Session</p>
+                  <h3 className="text-sm font-bold text-theme">Market Status</h3>
+                </div>
+              </div>
+              <MarketStatusDisplay clock={marketClock} />
+            </section>
 
             {/* Price Chart */}
             {selectedSymbol && (
@@ -287,59 +290,65 @@ export default function Trading() {
             )}
 
             {/* Positions */}
-            <div
-              className="animate-fade-in-up"
+            <section
+              className="glass-slab rounded-xl p-4 sm:p-6 animate-fade-in-up"
               style={{ animationDelay: '250ms', animationFillMode: 'both' }}
             >
-              <Card className="p-4">
-                <div className="flex items-center justify-between mb-4">
-                  <div className="flex items-center gap-2">
-                    <BarChart3 className="w-5 h-5 text-[var(--color-accent)]" />
-                    <h3 className="font-semibold text-[var(--color-text)]">Positions</h3>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => refetchPositions()}
-                    disabled={positionsLoading}
-                    aria-label="Refresh positions"
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-3">
+                  <div
+                    className="p-2 rounded-lg shrink-0"
+                    style={{ backgroundColor: 'color-mix(in srgb, var(--color-accent) 10%, transparent)' }}
                   >
-                    <RefreshCw className={`w-4 h-4 ${positionsLoading ? 'animate-spin' : ''}`} aria-hidden="true" />
-                  </Button>
+                    <BarChart3 className="w-4 h-4 text-[var(--color-accent)]" />
+                  </div>
+                  <div>
+                    <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Holdings</p>
+                    <h3 className="text-sm font-bold text-theme">Positions</h3>
+                  </div>
                 </div>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => refetchPositions()}
+                  disabled={positionsLoading}
+                  aria-label="Refresh positions"
+                >
+                  <RefreshCw className={`w-4 h-4 ${positionsLoading ? 'animate-spin' : ''}`} aria-hidden="true" />
+                </Button>
+              </div>
 
-                {positionsLoading ? (
-                  <div className="py-6 text-center text-[var(--color-text-muted)]">
-                    <RefreshCw className="w-6 h-6 mx-auto mb-2 animate-spin" />
-                    <p className="text-sm">Loading positions...</p>
-                  </div>
-                ) : positions.length === 0 ? (
-                  <div className="py-6 text-center text-[var(--color-text-muted)]">
-                    <Activity className="w-8 h-8 mx-auto mb-2 text-[var(--color-text-muted)]" />
-                    <p>No positions</p>
-                    <p className="text-sm">Place trades to build your portfolio</p>
-                  </div>
-                ) : (
-                  <div className="space-y-2">
-                    {positions.map((position) => (
+              {positionsLoading ? (
+                <div className="py-6 text-center text-theme-muted">
+                  <RefreshCw className="w-6 h-6 mx-auto mb-2 animate-spin" />
+                  <p className="text-sm">Loading positions...</p>
+                </div>
+              ) : positions.length === 0 ? (
+                <div className="py-6 text-center text-theme-muted">
+                  <Activity className="w-8 h-8 mx-auto mb-2 text-theme-muted" />
+                  <p className="text-sm font-semibold">No positions</p>
+                  <p className="text-xs mt-1">Place trades to build your portfolio</p>
+                </div>
+              ) : (
+                <div className="space-y-2 animate-stagger">
+                  {positions.map((position) => {
+                    const isSelected = selectedSymbol === position.symbol;
+                    const isPositive = position.unrealizedPnL >= 0;
+                    return (
                       <button
                         key={position.symbol}
                         onClick={() => setSelectedSymbol(position.symbol)}
-                        className={`w-full p-3 rounded-lg border transition-all duration-200 text-left hover:shadow-lg active:scale-[0.98] ${
-                          selectedSymbol === position.symbol
-                            ? 'border-[var(--color-info)] animate-pulse-subtle'
-                            : 'border-[var(--color-border-light)] hover:border-[var(--color-border)] hover:bg-[var(--color-bg-tertiary)]'
+                        aria-pressed={isSelected}
+                        className={`glass-slab-floating animate-enter w-full p-3 rounded-xl text-left animate-press transition-[border-color,box-shadow] duration-200 relative overflow-hidden ${
+                          isSelected
+                            ? "before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[image:var(--gradient-sovereign)] shadow-[0_4px_20px_rgba(123,44,255,0.18)]"
+                            : 'hover:border-[var(--color-border-hover)]'
                         }`}
-                        style={
-                          selectedSymbol === position.symbol
-                            ? { backgroundColor: 'color-mix(in srgb, var(--color-info) 10%, transparent)' }
-                            : undefined
-                        }
                       >
-                        <div className="flex items-center justify-between">
-                          <div>
-                            <div className="flex items-center gap-2">
-                              <span className="font-semibold text-[var(--color-text)]">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="min-w-0">
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className="mono uppercase font-bold text-theme">
                                 {position.symbol}
                               </span>
                               {position.side === 'long' ? (
@@ -349,69 +358,71 @@ export default function Trading() {
                               )}
                               <Sparkline symbol={position.symbol} />
                             </div>
-                            <p className="text-xs text-[var(--color-text-muted)]">
-                              {position.qty} shares @ ${position.avgEntryPrice.toFixed(2)}
+                            <p className="mono text-[11px] tabular-nums text-theme-muted mt-0.5">
+                              {position.qty} sh @ ${position.avgEntryPrice.toFixed(2)}
                             </p>
                           </div>
                           <div className="text-right">
-                            <p className="font-medium text-[var(--color-text)]">
+                            <p className="mono tabular-nums font-semibold text-theme">
                               ${position.currentPrice.toFixed(2)}
                             </p>
                             <p
-                              className="text-xs"
-                              style={{
-                                color:
-                                  position.unrealizedPnL >= 0
-                                    ? 'var(--color-positive)'
-                                    : 'var(--color-negative)',
-                              }}
+                              className={`mono text-[11px] tabular-nums mt-0.5 ${
+                                isPositive ? 'text-[var(--color-positive)]' : 'text-[var(--color-negative)]'
+                              }`}
                             >
-                              {position.unrealizedPnL >= 0 ? '+' : ''}
+                              {isPositive ? '+' : ''}
                               ${position.unrealizedPnL.toFixed(2)} ({position.unrealizedPnLPercent.toFixed(2)}%)
                             </p>
                           </div>
                         </div>
                       </button>
-                    ))}
-                  </div>
-                )}
-              </Card>
-            </div>
+                    );
+                  })}
+                </div>
+              )}
+            </section>
 
             {/* Trading Tips */}
-            <div
-              className="animate-fade-in-up"
+            <section
+              className="glass-slab rounded-xl p-4 sm:p-6 animate-fade-in-up"
               style={{ animationDelay: '300ms', animationFillMode: 'both' }}
             >
-              <Card className="p-4">
-                <div className="flex items-center gap-2 mb-4">
-                  <AlertTriangle className="w-5 h-5 text-[var(--color-warning)]" />
-                  <h3 className="font-semibold text-[var(--color-text)]">Trading Tips</h3>
+              <div className="flex items-center gap-3 mb-4">
+                <div
+                  className="p-2 rounded-lg shrink-0"
+                  style={{ backgroundColor: 'color-mix(in srgb, var(--color-warning) 10%, transparent)' }}
+                >
+                  <AlertTriangle className="w-4 h-4 text-[var(--color-warning)]" />
                 </div>
-                <ul className="space-y-2 text-sm text-[var(--color-text-secondary)]">
-                  <li className="flex items-start gap-2">
-                    <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
-                    Use limit orders for better price control
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
-                    Preview orders before submission to check estimated costs
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
-                    Check factor exposures before large trades
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
-                    Consider earnings dates for volatile stocks
-                  </li>
-                  <li className="flex items-start gap-2">
-                    <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
-                    Review optimization suggestions regularly
-                  </li>
-                </ul>
-              </Card>
-            </div>
+                <div>
+                  <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Discipline</p>
+                  <h3 className="text-sm font-bold text-theme">Trading Tips</h3>
+                </div>
+              </div>
+              <ul className="space-y-2.5 text-sm text-theme-secondary">
+                <li className="flex items-start gap-2">
+                  <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
+                  Use limit orders for better price control
+                </li>
+                <li className="flex items-start gap-2">
+                  <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
+                  Preview orders before submission to check estimated costs
+                </li>
+                <li className="flex items-start gap-2">
+                  <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
+                  Check factor exposures before large trades
+                </li>
+                <li className="flex items-start gap-2">
+                  <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
+                  Consider earnings dates for volatile stocks
+                </li>
+                <li className="flex items-start gap-2">
+                  <CheckCircle2 className="w-3.5 h-3.5 mt-0.5 flex-shrink-0 text-[var(--color-info)]" />
+                  Review optimization suggestions regularly
+                </li>
+              </ul>
+            </section>
           </div>
         </div>
 
@@ -551,12 +562,12 @@ function MarketStatusDisplay({ clock }: { clock?: { isOpen: boolean; nextOpen: s
             className={`w-3 h-3 rounded-full flex-shrink-0 ${isOpen ? 'animate-pulse-green' : ''}`}
             style={{ backgroundColor: isOpen ? 'var(--color-positive)' : 'var(--color-negative)' }}
           />
-          <span className="font-medium text-[var(--color-text)]">
+          <span className="mono text-[11px] tracking-[0.2em] uppercase font-semibold text-theme">
             Market {clock.isOpen ? 'Open' : 'Closed'}
           </span>
         </div>
         <span
-          className="text-xs font-medium px-2 py-0.5 rounded-full"
+          className="mono text-[10px] tracking-[0.2em] uppercase px-2 py-0.5 rounded-full"
           style={{
             color: barColor,
             backgroundColor: `color-mix(in srgb, ${barColor} 12%, transparent)`,
@@ -568,12 +579,9 @@ function MarketStatusDisplay({ clock }: { clock?: { isOpen: boolean; nextOpen: s
 
       {/* Progress bar */}
       <div>
-        <div
-          className="w-full h-2 rounded-full overflow-hidden"
-          style={{ backgroundColor: 'var(--color-bg-tertiary)' }}
-        >
+        <div className="w-full h-2 rounded-full overflow-hidden bg-[var(--color-bg-tertiary)]">
           <div
-            className="h-full rounded-full transition-all duration-1000"
+            className="h-full rounded-full transition-[width] duration-1000"
             style={{
               width: `${progressPercent}%`,
               background: `linear-gradient(to right, ${barColor}, color-mix(in srgb, ${barColor} 70%, var(--color-accent-secondary)))`,
@@ -581,25 +589,22 @@ function MarketStatusDisplay({ clock }: { clock?: { isOpen: boolean; nextOpen: s
           />
         </div>
         <div className="flex justify-between mt-1">
-          <span className="text-[10px] text-[var(--color-text-muted)]">
+          <span className="mono text-[10px] tabular-nums text-theme-muted">
             {label === 'Pre-Market' ? '4:00 AM' : label === 'Regular Hours' ? '9:30 AM' : label === 'After Hours' ? '4:00 PM' : '—'}
           </span>
-          <span className="text-[10px] text-[var(--color-text-muted)]">
+          <span className="mono text-[10px] tabular-nums text-theme-muted">
             {label === 'Pre-Market' ? '9:30 AM' : label === 'Regular Hours' ? '4:00 PM' : label === 'After Hours' ? '8:00 PM' : '—'}
           </span>
         </div>
       </div>
 
       {/* Countdown */}
-      <div
-        className="flex items-center justify-between p-2 rounded-lg"
-        style={{ backgroundColor: 'var(--color-bg-tertiary)' }}
-      >
-        <span className="text-xs text-[var(--color-text-muted)]">
+      <div className="flex items-center justify-between p-2.5 rounded-lg bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)]">
+        <span className="mono text-[10px] tracking-[0.2em] uppercase text-theme-muted">
           {clock.isOpen ? 'Closes in' : 'Opens in'}
         </span>
         <span
-          className="text-sm font-mono font-semibold tabular-nums"
+          className="mono tabular-nums text-sm font-semibold"
           style={{ color: barColor }}
         >
           {countdown}
@@ -608,18 +613,20 @@ function MarketStatusDisplay({ clock }: { clock?: { isOpen: boolean; nextOpen: s
 
       {/* Next event time */}
       {nextEventDate && (
-        <p className="text-xs text-[var(--color-text-secondary)]">
+        <p className="text-xs text-theme-secondary">
           {clock.isOpen ? 'Closes' : 'Opens'}:{' '}
-          {nextEventDate.toLocaleString('en-US', {
-            weekday: 'short',
-            hour: 'numeric',
-            minute: '2-digit',
-            timeZoneName: 'short',
-          })}
+          <span className="mono tabular-nums">
+            {nextEventDate.toLocaleString('en-US', {
+              weekday: 'short',
+              hour: 'numeric',
+              minute: '2-digit',
+              timeZoneName: 'short',
+            })}
+          </span>
         </p>
       )}
 
-      <p className="text-xs text-[var(--color-text-muted)]">
+      <p className="text-xs text-theme-muted">
         Extended hours trading may be available
       </p>
     </div>
@@ -668,31 +675,35 @@ function ConnectionSettingsModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4 animate-fade-in">
-      <Card className="w-full max-w-lg p-6 animate-scale-in">
+      <div className="glass-slab rounded-2xl p-6 sm:p-8 w-full max-w-lg animate-scale-in">
         <div className="flex items-center justify-between mb-6">
-          <h2 className="text-xl font-semibold text-[var(--color-text)]">Broker Connection</h2>
+          <div>
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted mb-1">Integrations</p>
+            <h2 className="text-lg font-bold text-theme">Broker Connection</h2>
+          </div>
           <button
             onClick={onClose}
-            className="p-2 min-w-[44px] min-h-[44px] flex items-center justify-center hover:bg-[var(--color-bg-secondary)] rounded transition-colors"
+            className="p-2 min-w-[44px] min-h-[44px] flex items-center justify-center hover:bg-[var(--color-bg-tertiary)] rounded animate-press transition-colors duration-200"
+            aria-label="Close broker connection settings"
           >
-            <X className="w-5 h-5 text-[var(--color-text-muted)]" />
+            <X className="w-5 h-5 text-theme-muted" />
           </button>
         </div>
 
         {/* Current Status */}
-        <div className="mb-6 p-4 bg-[var(--color-bg-tertiary)] rounded-lg">
+        <div className="mb-6 glass-slab-floating rounded-xl p-4">
           <div className="flex items-center gap-2 mb-2">
             {isConnected ? (
               <Link2 className="w-5 h-5 text-[var(--color-positive)]" />
             ) : (
-              <Unlink className="w-5 h-5 text-[var(--color-text-muted)]" />
+              <Unlink className="w-5 h-5 text-theme-muted" />
             )}
-            <span className="font-medium text-[var(--color-text)]">
+            <span className="mono text-[10px] tracking-[0.3em] uppercase font-semibold text-theme">
               {isConnected ? 'Connected' : 'Not Connected'}
             </span>
           </div>
           {isConnected && (
-            <p className="text-sm text-[var(--color-text-secondary)]">
+            <p className="text-sm text-theme-secondary">
               Broker: <span className="font-medium capitalize">{currentBroker}</span>
               {isPaperTrading && <Badge variant="info" className="ml-2">Paper</Badge>}
             </p>
@@ -701,76 +712,73 @@ function ConnectionSettingsModal({
 
         {/* Alpaca Connection Form */}
         <div className="space-y-4 mb-6">
-          <h3 className="font-medium text-[var(--color-text)]">Connect Alpaca Account</h3>
-          <p className="text-sm text-[var(--color-text-secondary)]">
+          <div>
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-theme-muted">Alpaca</p>
+            <h3 className="text-sm font-bold text-theme mt-1">Connect Account</h3>
+          </div>
+          <p className="text-sm text-theme-secondary">
             Get your API keys from{' '}
             <a
               href="https://app.alpaca.markets/paper/dashboard/overview"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-[var(--color-info)] hover:underline"
+              className="text-[var(--color-accent)] hover:underline animate-press"
             >
               Alpaca Dashboard
             </a>
           </p>
 
           <div>
-            <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
+            <label htmlFor="alpaca-api-key" className="block text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-2">
               API Key
             </label>
             <input
+              id="alpaca-api-key"
               type="text"
               value={apiKey}
               onChange={(e) => setApiKey(e.target.value)}
               placeholder="PK..."
-              className="w-full px-3 py-2 min-h-[44px] border border-[var(--color-border)] rounded-lg focus:ring-2 focus:ring-[var(--color-info)]"
+              className="block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm"
             />
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-[var(--color-text-secondary)] mb-1">
+            <label htmlFor="alpaca-api-secret" className="block text-[10px] mono tracking-[0.3em] uppercase text-theme-muted mb-2">
               API Secret
             </label>
             <input
+              id="alpaca-api-secret"
               type="password"
               value={apiSecret}
               onChange={(e) => setApiSecret(e.target.value)}
               placeholder="Your secret key"
-              className="w-full px-3 py-2 min-h-[44px] border border-[var(--color-border)] rounded-lg focus:ring-2 focus:ring-[var(--color-info)]"
+              className="block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm"
             />
           </div>
 
-          <label className="flex items-center gap-2 cursor-pointer min-h-[44px]">
+          <label className="flex items-center gap-2 cursor-pointer min-h-[44px] animate-press">
             <input
               type="checkbox"
               checked={paperTrading}
               onChange={(e) => setPaperTrading(e.target.checked)}
-              className="w-5 h-5 rounded border-[var(--color-border)] accent-[var(--color-info)]"
+              className="w-5 h-5 rounded border-[var(--color-border)] accent-[var(--color-accent)]"
             />
-            <span className="text-sm text-[var(--color-text-secondary)]">Paper trading (recommended)</span>
+            <span className="text-sm text-theme-secondary">Paper trading (recommended)</span>
           </label>
 
           {!paperTrading && (
-            <div
-              className="p-3 rounded-lg text-sm"
-              style={{
-                backgroundColor: 'color-mix(in srgb, var(--color-negative) 10%, transparent)',
-                color: 'var(--color-negative)',
-              }}
-            >
-              <strong>Warning:</strong> Live trading uses real money. Only disable paper trading if you understand the risks.
+            <div className="glass-slab-floating relative overflow-hidden rounded-xl p-3 text-sm before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-negative)]">
+              <p className="text-[var(--color-negative)]">
+                <strong>Warning:</strong> Live trading uses real money. Only disable paper trading if you understand the risks.
+              </p>
             </div>
           )}
 
           {connectBroker.isError && (
-            <div
-              className="p-3 rounded-lg text-sm"
-              style={{
-                backgroundColor: 'color-mix(in srgb, var(--color-negative) 10%, transparent)',
-                color: 'var(--color-negative)',
-              }}
-            >
-              {(connectBroker.error as Error)?.message || 'Connection failed. Check your credentials.'}
+            <div className="glass-slab-floating relative overflow-hidden rounded-xl p-3 text-sm before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-negative)]">
+              <p className="text-[var(--color-negative)]">
+                {(connectBroker.error as Error)?.message || 'Connection failed. Check your credentials.'}
+              </p>
             </div>
           )}
 
@@ -785,11 +793,11 @@ function ConnectionSettingsModal({
           </Button>
         </div>
 
-        <hr className="my-6 border-[var(--color-border)]" />
+        <hr className="my-6 border-[var(--color-border-light)]" />
 
         {/* Demo Mode */}
         <div className="text-center">
-          <p className="text-sm text-[var(--color-text-secondary)] mb-3">
+          <p className="text-sm text-theme-secondary mb-3">
             Or try the platform without a broker account
           </p>
           <Button
@@ -800,7 +808,7 @@ function ConnectionSettingsModal({
             Use Demo Mode
           </Button>
         </div>
-      </Card>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
24 files. 5 parallel agents across rounds 4-5. Brings the rest of the app into the metaventionsai family aesthetic that the first PR established for landing/auth/dashboard/sidebar/pricing/settings.

## Slices
- **App chrome** (Header, MockDataBanner, ConnectionStatus): logo lockup tightened, mono kickers everywhere, type-railed status banners matching Toast
- **Dashboard widgets** (PortfolioOverview, EquityCurve, MarketStatusStrip): glass-slab cards, fixed chart heights for CLS, segmented timeframe pills, tabular-nums on every numeric
- **Mobile** (MobileNav, BottomSheet, PullToRefresh, CommandPalette): bottom-tab bar with sovereign top rail, glass-modal sheets with React-state slide-in, sovereign-violet pull indicator, palette with sovereign-bar
- **Intelligence pages** (CVRF, Backtest, ML): family heroes, canonical inputs, sovereign Run CTA, ModelStatusBanner matching Toast
- **Execution pages** (Trading, Options, Earnings, Tax): family heroes, segmented controls, mono uppercase tables, type-railed banners
- **Help + Onboarding** (Help, Social, KeyboardHelpModal, HelpPanel, HelpButton, WelcomeModal, FeatureTour): glass-modal everywhere, sovereign-bar on every modal, animate-stagger on lists

## Test plan
- [x] Build clean — 82 modules, no errors
- [x] tsc --noEmit clean across the whole client
- [x] All agents grep-verified zero `transition-all` on interactive elements + `animate-press` everywhere
- [x] All numeric metrics carry `tabular-nums`
- [x] Shared components (HelpTooltip, OnboardingProvider, ml/cvrf subcomponents) scope-skipped per spec
- [ ] Manual: nav between all pages, confirm no layout shift on load (post-merge)

## Untouched
- `client/src/components/help/HelpTooltip.tsx` — shared with earnings/risk domains
- `client/src/components/onboarding/OnboardingProvider.tsx` — pure context, no visible chrome
- `client/src/components/cvrf/`, `client/src/components/ml/` — out of scope per slice spec