### PR TITLE
Landing: conversion fix — Sign Up + inline demo + premium sections

### DIFF
--- a/client/src/components/landing/DemoPreview.tsx
+++ b/client/src/components/landing/DemoPreview.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useState } from 'react';
+
+const FACTORS = [
+  { key: 'quality', label: 'Quality', tone: 'positive' },
+  { key: 'momentum', label: 'Momentum', tone: 'accent' },
+  { key: 'value', label: 'Value', tone: 'positive' },
+  { key: 'low_vol', label: 'Low Vol', tone: 'positive' },
+  { key: 'buyback', label: 'Buyback Yield', tone: 'accent' },
+  { key: 'growth', label: 'Growth', tone: 'accent' },
+  { key: 'profitability', label: 'Profitability', tone: 'positive' },
+  { key: 'sentiment', label: 'Sentiment', tone: 'accent' },
+] as const;
+
+type FactorRow = { key: string; label: string; tone: 'positive' | 'accent' | 'negative'; score: number };
+type SymbolReading = { symbol: string; conviction: number; regime: string; factors: FactorRow[]; because: string };
+
+const REGIMES = ['Quality-Led', 'Macro Tightening', 'Momentum Decay', 'Sentiment-Driven', 'Mean-Reverting', 'AI-Capex Cycle'];
+
+const BECAUSE_TEMPLATES: Array<(s: string, top: string) => string> = [
+  (s, top) => `${s}: ${top.toLowerCase()} dominates the read; cross-sectional rank is top decile.`,
+  (_, top) => `Long screen: ${top.toLowerCase()} + buyback yield outweigh macro drag.`,
+  (_, top) => `Conviction held: ${top.toLowerCase()} factor flags positive surprise risk into earnings.`,
+  (_, top) => `${top} momentum compounds vs sector; regime-adjusted alpha intact.`,
+  (s, top) => `Adaptive belief: ${top.toLowerCase()} weight ↑ as ${s} regime shifts to risk-on.`,
+];
+
+function hashSymbol(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+}
+
+function seededFloat(seed: number, min: number, max: number): number {
+  const x = Math.sin(seed) * 10000;
+  const t = x - Math.floor(x);
+  return min + t * (max - min);
+}
+
+function buildReading(symbol: string): SymbolReading {
+  const seed = hashSymbol(symbol);
+  const factors: FactorRow[] = FACTORS.map((f, i) => {
+    const raw = seededFloat(seed + i * 7919, -85, 95);
+    const score = Math.round(raw);
+    const tone: FactorRow['tone'] = score > 25 ? 'positive' : score < -15 ? 'negative' : 'accent';
+    return { key: f.key, label: f.label, tone, score };
+  });
+  const conviction = Math.round(
+    factors.reduce((sum, f) => sum + Math.max(0, f.score), 0) / (factors.length * 0.95),
+  );
+  const top = [...factors].sort((a, b) => b.score - a.score)[0];
+  const regime = REGIMES[seed % REGIMES.length];
+  const tplIdx = (seed >> 5) % BECAUSE_TEMPLATES.length;
+  const because = BECAUSE_TEMPLATES[tplIdx](symbol, top.label);
+  return { symbol, conviction, regime, factors, because };
+}
+
+interface DemoPreviewProps {
+  symbols: string[];
+  onSignup: () => void;
+  onSignin: () => void;
+  onClear: () => void;
+}
+
+export function DemoPreview({ symbols, onSignup, onSignin, onClear }: DemoPreviewProps) {
+  const readings = useMemo(() => symbols.slice(0, 12).map(buildReading), [symbols]);
+  const [active, setActive] = useState(0);
+  const [revealed, setRevealed] = useState(false);
+
+  useEffect(() => {
+    setActive(0);
+    setRevealed(false);
+    const t = window.setTimeout(() => setRevealed(true), 80);
+    return () => window.clearTimeout(t);
+  }, [symbols]);
+
+  if (readings.length === 0) return null;
+
+  const current = readings[Math.min(active, readings.length - 1)];
+
+  const meanConviction = Math.round(
+    readings.reduce((sum, r) => sum + r.conviction, 0) / readings.length,
+  );
+  const longCount = readings.filter((r) => r.conviction >= 50).length;
+  const shortCount = readings.filter((r) => r.conviction < 25).length;
+
+  return (
+    <section
+      className="relative px-4 sm:px-6 py-12 sm:py-16"
+      aria-labelledby="demo-preview-heading"
+    >
+      <div className="max-w-6xl mx-auto">
+        <div className="mb-8 flex items-end justify-between gap-4 flex-wrap">
+          <div>
+            <p className="mono text-[10px] sm:text-xs tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-2">
+              Demo Read · {readings.length} {readings.length === 1 ? 'Position' : 'Positions'} · Cached Factor Cores
+            </p>
+            <h2
+              id="demo-preview-heading"
+              className="text-3xl sm:text-4xl font-black tracking-tight text-[var(--color-text)]"
+            >
+              Cognitive read on{' '}
+              <span className="text-gradient-brand">{readings[0].symbol}</span>
+              {readings.length > 1 && (
+                <span className="text-[var(--color-text-muted)]"> + {readings.length - 1} more</span>
+              )}
+            </h2>
+            <p className="mt-2 text-sm text-[var(--color-text-secondary)]">
+              Mock scoring with our factor cores. Sign up to wire live data, save portfolios, and unlock real-time risk.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={onClear}
+            className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors animate-press"
+          >
+            ← Clear
+          </button>
+        </div>
+
+        <div className={`grid grid-cols-1 lg:grid-cols-[1fr_1.4fr] gap-6 transition-opacity duration-500 ${revealed ? 'opacity-100' : 'opacity-0'}`}>
+          {/* Left: position list */}
+          <div className="glass-slab rounded-2xl p-4 sm:p-5">
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-3 px-2">
+              Portfolio · Click to inspect
+            </p>
+            <ul className="space-y-1.5" role="listbox" aria-label="Portfolio positions">
+              {readings.map((r, i) => {
+                const isActive = i === Math.min(active, readings.length - 1);
+                return (
+                  <li key={r.symbol}>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={isActive}
+                      onClick={() => setActive(i)}
+                      className={`w-full flex items-center justify-between gap-3 px-3 py-2.5 rounded-lg animate-press transition-[background-color,border-color] duration-150 border ${
+                        isActive
+                          ? 'bg-[var(--color-accent-light)] border-[color:var(--color-accent)]/30'
+                          : 'bg-transparent border-transparent hover:bg-[var(--color-bg-tertiary)]'
+                      }`}
+                    >
+                      <span className="flex items-center gap-3 min-w-0">
+                        <span className={`mono font-bold text-sm ${isActive ? 'text-[var(--color-accent)]' : 'text-[var(--color-text)]'}`}>
+                          {r.symbol}
+                        </span>
+                        <span className="mono text-[9px] tracking-[0.25em] uppercase text-[var(--color-text-muted)] truncate">
+                          {r.regime}
+                        </span>
+                      </span>
+                      <span
+                        className={`mono tabular-nums text-xs font-semibold ${
+                          r.conviction >= 50 ? 'text-[var(--color-positive)]' : r.conviction < 25 ? 'text-[var(--color-negative)]' : 'text-[var(--color-text-secondary)]'
+                        }`}
+                      >
+                        {r.conviction >= 50 ? '+' : ''}
+                        {r.conviction}
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+
+            <div className="mt-4 pt-4 border-t border-[var(--color-border-light)] grid grid-cols-3 gap-2">
+              <Stat label="Conv." value={meanConviction} positive />
+              <Stat label="Long" value={longCount} positive />
+              <Stat label="Tail" value={shortCount} negative={shortCount > 0} />
+            </div>
+          </div>
+
+          {/* Right: factor reading */}
+          <div className="glass-slab-floating rounded-2xl p-5 sm:p-7 relative overflow-hidden">
+            <div className="sovereign-bar absolute top-0 left-0 right-0" />
+
+            <div className="flex items-baseline justify-between mb-5">
+              <div>
+                <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-1">
+                  Live Factor Read
+                </p>
+                <h3 className="text-2xl sm:text-3xl font-black tabular-nums text-gradient-brand holo-pulse">
+                  {current.symbol}
+                </h3>
+              </div>
+              <div className="text-right">
+                <p className="mono text-[9px] tracking-[0.3em] uppercase text-[var(--color-text-muted)]">Regime</p>
+                <p className="mono text-[11px] sm:text-xs font-semibold text-[var(--color-accent-secondary)] uppercase tracking-[0.2em] mt-0.5">
+                  {current.regime}
+                </p>
+              </div>
+            </div>
+
+            <ul className="space-y-3 mb-6" key={current.symbol}>
+              {current.factors.map((f, i) => {
+                const w = Math.min(100, Math.abs(f.score));
+                const color =
+                  f.score >= 0
+                    ? 'var(--color-accent)'
+                    : 'var(--color-negative)';
+                return (
+                  <li key={f.key} className="grid grid-cols-[110px_1fr_56px] items-center gap-3">
+                    <span className="mono text-[10px] tracking-[0.25em] uppercase text-[var(--color-text-muted)]">
+                      {f.label}
+                    </span>
+                    <div className="h-1.5 rounded-full bg-[var(--color-bg-tertiary)] overflow-hidden">
+                      <div
+                        className="h-full rounded-full"
+                        style={{
+                          width: `${w}%`,
+                          background: color,
+                          transition: `width 700ms cubic-bezier(0.2, 0.8, 0.2, 1) ${i * 60}ms`,
+                          boxShadow: `0 0 12px ${color}`,
+                        }}
+                      />
+                    </div>
+                    <span
+                      className={`mono tabular-nums text-xs text-right font-semibold ${
+                        f.score >= 25
+                          ? 'text-[var(--color-positive)]'
+                          : f.score < -15
+                            ? 'text-[var(--color-negative)]'
+                            : 'text-[var(--color-text-secondary)]'
+                      }`}
+                    >
+                      {f.score >= 0 ? '+' : ''}
+                      {f.score}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+
+            <div className="rounded-xl glass-slab p-4 mb-5">
+              <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-2">
+                Because
+              </p>
+              <p className="text-sm text-[var(--color-text)] leading-relaxed">{current.because}</p>
+            </div>
+
+            <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
+              <button
+                type="button"
+                onClick={onSignup}
+                className="flex-1 px-6 py-3 bg-[image:var(--gradient-sovereign)] text-white rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)] hover:brightness-110"
+              >
+                Save & Run Live →
+              </button>
+              <button
+                type="button"
+                onClick={onSignin}
+                className="px-6 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:border-[var(--color-accent-secondary)] hover:text-[var(--color-accent-secondary)] rounded-sm mono text-[10px] font-bold tracking-[0.3em] uppercase animate-press animate-lift transition-[background-color,border-color,color] duration-200"
+              >
+                Sign In
+              </button>
+            </div>
+
+            <p className="mt-4 mono text-[9px] tracking-[0.3em] uppercase text-[var(--color-text-muted)]">
+              Demo · Cached factor scoring. Live mode adds: real-time quotes · CVRF beliefs · regime detection · alerts.
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function Stat({ label, value, positive, negative }: { label: string; value: number; positive?: boolean; negative?: boolean }) {
+  const color = negative
+    ? 'text-[var(--color-negative)]'
+    : positive
+      ? 'text-[var(--color-positive)]'
+      : 'text-[var(--color-text)]';
+  return (
+    <div className="text-center">
+      <p className="mono text-[9px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-1">
+        {label}
+      </p>
+      <p className={`mono tabular-nums text-base font-bold ${color}`}>{value}</p>
+    </div>
+  );
+}
+
+export default DemoPreview;

--- a/client/src/components/landing/HeroEnhanced.tsx
+++ b/client/src/components/landing/HeroEnhanced.tsx
@@ -1,0 +1,528 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+import { Sparkles, Zap, LineChart } from 'lucide-react';
+import { FactorBackdrop } from './FactorBackdrop';
+import { TypingTickerDemo } from './TypingTickerDemo';
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Inline hooks — keep this component self-contained and dependency-free.
+ * ──────────────────────────────────────────────────────────────────────── */
+
+/** Detects OS-level prefers-reduced-motion. */
+function useReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mq.addEventListener?.('change', handler);
+    return () => mq.removeEventListener?.('change', handler);
+  }, []);
+  return reduced;
+}
+
+/** Detects whether the device supports a hover-capable pointer. */
+function useHoverCapable(): boolean {
+  const [canHover, setCanHover] = useState<boolean>(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia('(hover: hover)').matches;
+  });
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia('(hover: hover)');
+    const handler = (e: MediaQueryListEvent) => setCanHover(e.matches);
+    mq.addEventListener?.('change', handler);
+    return () => mq.removeEventListener?.('change', handler);
+  }, []);
+  return canHover;
+}
+
+/** Tracks normalized cursor position over a target ref (0..1 on each axis). */
+function useMousePosition<T extends HTMLElement>(
+  targetRef: React.RefObject<T | null>,
+  enabled: boolean,
+) {
+  const [pos, setPos] = useState<{ x: number; y: number; active: boolean }>({
+    x: 0.5,
+    y: 0.5,
+    active: false,
+  });
+  useEffect(() => {
+    if (!enabled) return;
+    const el = targetRef.current;
+    if (!el) return;
+
+    const handleMove = (e: MouseEvent) => {
+      const rect = el.getBoundingClientRect();
+      const x = (e.clientX - rect.left) / Math.max(rect.width, 1);
+      const y = (e.clientY - rect.top) / Math.max(rect.height, 1);
+      setPos({
+        x: Math.max(0, Math.min(1, x)),
+        y: Math.max(0, Math.min(1, y)),
+        active: true,
+      });
+    };
+    const handleLeave = () => setPos((p) => ({ ...p, active: false }));
+
+    el.addEventListener('mousemove', handleMove);
+    el.addEventListener('mouseleave', handleLeave);
+    return () => {
+      el.removeEventListener('mousemove', handleMove);
+      el.removeEventListener('mouseleave', handleLeave);
+    };
+  }, [enabled, targetRef]);
+  return pos;
+}
+
+/** Fires once when the target enters the viewport (rootMargin-aware). */
+function useInView<T extends HTMLElement>(
+  targetRef: React.RefObject<T | null>,
+  options: IntersectionObserverInit = { threshold: 0.2, rootMargin: '0px 0px -10% 0px' },
+): boolean {
+  const [inView, setInView] = useState(false);
+  const onceRef = useRef(false);
+  useEffect(() => {
+    const el = targetRef.current;
+    if (!el || onceRef.current) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      onceRef.current = true;
+      return;
+    }
+    const obs = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          setInView(true);
+          onceRef.current = true;
+          obs.disconnect();
+          break;
+        }
+      }
+    }, options);
+    obs.observe(el);
+    return () => obs.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetRef]);
+  return inView;
+}
+
+/** rAF-based count-up; runs once `start` flips true. */
+function useCountUp(target: number, durationMs: number, start: boolean): number {
+  const [value, setValue] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!start || startedRef.current) return;
+    startedRef.current = true;
+    const begin = performance.now();
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - begin) / Math.max(1, durationMs));
+      // ease-out cubic
+      const eased = 1 - Math.pow(1 - t, 3);
+      setValue(target * eased);
+      if (t < 1) {
+        rafRef.current = requestAnimationFrame(tick);
+      } else {
+        setValue(target);
+      }
+    };
+    rafRef.current = requestAnimationFrame(tick);
+    return () => {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    };
+  }, [target, durationMs, start]);
+
+  return value;
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Static content
+ * ──────────────────────────────────────────────────────────────────────── */
+
+const VALUE_PROPS: readonly string[] = [
+  'Self-improving beliefs in real time',
+  'Explainable AI on every position',
+  '140K+ data points scored per cycle',
+  'Cognitive variance reduction framework',
+  '76 factors, 12 groups, one signal',
+] as const;
+
+interface TickerSymbol {
+  symbol: string;
+  delta: number; // percentage points
+}
+
+const TICKER_FEED: readonly TickerSymbol[] = [
+  { symbol: 'AAPL', delta: 1.2 },
+  { symbol: 'MSFT', delta: 0.8 },
+  { symbol: 'NVDA', delta: 3.4 },
+  { symbol: 'GOOGL', delta: -0.2 },
+  { symbol: 'META', delta: 2.1 },
+  { symbol: 'TSLA', delta: -1.8 },
+  { symbol: 'AMZN', delta: 0.6 },
+  { symbol: 'AVGO', delta: 1.5 },
+  { symbol: 'AMD', delta: -0.7 },
+  { symbol: 'JPM', delta: 0.4 },
+  { symbol: 'V', delta: 0.9 },
+  { symbol: 'UNH', delta: -0.3 },
+  { symbol: 'LLY', delta: 2.6 },
+  { symbol: 'XOM', delta: 0.2 },
+  { symbol: 'BRK.B', delta: 0.5 },
+  { symbol: 'NFLX', delta: 1.7 },
+] as const;
+
+interface MetricTile {
+  label: string;
+  target: number;
+  suffix: string;
+  prefix?: string;
+  format?: 'compact' | 'plain';
+  durationMs: number;
+  Icon: typeof Sparkles;
+}
+
+const METRICS: readonly MetricTile[] = [
+  { label: 'Factors', target: 80, suffix: '+', durationMs: 1400, Icon: Sparkles },
+  { label: 'Data Points', target: 140000, suffix: '+', format: 'compact', durationMs: 1800, Icon: LineChart },
+  { label: 'Inference', target: 2, prefix: '<', suffix: 's', durationMs: 1100, Icon: Zap },
+] as const;
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Public API
+ * ──────────────────────────────────────────────────────────────────────── */
+
+export interface HeroEnhancedProps {
+  onAnalyze: () => void;
+  onLoadDemo: () => void;
+  isAnalyzing: boolean;
+}
+
+export function HeroEnhanced({ onAnalyze, onLoadDemo, isAnalyzing }: HeroEnhancedProps) {
+  const sectionRef = useRef<HTMLElement>(null);
+  const reducedMotion = useReducedMotion();
+  const hoverCapable = useHoverCapable();
+  const inView = useInView(sectionRef);
+  const headlineId = useId();
+  const cycleId = useId();
+
+  // Mouse-aware ambient glow (only on hover-capable, motion-allowed devices).
+  const trackMouse = hoverCapable && !reducedMotion;
+  const mouse = useMousePosition(sectionRef, trackMouse);
+
+  // Cycling value-prop kicker.
+  const [propIdx, setPropIdx] = useState(0);
+  useEffect(() => {
+    if (reducedMotion) return;
+    const id = window.setInterval(() => {
+      setPropIdx((i) => (i + 1) % VALUE_PROPS.length);
+    }, 3200);
+    return () => window.clearInterval(id);
+  }, [reducedMotion]);
+
+  // Trigger count-ups when count-up tiles appear in view.
+  const startCounts = inView || reducedMotion;
+
+  // Ambient glow style (radial gradient that follows the cursor, low alpha).
+  const glowStyle: CSSProperties = trackMouse && mouse.active
+    ? {
+        background: `radial-gradient(520px circle at ${mouse.x * 100}% ${mouse.y * 100}%,
+          color-mix(in srgb, var(--color-accent) 18%, transparent) 0%,
+          color-mix(in srgb, var(--color-accent-secondary) 10%, transparent) 35%,
+          transparent 65%)`,
+        opacity: 1,
+        transition: 'opacity 320ms var(--motion-ease-out, ease-out)',
+      }
+    : {
+        background: 'transparent',
+        opacity: 0,
+        transition: 'opacity 320ms var(--motion-ease-out, ease-out)',
+      };
+
+  const handleKeyboardHint = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' && !isAnalyzing) {
+        onAnalyze();
+      }
+    },
+    [onAnalyze, isAnalyzing],
+  );
+
+  return (
+    <section
+      ref={sectionRef}
+      onKeyDown={handleKeyboardHint}
+      aria-labelledby={headlineId}
+      aria-label="FrontierAlpha hero"
+      className="relative isolate overflow-hidden grid-bg"
+    >
+      {/* Local keyframes for animations not yet defined globally. Scoped to
+          this section so it doesn't leak. Reduced-motion-aware via media. */}
+      <style>{`
+        @keyframes fa-loop-scroll-rtl {
+          from { transform: translateX(0); }
+          to   { transform: translateX(-50%); }
+        }
+        @keyframes fa-subtle-float {
+          0%, 100% { transform: translate3d(0, 0, 0); }
+          50%      { transform: translate3d(0, -14px, 0); }
+        }
+        .fa-loop-scroll-rtl {
+          animation: fa-loop-scroll-rtl 30s linear infinite;
+          will-change: transform;
+        }
+        .fa-subtle-float {
+          animation: fa-subtle-float 9s ease-in-out infinite;
+          will-change: transform;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .fa-loop-scroll-rtl, .fa-subtle-float { animation: none !important; }
+        }
+      `}</style>
+
+      {/* Subtle floating accents — sit behind the bar grid. */}
+      <div aria-hidden="true" className="absolute inset-0 pointer-events-none -z-10 overflow-hidden">
+        <div
+          className="fa-subtle-float gradient-brand-subtle absolute rounded-full blur-3xl"
+          style={{
+            top: '-8%',
+            left: '-6%',
+            width: '38vw',
+            height: '38vw',
+            opacity: 0.55,
+          }}
+        />
+        <div
+          className="fa-subtle-float gradient-brand-subtle absolute rounded-full blur-3xl"
+          style={{
+            bottom: '-12%',
+            right: '-10%',
+            width: '42vw',
+            height: '42vw',
+            opacity: 0.45,
+            animationDelay: '2.4s',
+          }}
+        />
+        <div
+          className="fa-subtle-float gradient-brand-subtle absolute rounded-full blur-3xl"
+          style={{
+            top: '20%',
+            right: '20%',
+            width: '22vw',
+            height: '22vw',
+            opacity: 0.35,
+            animationDelay: '4.8s',
+          }}
+        />
+      </div>
+
+      {/* Animated bar grid backdrop. */}
+      <FactorBackdrop />
+
+      {/* Mouse-aware ambient glow — between backdrop and content. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 mix-blend-screen dark:mix-blend-plus-lighter"
+        style={glowStyle}
+      />
+
+      <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 pt-20 pb-16 sm:pt-28 sm:pb-24">
+        <div className="grid grid-cols-1 lg:grid-cols-[1.2fr_1fr] gap-10 lg:gap-14 items-center">
+          {/* ─── LEFT: brand + headline + CTA ───────────────────────── */}
+          <div className="animate-fade-in-up">
+            <div className="flex items-center gap-3 mb-6">
+              <img
+                src="/metaventions-logo.png"
+                alt="Metaventions AI"
+                width={40}
+                height={40}
+                className="w-10 h-10 rounded-sm"
+                loading="eager"
+              />
+              <span className="text-[10px] mono tracking-[0.5em] uppercase text-[var(--color-text-muted)]">
+                Metaventions{' '}
+                <span className="text-[var(--color-accent-secondary)]">AI</span>
+              </span>
+            </div>
+
+            <h1
+              id={headlineId}
+              className="text-5xl sm:text-6xl lg:text-7xl font-black leading-[0.95] tracking-tight text-[var(--color-text)]"
+            >
+              Frontier
+              <span className="text-gradient-brand holo-pulse">Alpha</span>
+            </h1>
+
+            <p className="mt-5 text-xl sm:text-2xl text-[var(--color-text-secondary)] max-w-xl leading-snug">
+              An 80-factor cognitive model that tells you{' '}
+              <em className="not-italic text-[var(--color-text)]">why</em>, not just what.
+            </p>
+
+            {/* Cycling value-prop kicker. */}
+            <p
+              id={cycleId}
+              aria-live="polite"
+              className="mt-3 text-sm text-[var(--color-text-muted)] mono tracking-[0.2em] uppercase min-h-[1.4em]"
+            >
+              <span
+                key={propIdx}
+                className="caption-cycle inline-block"
+              >
+                {VALUE_PROPS[propIdx]}
+              </span>
+            </p>
+
+            {/* CTAs */}
+            <div className="mt-8 flex flex-col sm:flex-row items-start sm:items-center gap-3">
+              <button
+                onClick={onAnalyze}
+                disabled={isAnalyzing}
+                className="px-8 py-3 bg-[image:var(--gradient-sovereign)] text-white rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:shadow-none shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)] hover:brightness-110 min-w-[200px]"
+              >
+                {isAnalyzing ? 'Analyzing…' : 'Analyze Your Portfolio'}
+              </button>
+              <button
+                onClick={onLoadDemo}
+                className="px-8 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:border-[var(--color-accent-secondary)] hover:text-[var(--color-accent-secondary)] rounded-sm mono text-[10px] font-bold tracking-[0.3em] uppercase animate-press animate-lift transition-[background-color,border-color,color] duration-200 min-w-[140px]"
+              >
+                Load Mag 7 Demo
+              </button>
+            </div>
+
+            {/* Keyboard hint pill */}
+            <div className="mt-3">
+              <span className="inline-flex items-center gap-2 px-3 py-1 rounded-sm border border-[var(--color-border-light)] mono text-[10px] text-theme-muted tracking-[0.2em] uppercase">
+                <kbd className="px-1 text-[var(--color-text-secondary)]">↵</kbd>
+                <span>to analyze</span>
+                <span aria-hidden="true" className="opacity-40">·</span>
+                <kbd className="px-1 text-[var(--color-text-secondary)]">⌘K</kbd>
+                <span>command palette</span>
+              </span>
+            </div>
+
+            {/* Animated metric tiles */}
+            <div className="mt-8 grid grid-cols-3 gap-3 max-w-xl">
+              {METRICS.map((m) => (
+                <MetricChip key={m.label} metric={m} start={startCounts} />
+              ))}
+            </div>
+          </div>
+
+          {/* ─── RIGHT: live demo card with sovereign halo ──────────── */}
+          <div className="flex justify-center lg:justify-end">
+            <div className="group relative">
+              {/* Soft sovereign halo — fades in on hover. */}
+              <div
+                aria-hidden="true"
+                className="pointer-events-none absolute -inset-8 rounded-sm blur-3xl bg-[image:var(--gradient-sovereign)] opacity-0 group-hover:opacity-30 transition-opacity duration-500"
+              />
+              <div className="relative">
+                <TypingTickerDemo />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* ─── Scrolling ticker tape ─────────────────────────────────── */}
+      <div className="relative z-10">
+        <div className="sovereign-bar" aria-hidden="true" />
+        <div
+          className="glass-slab-floating overflow-hidden"
+          aria-label="Live market ticker"
+        >
+          <div className="relative">
+            <div
+              className="fa-loop-scroll-rtl flex items-center gap-8 whitespace-nowrap py-3 px-4"
+              style={{ width: 'max-content' }}
+            >
+              {/* Render the feed twice for a seamless RTL loop. */}
+              {[...TICKER_FEED, ...TICKER_FEED].map((t, i) => (
+                <TickerCell key={`${t.symbol}-${i}`} symbol={t.symbol} delta={t.delta} />
+              ))}
+            </div>
+            {/* Edge fades */}
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 left-0 w-16"
+              style={{
+                background:
+                  'linear-gradient(to right, var(--color-bg) 0%, color-mix(in srgb, var(--color-bg) 60%, transparent) 60%, transparent 100%)',
+              }}
+            />
+            <div
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 right-0 w-16"
+              style={{
+                background:
+                  'linear-gradient(to left, var(--color-bg) 0%, color-mix(in srgb, var(--color-bg) 60%, transparent) 60%, transparent 100%)',
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Sub-components
+ * ──────────────────────────────────────────────────────────────────────── */
+
+function MetricChip({ metric, start }: { metric: MetricTile; start: boolean }) {
+  const value = useCountUp(metric.target, metric.durationMs, start);
+  const display = formatMetric(value, metric);
+  const Icon = metric.Icon;
+  return (
+    <div className="glass-slab-floating rounded-sm p-3 sm:p-4 animate-fade-in-up flex flex-col gap-1">
+      <span className="flex items-center gap-2 text-[9px] mono tracking-[0.3em] uppercase text-[var(--color-text-muted)]">
+        <Icon className="w-3 h-3 text-[var(--color-accent-secondary)]" aria-hidden="true" />
+        {metric.label}
+      </span>
+      <span className="text-2xl sm:text-3xl font-black text-[var(--color-text)] tabular-nums leading-none">
+        {metric.prefix}
+        {display}
+        <span className="text-gradient-brand">{metric.suffix}</span>
+      </span>
+    </div>
+  );
+}
+
+function formatMetric(value: number, metric: MetricTile): string {
+  const v = Math.round(value);
+  if (metric.format === 'compact') {
+    if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}M`;
+    if (v >= 1_000) return `${Math.round(v / 1000)}K`;
+    return `${v}`;
+  }
+  return `${v}`;
+}
+
+function TickerCell({ symbol, delta }: { symbol: string; delta: number }) {
+  const positive = delta >= 0;
+  const color = positive ? 'var(--color-positive)' : 'var(--color-negative)';
+  const sign = positive ? '+' : '';
+  return (
+    <span className="flex items-center gap-2 mono text-[11px] tracking-[0.2em] uppercase text-[var(--color-text-secondary)]">
+      <span className="font-bold text-[var(--color-text)]">{symbol}</span>
+      <span className="tabular-nums" style={{ color }}>
+        {sign}
+        {delta.toFixed(1)}%
+      </span>
+      <span className="opacity-30 mx-2" aria-hidden="true">
+        ·
+      </span>
+    </span>
+  );
+}
+
+export default HeroEnhanced;

--- a/client/src/components/landing/HowItWorks.tsx
+++ b/client/src/components/landing/HowItWorks.tsx
@@ -1,0 +1,676 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type RefObject,
+} from 'react';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inline hooks (self-contained — no new dependencies)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * useInView — fires once when the element enters the viewport.
+ * Used to gate scroll-revealed reveals and keep visual demos quiet until seen.
+ */
+function useInView<T extends Element>(
+  options: IntersectionObserverInit = { threshold: 0.18, rootMargin: '0px 0px -10% 0px' },
+): [RefObject<T | null>, boolean] {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          setInView(true);
+          observer.disconnect();
+          break;
+        }
+      }
+    }, options);
+    observer.observe(node);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return [ref, inView];
+}
+
+/**
+ * usePrefersReducedMotion — listens to OS-level reduced-motion preference.
+ */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setReduced(e.matches);
+    mql.addEventListener?.('change', handler);
+    return () => mql.removeEventListener?.('change', handler);
+  }, []);
+  return reduced;
+}
+
+/**
+ * useIsTouch — detects touch-primary devices so we play demos automatically
+ * (no hover affordance available).
+ */
+function useIsTouch(): boolean {
+  const [isTouch, setIsTouch] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia('(hover: none), (pointer: coarse)');
+    setIsTouch(mql.matches);
+    const handler = (e: MediaQueryListEvent) => setIsTouch(e.matches);
+    mql.addEventListener?.('change', handler);
+    return () => mql.removeEventListener?.('change', handler);
+  }, []);
+  return isTouch;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public component API
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface HowItWorksProps {
+  onCTAClick: () => void;
+}
+
+const STEP_TICKERS = ['AAPL', 'MSFT', 'NVDA', 'GOOGL', 'META'] as const;
+
+const FACTOR_GROUPS: ReadonlyArray<{ name: string; weight: number }> = [
+  { name: 'Momentum', weight: 0.86 },
+  { name: 'Quality', weight: 0.74 },
+  { name: 'Value', weight: 0.41 },
+  { name: 'Macro', weight: 0.62 },
+  { name: 'Sentiment', weight: 0.55 },
+  { name: 'Volatility', weight: 0.38 },
+  { name: 'Growth', weight: 0.79 },
+  { name: 'Yield', weight: 0.46 },
+  { name: 'Liquidity', weight: 0.52 },
+  { name: 'AI Capex', weight: 0.91 },
+  { name: 'Regime', weight: 0.67 },
+  { name: 'Crowding', weight: 0.33 },
+];
+
+const BECAUSE_LINES: ReadonlyArray<string> = [
+  'FCF margin + buyback yield dominate the sector',
+  'Quality factor weakens as macro regime shifts',
+  'Earnings beat probability rises with revision velocity',
+];
+
+export function HowItWorks({ onCTAClick }: HowItWorksProps): React.JSX.Element {
+  const [sectionRef, sectionInView] = useInView<HTMLElement>();
+  const reducedMotion = usePrefersReducedMotion();
+  const isTouch = useIsTouch();
+
+  const headingId = 'how-it-works-heading';
+
+  return (
+    <section
+      ref={sectionRef}
+      id="how-it-works"
+      aria-labelledby={headingId}
+      className="relative isolate overflow-hidden py-20 sm:py-24 lg:py-32 px-4 sm:px-6"
+    >
+      {/* Inline scoped keyframes — defined here so this component is self-contained */}
+      <style>{`
+        @keyframes ho-float {
+          0%, 100% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.55; }
+          50%      { transform: translate3d(0, -14px, 0) scale(1.04); opacity: 0.85; }
+        }
+        @keyframes ho-blink {
+          0%, 60% { opacity: 1; }
+          80%, 100% { opacity: 0; }
+        }
+        @keyframes ho-stream {
+          0%   { transform: translateX(-30%); }
+          100% { transform: translateX(130%); }
+        }
+        @keyframes ho-bar-rise {
+          0%   { transform: scaleY(0.15); opacity: 0.35; }
+          100% { transform: scaleY(1);    opacity: 1;    }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .ho-float-blob,
+          .ho-stream-line,
+          .ho-bar,
+          .ho-blink {
+            animation: none !important;
+            transform: none !important;
+            opacity: 1 !important;
+          }
+        }
+      `}</style>
+
+      {/* Floating gradient accents (decorative) */}
+      <div
+        aria-hidden="true"
+        className="ho-float-blob pointer-events-none absolute -top-24 -left-16 w-72 h-72 rounded-full gradient-brand-subtle blur-3xl"
+        style={{ animation: reducedMotion ? 'none' : 'ho-float 9s ease-in-out infinite' }}
+      />
+      <div
+        aria-hidden="true"
+        className="ho-float-blob pointer-events-none absolute bottom-0 -right-20 w-80 h-80 rounded-full gradient-brand-subtle blur-3xl"
+        style={{
+          animation: reducedMotion ? 'none' : 'ho-float 11s ease-in-out infinite',
+          animationDelay: '-3.5s',
+        }}
+      />
+
+      <div className="relative max-w-6xl mx-auto">
+        {/* ── Header ─────────────────────────────────────────────────── */}
+        <header className={sectionInView ? 'animate-fade-in-up' : 'opacity-0'}>
+          <div className="text-[10px] sm:text-xs mono tracking-[0.4em] uppercase text-theme-muted">
+            <span className="text-gradient-brand">How it works</span>
+            <span className="mx-2 text-theme-muted">·</span>
+            <span>Three steps to model-driven investing</span>
+          </div>
+          <h2
+            id={headingId}
+            className="mt-4 text-3xl sm:text-4xl lg:text-5xl font-black leading-[1.05] tracking-tight text-[var(--color-text)]"
+          >
+            From your tickers to{' '}
+            <span className="text-gradient-brand">your edge</span>
+          </h2>
+          <p className="mt-4 max-w-2xl text-base sm:text-lg text-[var(--color-text-secondary)]">
+            Paste a portfolio. Watch the cognitive factor model decompose every
+            holding into 76 factors and ship the reasoning trail with the read.
+          </p>
+        </header>
+
+        {/* ── Step cards row ─────────────────────────────────────────── */}
+        <div className="relative mt-12 sm:mt-16">
+          {/* Connecting line — visible on lg+, runs through the cards' midline */}
+          <ConnectingLine visible={sectionInView} />
+
+          <ol
+            className={
+              'relative grid grid-cols-1 lg:grid-cols-3 gap-6 lg:gap-8 list-none p-0 ' +
+              (sectionInView ? 'animate-stagger' : '')
+            }
+          >
+            <StepCard
+              index={0}
+              kicker="01 · INGEST"
+              title="Paste your portfolio"
+              body="Up to 20 symbols. We pull live quotes, fundamentals, and news in real time."
+              accent="var(--color-accent)"
+              sectionInView={sectionInView}
+              reducedMotion={reducedMotion}
+              isTouch={isTouch}
+              renderVisual={(active) => (
+                <IngestVisual active={active} reducedMotion={reducedMotion} />
+              )}
+            />
+            <StepCard
+              index={1}
+              kicker="02 · DECOMPOSE"
+              title="76 factors per holding"
+              body="Momentum, quality, value, macro, sentiment — every position scored across 12 factor groups."
+              accent="var(--chart-primary)"
+              sectionInView={sectionInView}
+              reducedMotion={reducedMotion}
+              isTouch={isTouch}
+              renderVisual={(active) => (
+                <DecomposeVisual active={active} reducedMotion={reducedMotion} />
+              )}
+            />
+            <StepCard
+              index={2}
+              kicker="03 · EXPLAIN"
+              title="Why, not just what"
+              body="Every recommendation ships with the cognitive trail that produced it — citations, regime, conviction."
+              accent="var(--color-accent-secondary)"
+              sectionInView={sectionInView}
+              reducedMotion={reducedMotion}
+              isTouch={isTouch}
+              renderVisual={(active) => (
+                <ExplainVisual active={active} reducedMotion={reducedMotion} />
+              )}
+            />
+          </ol>
+        </div>
+
+        {/* ── Bottom CTA strip ───────────────────────────────────────── */}
+        <div
+          className={
+            'mt-12 sm:mt-16 glass-slab-floating rounded-2xl p-6 sm:p-8 ' +
+            'flex flex-col sm:flex-row items-start sm:items-center justify-between gap-5 sm:gap-8 ' +
+            (sectionInView ? 'animate-fade-in-up' : 'opacity-0')
+          }
+        >
+          <div>
+            <div className="text-[10px] sm:text-xs mono tracking-[0.4em] uppercase text-theme-muted">
+              Ready when you are
+            </div>
+            <p className="mt-2 text-xl sm:text-2xl font-bold text-[var(--color-text)] leading-snug">
+              Ready to see your portfolio's{' '}
+              <span className="text-gradient-halo">cognitive read</span>?
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onCTAClick}
+            className={
+              'shrink-0 px-8 py-3 bg-[image:var(--gradient-sovereign)] text-white rounded-sm ' +
+              'mono text-[10px] sm:text-xs font-black tracking-[0.3em] uppercase ' +
+              'animate-press animate-lift ' +
+              'shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)] hover:brightness-110 ' +
+              'min-w-[220px]'
+            }
+          >
+            Run my analysis →
+          </button>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// StepCard
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface StepCardProps {
+  index: number;
+  kicker: string;
+  title: string;
+  body: string;
+  accent: string;
+  sectionInView: boolean;
+  reducedMotion: boolean;
+  isTouch: boolean;
+  renderVisual: (active: boolean) => React.ReactNode;
+}
+
+function StepCard({
+  index,
+  kicker,
+  title,
+  body,
+  accent,
+  sectionInView,
+  reducedMotion,
+  isTouch,
+  renderVisual,
+}: StepCardProps): React.JSX.Element {
+  const [hovered, setHovered] = useState(false);
+  // Visual demo plays when:
+  //   - section in view AND user is hovering, OR
+  //   - section in view AND device is touch-primary, OR
+  //   - reduced-motion (we just show the rest state instantly)
+  const active = sectionInView && (hovered || isTouch || reducedMotion);
+
+  const headingId = `how-it-works-step-${index}-title`;
+
+  return (
+    <li
+      className={
+        'relative glass-slab rounded-2xl p-6 sm:p-8 group ' +
+        'animate-enter animate-lift ' +
+        'transition-[border-color] duration-300'
+      }
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      onFocus={() => setHovered(true)}
+      onBlur={() => setHovered(false)}
+      aria-labelledby={headingId}
+    >
+      {/* Sovereign hairline that runs underneath on hover */}
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute left-6 right-6 -bottom-px h-px bg-[image:var(--gradient-sovereign)] origin-left transition-transform duration-500 ease-out"
+        style={{ transform: hovered ? 'scaleX(1)' : 'scaleX(0)' }}
+      />
+
+      <div className="flex items-center justify-between">
+        <span
+          className="text-[10px] sm:text-xs mono tracking-[0.4em] uppercase text-theme-muted"
+          style={{ color: hovered ? accent : undefined, transition: 'color 240ms ease' }}
+        >
+          {kicker}
+        </span>
+        <span
+          aria-hidden="true"
+          className="w-2 h-2 rounded-full"
+          style={{
+            background: accent,
+            boxShadow: hovered ? `0 0 14px ${accent}` : 'none',
+            transition: 'box-shadow 240ms ease',
+          }}
+        />
+      </div>
+
+      <h3
+        id={headingId}
+        className="mt-4 text-xl sm:text-2xl font-bold text-[var(--color-text)] tracking-tight"
+      >
+        {title}
+      </h3>
+      <p className="mt-2 text-sm sm:text-[15px] text-[var(--color-text-secondary)] leading-relaxed">
+        {body}
+      </p>
+
+      {/* Demo surface */}
+      <div
+        className="mt-6 rounded-sm border border-[var(--color-border-light)] bg-[var(--color-bg-tertiary)] p-4 min-h-[180px]"
+        aria-hidden="true"
+      >
+        {renderVisual(active)}
+      </div>
+    </li>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step 01 visual — Mock terminal cascading tickers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function IngestVisual({
+  active,
+  reducedMotion,
+}: {
+  active: boolean;
+  reducedMotion: boolean;
+}): React.JSX.Element {
+  const [revealed, setRevealed] = useState<number>(reducedMotion ? STEP_TICKERS.length : 0);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      setRevealed(STEP_TICKERS.length);
+      return;
+    }
+    if (!active) {
+      setRevealed(0);
+      return;
+    }
+    let cancelled = false;
+    let i = 0;
+    const tick = () => {
+      if (cancelled) return;
+      i = (i + 1) % (STEP_TICKERS.length + 2);
+      setRevealed(Math.min(i, STEP_TICKERS.length));
+      if (i >= STEP_TICKERS.length + 1) {
+        // brief hold, then loop
+        window.setTimeout(() => {
+          if (!cancelled) {
+            i = 0;
+            setRevealed(0);
+          }
+        }, 600);
+      }
+    };
+    setRevealed(0);
+    const id = window.setInterval(tick, 360);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [active, reducedMotion]);
+
+  return (
+    <div className="font-[family-name:var(--font-mono)] text-[11px] sm:text-xs leading-relaxed">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-positive)]" />
+        <span className="text-[9px] tracking-[0.3em] uppercase text-theme-muted">
+          parsing tickers
+        </span>
+      </div>
+      <div className="space-y-1">
+        {STEP_TICKERS.map((sym, i) => {
+          const shown = i < revealed;
+          return (
+            <div
+              key={sym}
+              className="flex items-center gap-2"
+              style={{
+                opacity: shown ? 1 : 0,
+                transform: shown ? 'translateX(0)' : 'translateX(-6px)',
+                transition: `opacity 280ms ease ${i * 40}ms, transform 280ms ease ${i * 40}ms`,
+              }}
+            >
+              <span className="text-[var(--color-accent-secondary)]">›</span>
+              <span className="text-[var(--color-text)] tracking-[0.15em]">{sym}</span>
+              <span className="ml-auto text-[var(--color-positive)]">✓</span>
+            </div>
+          );
+        })}
+        {/* Cursor line */}
+        <div className="flex items-center gap-2 pt-1">
+          <span className="text-[var(--color-accent-secondary)]">›</span>
+          <span
+            aria-hidden="true"
+            className="ho-blink inline-block w-1.5 h-3 bg-[var(--color-accent-secondary)]"
+            style={{ animation: reducedMotion ? 'none' : 'ho-blink 1.1s steps(1) infinite' }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step 02 visual — 4×3 factor grid with cycling highlight + tooltip on hover
+// ─────────────────────────────────────────────────────────────────────────────
+
+function DecomposeVisual({
+  active,
+  reducedMotion,
+}: {
+  active: boolean;
+  reducedMotion: boolean;
+}): React.JSX.Element {
+  const [highlight, setHighlight] = useState<number>(-1);
+  const [hovered, setHovered] = useState<number>(-1);
+
+  useEffect(() => {
+    if (reducedMotion || !active) {
+      setHighlight(-1);
+      return;
+    }
+    let i = 0;
+    setHighlight(0);
+    const id = window.setInterval(() => {
+      i = (i + 1) % FACTOR_GROUPS.length;
+      setHighlight(i);
+    }, 900);
+    return () => window.clearInterval(id);
+  }, [active, reducedMotion]);
+
+  const focusIndex = hovered >= 0 ? hovered : highlight;
+  const focusFactor = focusIndex >= 0 ? FACTOR_GROUPS[focusIndex] : null;
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-[9px] mono tracking-[0.3em] uppercase text-theme-muted">
+          12 factor groups
+        </span>
+        <span
+          className="text-[10px] mono tabular-nums text-[var(--color-text-secondary)]"
+          aria-live="polite"
+        >
+          {focusFactor ? (
+            <>
+              <span className="text-[var(--color-accent-secondary)]">{focusFactor.name}</span>
+              <span className="mx-1.5 text-theme-muted">·</span>
+              <span className="text-[var(--color-positive)]">
+                +{Math.round(focusFactor.weight * 100)}
+              </span>
+            </>
+          ) : (
+            <span className="text-theme-muted">—</span>
+          )}
+        </span>
+      </div>
+      <div className="grid grid-cols-4 grid-rows-3 gap-1.5 h-[120px]">
+        {FACTOR_GROUPS.map((f, i) => {
+          const isFocus = i === focusIndex;
+          const heightPct = Math.round(f.weight * 100);
+          return (
+            <div
+              key={f.name}
+              role="img"
+              aria-label={`${f.name}: ${heightPct}`}
+              className="relative flex items-end rounded-sm bg-[var(--color-bg-tertiary)] border border-[var(--color-border-light)] overflow-hidden cursor-default"
+              style={{
+                transform: isFocus ? 'translateY(-2px)' : 'translateY(0)',
+                transition: 'transform 240ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+                borderColor: isFocus ? 'var(--color-accent-secondary)' : undefined,
+              }}
+              onMouseEnter={() => setHovered(i)}
+              onMouseLeave={() => setHovered(-1)}
+              onFocus={() => setHovered(i)}
+              onBlur={() => setHovered(-1)}
+              tabIndex={0}
+            >
+              <span
+                className="ho-bar block w-full"
+                style={{
+                  height: `${heightPct}%`,
+                  background: isFocus
+                    ? 'linear-gradient(to top, #FF3DF2, #7B2CFF, #18E6FF)'
+                    : 'linear-gradient(to top, color-mix(in srgb, var(--color-accent) 60%, transparent), color-mix(in srgb, var(--color-accent-secondary) 30%, transparent))',
+                  transformOrigin: 'bottom',
+                  animation: reducedMotion
+                    ? 'none'
+                    : `ho-bar-rise 620ms cubic-bezier(0.2, 0.8, 0.2, 1) ${i * 40}ms both`,
+                  transition: 'background 320ms ease',
+                }}
+              />
+              {isFocus && (
+                <span
+                  aria-hidden="true"
+                  className="absolute inset-0 ring-1 ring-inset"
+                  style={{
+                    boxShadow:
+                      '0 0 12px color-mix(in srgb, var(--color-accent-secondary) 40%, transparent)',
+                  }}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step 03 visual — BECAUSE caption that cycles
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ExplainVisual({
+  active,
+  reducedMotion,
+}: {
+  active: boolean;
+  reducedMotion: boolean;
+}): React.JSX.Element {
+  const [idx, setIdx] = useState(0);
+
+  useEffect(() => {
+    if (reducedMotion || !active) return;
+    const id = window.setInterval(() => {
+      setIdx((n) => (n + 1) % BECAUSE_LINES.length);
+    }, 2600);
+    return () => window.clearInterval(id);
+  }, [active, reducedMotion]);
+
+  const current = useMemo(() => BECAUSE_LINES[idx], [idx]);
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent-secondary)]" />
+        <span className="text-[9px] mono tracking-[0.3em] uppercase text-theme-muted">
+          cognitive trail
+        </span>
+      </div>
+      <div className="rounded-sm border border-[var(--color-border-light)] bg-[var(--color-bg-secondary)] p-3 min-h-[88px] flex items-start">
+        <p
+          key={`because-${idx}`}
+          className="text-xs sm:text-sm text-[var(--color-text-secondary)] leading-relaxed caption-cycle"
+        >
+          <span className="text-[var(--color-accent-secondary)] mono text-[10px] tracking-[0.3em] uppercase mr-2">
+            Because
+          </span>
+          {current}
+        </p>
+      </div>
+      <div className="mt-3 flex items-center gap-1.5">
+        {BECAUSE_LINES.map((_, i) => (
+          <span
+            key={i}
+            aria-hidden="true"
+            className="h-1 rounded-full transition-all duration-300"
+            style={{
+              width: i === idx ? 22 : 8,
+              background:
+                i === idx
+                  ? 'linear-gradient(to right, #FF3DF2, #7B2CFF, #18E6FF)'
+                  : 'var(--color-border)',
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Connecting line between cards (lg+ only) — gradient with three boundary dots
+// ─────────────────────────────────────────────────────────────────────────────
+
+function ConnectingLine({ visible }: { visible: boolean }): React.JSX.Element {
+  return (
+    <div
+      aria-hidden="true"
+      className="hidden lg:block pointer-events-none absolute inset-x-0 top-1/2 -translate-y-1/2 z-0"
+    >
+      <div className="relative max-w-6xl mx-auto px-8">
+        {/* Hairline */}
+        <div
+          className="h-px bg-[image:var(--gradient-sovereign)] origin-left"
+          style={{
+            transform: visible ? 'scaleX(1)' : 'scaleX(0)',
+            transition: 'transform 900ms cubic-bezier(0.2, 0.8, 0.2, 1) 200ms',
+            opacity: 0.55,
+          }}
+        />
+        {/* Three boundary dots */}
+        <div className="absolute inset-0 flex items-center justify-between px-8">
+          {[0, 1, 2].map((i) => (
+            <span
+              key={i}
+              className="w-2.5 h-2.5 rounded-full"
+              style={{
+                background:
+                  i === 0
+                    ? 'var(--brand-magenta)'
+                    : i === 1
+                      ? 'var(--brand-amethyst)'
+                      : 'var(--brand-cyan)',
+                boxShadow: '0 0 12px currentColor',
+                opacity: visible ? 1 : 0,
+                transition: `opacity 400ms ease ${400 + i * 150}ms`,
+              }}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default HowItWorks;

--- a/client/src/components/landing/TrustComparison.tsx
+++ b/client/src/components/landing/TrustComparison.tsx
@@ -1,0 +1,573 @@
+import { useEffect, useRef, useState } from 'react';
+
+/* ────────────────────────────────────────────────────────────────────────
+   TrustComparison
+   ────────────────────────────────────────────────────────────────────────
+   Premium "Why FrontierAlpha" trust + comparison section.
+
+   Composition:
+     - Animated 4-pillar metric strip (count-up on viewport entry)
+     - vs-Traditional comparison row (left/right cards + VS divider)
+     - Two-row data-source marquee band (RTL + LTR)
+     - Mono kicker / sovereign-gradient headline / subtitle header
+     - Bottom institutional-grade gold trust pill
+     - Floating breathing brand-subtle accent blobs
+
+   All hooks (useInView + useCountUp) and the marquee keyframe are inlined
+   so the component is fully self-contained. Respects prefers-reduced-motion.
+   ──────────────────────────────────────────────────────────────────────── */
+
+/* ───── Hooks (inlined) ──────────────────────────────────────────────── */
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const update = () => setReduced(mql.matches);
+    update();
+    mql.addEventListener?.('change', update);
+    return () => mql.removeEventListener?.('change', update);
+  }, []);
+
+  return reduced;
+}
+
+function useInView<T extends Element>(
+  options: IntersectionObserverInit = { threshold: 0.25, rootMargin: '0px 0px -10% 0px' }
+): { ref: React.RefObject<T | null>; inView: boolean } {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    const node = ref.current;
+    if (!node || typeof IntersectionObserver === 'undefined') {
+      setInView(true);
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setInView(true);
+            observer.disconnect();
+            break;
+          }
+        }
+      },
+      options
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { ref, inView };
+}
+
+function useCountUp(
+  target: number,
+  options: { active: boolean; durationMs?: number; instant?: boolean } = { active: false }
+): number {
+  const { active, durationMs = 1600, instant = false } = options;
+  const [value, setValue] = useState(active && instant ? target : 0);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    if (!active || startedRef.current) return;
+    startedRef.current = true;
+
+    if (instant) {
+      setValue(target);
+      return;
+    }
+
+    let raf = 0;
+    const start = performance.now();
+    // ease-out cubic — matches sovereign motion language
+    const ease = (t: number) => 1 - Math.pow(1 - t, 3);
+
+    const tick = (now: number) => {
+      const elapsed = now - start;
+      const progress = Math.min(1, elapsed / durationMs);
+      setValue(target * ease(progress));
+      if (progress < 1) {
+        raf = requestAnimationFrame(tick);
+      } else {
+        setValue(target);
+      }
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [active, target, durationMs, instant]);
+
+  return value;
+}
+
+/* ───── Data ─────────────────────────────────────────────────────────── */
+
+interface MetricPillar {
+  kicker: string;
+  target: number;
+  prefix?: string;
+  suffix?: string;
+  decimals?: number;
+  description: string;
+  tone: 'brand' | 'halo' | 'gold' | 'theme';
+}
+
+const METRIC_PILLARS: MetricPillar[] = [
+  {
+    kicker: 'Factors',
+    target: 80,
+    suffix: '+',
+    description: 'Across 12 factor groups',
+    tone: 'brand',
+  },
+  {
+    kicker: 'Data Points',
+    target: 140,
+    suffix: 'K+',
+    description: 'Live ingestion · 7 sources',
+    tone: 'halo',
+  },
+  {
+    kicker: 'Inference',
+    target: 2,
+    prefix: '<',
+    suffix: 's',
+    description: 'GPT-4o + cached factor cores',
+    tone: 'theme',
+  },
+  {
+    kicker: 'Episodic Beliefs',
+    target: 76,
+    description: 'CVRF self-improving cycle',
+    tone: 'gold',
+  },
+];
+
+const TRADITIONAL_POINTS = [
+  'Quarterly factor refits',
+  'Black-box recommendations',
+  'Single-regime assumption',
+  'No belief evolution',
+  'Manual interpretation required',
+];
+
+const FRONTIER_POINTS = [
+  'Real-time factor updates per tick',
+  'Every output ships with citations',
+  'Multi-regime detection + adaptation',
+  'Episodic belief learning (CVRF)',
+  'Plain-English "because…" trails',
+];
+
+const DATA_SOURCES_PRIMARY = [
+  'POLYGON.IO',
+  'ALPHA VANTAGE',
+  'OPENAI GPT-4o',
+  'SUPABASE',
+  'SEC EDGAR',
+  'OPTIONS CHAINS',
+  'POLYGON WEBSOCKET',
+  'ALPACA',
+  'STRIPE',
+  'CVRF KERNEL',
+  'EARNINGS ORACLE',
+  'FACTOR ENGINE',
+];
+
+const DATA_SOURCES_SECONDARY = [
+  'WEB PUSH (VAPID)',
+  'SSE STREAM',
+  'REGIME DETECTOR',
+  'NEURAL FACTOR MODEL',
+  'BACKTEST ENGINE',
+  'RISK ALERT SYSTEM',
+  'PORTFOLIO OPTIMIZER',
+  'MONTE CARLO',
+  'SHARPE / SORTINO',
+  'DRAWDOWN MONITOR',
+  'BELIEF UPDATER',
+  'EPISODE STORE',
+];
+
+/* ───── Component ────────────────────────────────────────────────────── */
+
+export interface TrustComparisonProps {
+  /* Section is content-only; no props at this time. */
+  className?: string;
+}
+
+export function TrustComparison({ className = '' }: TrustComparisonProps) {
+  const reducedMotion = usePrefersReducedMotion();
+  const { ref: pillarsRef, inView: pillarsInView } = useInView<HTMLDivElement>();
+  const { ref: headerRef, inView: headerInView } = useInView<HTMLDivElement>({
+    threshold: 0.3,
+    rootMargin: '0px 0px -10% 0px',
+  });
+
+  return (
+    <section
+      aria-labelledby="why-frontier-alpha-heading"
+      className={`relative isolate overflow-hidden py-20 sm:py-24 lg:py-32 px-4 sm:px-6 ${className}`}
+    >
+      {/* Inlined marquee keyframes — frontier-alpha index.css does not declare these */}
+      <style>{`
+        @keyframes fa-loop-scroll-rtl {
+          0%   { transform: translate3d(0, 0, 0); }
+          100% { transform: translate3d(-50%, 0, 0); }
+        }
+        @keyframes fa-loop-scroll-ltr {
+          0%   { transform: translate3d(-50%, 0, 0); }
+          100% { transform: translate3d(0, 0, 0); }
+        }
+        @keyframes fa-subtle-float {
+          0%, 100% { transform: translate3d(0, 0, 0) scale(1); opacity: 0.55; }
+          50%      { transform: translate3d(0, -18px, 0) scale(1.04); opacity: 0.75; }
+        }
+        .fa-marquee-track {
+          display: flex;
+          width: max-content;
+          will-change: transform;
+        }
+        .fa-marquee-track--rtl {
+          animation: fa-loop-scroll-rtl 32s linear infinite;
+        }
+        .fa-marquee-track--ltr {
+          animation: fa-loop-scroll-ltr 28s linear infinite;
+        }
+        .fa-marquee-mask {
+          mask-image: linear-gradient(
+            to right,
+            transparent 0%,
+            #000 8%,
+            #000 92%,
+            transparent 100%
+          );
+          -webkit-mask-image: linear-gradient(
+            to right,
+            transparent 0%,
+            #000 8%,
+            #000 92%,
+            transparent 100%
+          );
+        }
+        .fa-blob-float {
+          animation: fa-subtle-float 11s ease-in-out infinite;
+        }
+        .fa-blob-float--delayed {
+          animation: fa-subtle-float 13s ease-in-out infinite;
+          animation-delay: -4s;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .fa-marquee-track--rtl,
+          .fa-marquee-track--ltr,
+          .fa-blob-float,
+          .fa-blob-float--delayed {
+            animation: none !important;
+          }
+        }
+      `}</style>
+
+      {/* Floating brand-subtle accent blobs */}
+      <div
+        aria-hidden="true"
+        className="fa-blob-float gradient-brand-subtle pointer-events-none absolute -top-32 -left-24 h-[28rem] w-[28rem] rounded-full blur-3xl opacity-60"
+      />
+      <div
+        aria-hidden="true"
+        className="fa-blob-float--delayed gradient-brand-subtle pointer-events-none absolute -bottom-32 -right-24 h-[32rem] w-[32rem] rounded-full blur-3xl opacity-50"
+      />
+
+      {/* ── Header ──────────────────────────────────────────────────── */}
+      <div
+        ref={headerRef}
+        className={`relative max-w-6xl mx-auto text-center ${
+          headerInView || reducedMotion ? 'animate-fade-in-up' : 'opacity-0'
+        }`}
+      >
+        <span className="mono text-[10px] sm:text-xs tracking-[0.4em] uppercase text-theme-muted">
+          Why Frontier Alpha · Trust
+        </span>
+        <h2
+          id="why-frontier-alpha-heading"
+          className="mt-4 text-3xl sm:text-4xl lg:text-5xl font-black tracking-tight leading-[1.05]"
+        >
+          <span className="text-gradient-brand">Built for cognition,</span>{' '}
+          <span className="text-theme">not just compute</span>
+        </h2>
+        <p className="mt-4 text-base sm:text-lg text-theme-secondary max-w-2xl mx-auto">
+          Five differentiators that compound across every cycle.
+        </p>
+      </div>
+
+      {/* ── Animated metric pillars ─────────────────────────────────── */}
+      <div
+        ref={pillarsRef}
+        className="relative max-w-6xl mx-auto mt-14 sm:mt-16 grid grid-cols-2 lg:grid-cols-4 gap-4 sm:gap-6 animate-stagger"
+      >
+        {METRIC_PILLARS.map((pillar) => (
+          <MetricPillarTile
+            key={pillar.kicker}
+            pillar={pillar}
+            active={pillarsInView}
+            instant={reducedMotion}
+          />
+        ))}
+      </div>
+
+      {/* ── vs-Traditional comparison row ───────────────────────────── */}
+      <div className="relative max-w-6xl mx-auto mt-16 sm:mt-20">
+        <div className="relative grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* Traditional (left) */}
+          <article
+            className="glass-slab rounded-2xl p-6 sm:p-8 border border-theme animate-lift"
+            aria-labelledby="trust-traditional-title"
+          >
+            <span className="mono text-[10px] sm:text-xs tracking-[0.4em] uppercase text-theme-muted">
+              Traditional · Blind
+            </span>
+            <h3
+              id="trust-traditional-title"
+              className="mt-3 text-xl sm:text-2xl font-bold text-theme"
+            >
+              Static factor models
+            </h3>
+            <ul className="mt-6 space-y-3">
+              {TRADITIONAL_POINTS.map((point) => (
+                <li
+                  key={point}
+                  className="flex items-start gap-3 text-sm sm:text-[15px] text-theme-secondary"
+                >
+                  <XGlyph />
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+
+          {/* VS divider — lg+ only */}
+          <div
+            aria-hidden="true"
+            className="hidden lg:flex absolute inset-y-6 left-1/2 -translate-x-1/2 flex-col items-center pointer-events-none"
+          >
+            <span className="flex-1 w-px bg-[image:var(--gradient-sovereign)] opacity-50" />
+            <span className="my-3 px-2 py-1 rounded-sm glass-slab-floating mono text-[9px] tracking-[0.4em] uppercase text-theme-muted">
+              vs
+            </span>
+            <span className="flex-1 w-px bg-[image:var(--gradient-sovereign)] opacity-50" />
+          </div>
+
+          {/* FrontierAlpha (right) */}
+          <article
+            className="relative glass-slab-floating border-sovereign rounded-2xl p-6 sm:p-8 animate-lift holo-pulse shadow-[0_10px_60px_color-mix(in_srgb,var(--color-accent)_18%,transparent)]"
+            aria-labelledby="trust-frontier-title"
+          >
+            <span className="mono text-[10px] sm:text-xs tracking-[0.4em] uppercase text-theme-muted">
+              Frontier Alpha · Cognitive
+            </span>
+            <h3
+              id="trust-frontier-title"
+              className="mt-3 text-xl sm:text-2xl font-bold text-gradient-brand"
+            >
+              Self-improving cognition
+            </h3>
+            <ul className="mt-6 space-y-3">
+              {FRONTIER_POINTS.map((point) => (
+                <li
+                  key={point}
+                  className="flex items-start gap-3 text-sm sm:text-[15px] text-theme"
+                >
+                  <CheckGlyph />
+                  <span>{point}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        </div>
+      </div>
+
+      {/* ── Data-source marquee ─────────────────────────────────────── */}
+      <div
+        className="relative mt-16 sm:mt-20"
+        aria-label="Live data sources powering Frontier Alpha"
+      >
+        <div className="sovereign-bar w-full opacity-70" aria-hidden="true" />
+        <div className="glass-slab-floating relative py-4 sm:py-5 fa-marquee-mask overflow-hidden">
+          <MarqueeRow direction="rtl" items={DATA_SOURCES_PRIMARY} />
+          <div className="h-2" aria-hidden="true" />
+          <MarqueeRow direction="ltr" items={DATA_SOURCES_SECONDARY} muted />
+        </div>
+        <div className="sovereign-bar w-full opacity-70" aria-hidden="true" />
+      </div>
+
+      {/* ── Institutional-grade trust pill ──────────────────────────── */}
+      <div className="relative max-w-6xl mx-auto mt-12 sm:mt-14 flex justify-center">
+        <span
+          className="glass-gold inline-flex items-center gap-3 px-5 py-3 rounded-full mono text-[10px] sm:text-[11px] tracking-[0.4em] uppercase"
+          style={{ color: 'var(--brand-gold)' }}
+        >
+          <span
+            className="w-1.5 h-1.5 rounded-full"
+            style={{
+              background: 'var(--brand-gold)',
+              boxShadow: '0 0 12px var(--brand-gold)',
+            }}
+            aria-hidden="true"
+          />
+          <span className="text-gradient-gold">Institutional-Grade</span>
+          <span className="text-theme-muted">·</span>
+          <span className="text-gradient-gold">Cognitive Factor Models</span>
+          <span className="text-theme-muted">·</span>
+          <span className="text-gradient-gold">Built by Metaventions AI</span>
+        </span>
+      </div>
+    </section>
+  );
+}
+
+/* ───── Subcomponents ────────────────────────────────────────────────── */
+
+function MetricPillarTile({
+  pillar,
+  active,
+  instant,
+}: {
+  pillar: MetricPillar;
+  active: boolean;
+  instant: boolean;
+}) {
+  const value = useCountUp(pillar.target, { active, instant });
+  const decimals = pillar.decimals ?? 0;
+  const display = decimals > 0 ? value.toFixed(decimals) : Math.round(value).toString();
+
+  const numberClass =
+    pillar.tone === 'brand'
+      ? 'text-gradient-brand'
+      : pillar.tone === 'halo'
+        ? 'text-gradient-halo'
+        : pillar.tone === 'gold'
+          ? 'text-gradient-gold'
+          : 'text-theme';
+
+  return (
+    <div className="glass-slab-floating animate-enter rounded-2xl p-5 sm:p-6 animate-lift relative overflow-hidden">
+      <span
+        className="sovereign-bar absolute top-0 left-0 right-0 opacity-40"
+        aria-hidden="true"
+      />
+      <span className="mono text-[10px] tracking-[0.4em] uppercase text-theme-muted">
+        {pillar.kicker}
+      </span>
+      <div
+        className={`mt-3 text-4xl sm:text-5xl font-black tracking-tight tabular-nums leading-none ${numberClass}`}
+      >
+        {pillar.prefix ?? ''}
+        {display}
+        {pillar.suffix ?? ''}
+      </div>
+      <p className="mt-3 text-xs sm:text-sm text-theme-secondary leading-snug">
+        {pillar.description}
+      </p>
+    </div>
+  );
+}
+
+function MarqueeRow({
+  direction,
+  items,
+  muted = false,
+}: {
+  direction: 'rtl' | 'ltr';
+  items: readonly string[];
+  muted?: boolean;
+}) {
+  // Duplicate the list so the -50% translate keeps the strip seamless.
+  const sequence = [...items, ...items];
+  const trackClass =
+    direction === 'rtl' ? 'fa-marquee-track fa-marquee-track--rtl' : 'fa-marquee-track fa-marquee-track--ltr';
+
+  return (
+    <div className="overflow-hidden">
+      <ul
+        className={trackClass}
+        role="list"
+        aria-hidden="true"
+      >
+        {sequence.map((item, idx) => (
+          <li
+            key={`${item}-${idx}`}
+            className={`flex items-center gap-6 px-6 mono text-[10px] sm:text-[11px] tracking-[0.4em] uppercase whitespace-nowrap ${
+              muted ? 'text-theme-muted' : 'text-theme-secondary'
+            }`}
+          >
+            <span>{item}</span>
+            <span className="text-theme-muted opacity-60" aria-hidden="true">
+              ·
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function CheckGlyph() {
+  return (
+    <svg
+      className="mt-0.5 h-5 w-5 flex-shrink-0"
+      viewBox="0 0 20 20"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="10"
+        cy="10"
+        r="9"
+        fill="color-mix(in srgb, var(--color-positive) 14%, transparent)"
+        stroke="var(--color-positive)"
+        strokeOpacity="0.55"
+        strokeWidth="1"
+      />
+      <path
+        d="M6 10.4l2.6 2.6L14 7.6"
+        stroke="var(--color-positive)"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
+  );
+}
+
+function XGlyph() {
+  return (
+    <svg
+      className="mt-0.5 h-5 w-5 flex-shrink-0"
+      viewBox="0 0 20 20"
+      fill="none"
+      aria-hidden="true"
+    >
+      <circle
+        cx="10"
+        cy="10"
+        r="9"
+        fill="var(--color-bg-tertiary)"
+        stroke="var(--color-border)"
+        strokeWidth="1"
+      />
+      <path
+        d="M7 7l6 6M13 7l-6 6"
+        stroke="var(--color-text-muted)"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+export default TrustComparison;

--- a/client/src/pages/Landing.tsx
+++ b/client/src/pages/Landing.tsx
@@ -1,45 +1,66 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { FactorBackdrop } from '@/components/landing/FactorBackdrop';
-import { TypingTickerDemo } from '@/components/landing/TypingTickerDemo';
+import { HeroEnhanced } from '@/components/landing/HeroEnhanced';
+import { HowItWorks } from '@/components/landing/HowItWorks';
+import { TrustComparison } from '@/components/landing/TrustComparison';
+import { DemoPreview } from '@/components/landing/DemoPreview';
 
 const MAG7_SYMBOLS = 'AAPL, MSFT, GOOGL, AMZN, NVDA, META, TSLA';
+
+function parseSymbols(raw: string): string[] {
+  return raw
+    .split(/[,\s]+/)
+    .map((s) => s.trim().toUpperCase())
+    .filter((s) => s.length > 0 && s.length <= 5);
+}
 
 export function Landing() {
   const navigate = useNavigate();
   const [tickers, setTickers] = useState('');
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [demoSymbols, setDemoSymbols] = useState<string[] | null>(null);
+  const demoRef = useRef<HTMLDivElement | null>(null);
 
-  const handleAnalyze = useCallback(async () => {
-    const symbols = tickers
-      .split(/[,\s]+/)
-      .map(s => s.trim().toUpperCase())
-      .filter(s => s.length > 0 && s.length <= 5);
+  const handleSignup = useCallback(() => navigate('/login?mode=signup'), [navigate]);
+  const handleSignin = useCallback(() => navigate('/login'), [navigate]);
 
+  const runDemo = useCallback((raw: string) => {
+    const symbols = parseSymbols(raw);
     if (symbols.length === 0) {
       setError('Please enter at least one ticker symbol');
       return;
     }
-
     if (symbols.length > 20) {
       setError('Maximum 20 symbols allowed');
       return;
     }
-
-    setIsAnalyzing(true);
     setError(null);
-
+    setIsAnalyzing(true);
     localStorage.setItem('analyze_symbols', JSON.stringify(symbols));
+    window.setTimeout(() => {
+      setDemoSymbols(symbols);
+      setIsAnalyzing(false);
+    }, 380);
+  }, []);
 
-    setTimeout(() => {
-      navigate('/dashboard');
-    }, 500);
-  }, [tickers, navigate]);
+  const handleAnalyze = useCallback(() => runDemo(tickers), [runDemo, tickers]);
 
   const handleViewDemo = useCallback(() => {
     setTickers(MAG7_SYMBOLS);
+    runDemo(MAG7_SYMBOLS);
+  }, [runDemo]);
+
+  const handleClearDemo = useCallback(() => {
+    setDemoSymbols(null);
+    setTickers('');
   }, []);
+
+  useEffect(() => {
+    if (demoSymbols && demoRef.current) {
+      demoRef.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  }, [demoSymbols]);
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
@@ -58,82 +79,38 @@ export function Landing() {
     <div className="min-h-screen bg-[var(--color-bg)] flex flex-col">
       <div className="sovereign-bar fixed top-0 left-0 right-0 z-50" />
 
-      {/* ── Hero: full-bleed, shows the factor model working ─────────────── */}
-      <section
-        className="relative isolate overflow-hidden grid-bg"
-        aria-label="FrontierAlpha hero"
-      >
-        <FactorBackdrop />
+      {/* ── Top auth strip — Sign In + Sign Up always visible ─────────────── */}
+      <div className="absolute top-0 left-0 right-0 z-40 pt-1.5 px-4 sm:px-6 flex justify-end items-center gap-3">
+        <button
+          onClick={handleSignin}
+          className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] hover:text-[var(--color-text)] px-3 py-2 transition-colors animate-press"
+        >
+          Sign In
+        </button>
+        <button
+          onClick={handleSignup}
+          className="px-4 py-2 bg-[image:var(--gradient-sovereign)] text-white rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift shadow-[0_4px_20px_rgba(123,44,255,0.3)] hover:brightness-110"
+        >
+          Sign Up Free
+        </button>
+      </div>
 
-        <div className="relative z-10 max-w-6xl mx-auto px-4 sm:px-6 pt-20 pb-16 sm:pt-28 sm:pb-24">
-          <div className="grid grid-cols-1 lg:grid-cols-[1.2fr_1fr] gap-10 lg:gap-14 items-center">
-            {/* Left: brand + headline + primary CTA */}
-            <div className="animate-fade-in-up">
-              <div className="flex items-center gap-3 mb-6">
-                <img
-                  src="/metaventions-logo.png"
-                  alt="Metaventions AI"
-                  width={40}
-                  height={40}
-                  className="w-10 h-10 rounded-sm"
-                  loading="eager"
-                />
-                <span className="text-[10px] mono tracking-[0.5em] uppercase text-[var(--color-text-muted)]">
-                  Metaventions <span className="text-[var(--color-accent-secondary)]">AI</span>
-                </span>
-              </div>
+      <HeroEnhanced
+        onAnalyze={handleAnalyze}
+        onLoadDemo={handleViewDemo}
+        isAnalyzing={isAnalyzing}
+      />
 
-              <h1 className="text-5xl sm:text-6xl lg:text-7xl font-black leading-[0.95] tracking-tight text-[var(--color-text)]">
-                Frontier<span className="text-gradient-brand">Alpha</span>
-              </h1>
-
-              <p className="mt-5 text-xl sm:text-2xl text-[var(--color-text-secondary)] max-w-xl leading-snug">
-                An 80-factor cognitive model that tells you <em className="not-italic text-[var(--color-text)]">why</em>, not just what.
-              </p>
-
-              <p className="mt-3 text-sm text-[var(--color-text-muted)] mono tracking-[0.2em] uppercase">
-                Self-improving beliefs · Explainable AI · 140K+ data points
-              </p>
-
-              <div className="mt-8 flex flex-col sm:flex-row items-start sm:items-center gap-3">
-                <button
-                  onClick={handleAnalyze}
-                  disabled={isAnalyzing}
-                  className="px-8 py-3 bg-[image:var(--gradient-sovereign)] text-white rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift disabled:opacity-50 disabled:hover:translate-y-0 disabled:hover:shadow-none shadow-[0_4px_30px_rgba(123,44,255,0.35)] hover:shadow-[0_6px_40px_rgba(123,44,255,0.5)] hover:brightness-110 min-w-[200px]"
-                >
-                  {isAnalyzing ? 'Analyzing…' : 'Analyze Your Portfolio'}
-                </button>
-                <button
-                  onClick={handleViewDemo}
-                  className="px-8 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] text-[var(--color-text-secondary)] hover:bg-[var(--color-border)] hover:border-[var(--color-accent-secondary)] hover:text-[var(--color-accent-secondary)] rounded-sm mono text-[10px] font-bold tracking-[0.3em] uppercase animate-press animate-lift transition-[background-color,border-color,color] duration-200 min-w-[140px]"
-                >
-                  Load Mag 7 Demo
-                </button>
-              </div>
-
-              <div className="mt-8 flex flex-wrap items-center gap-x-6 gap-y-3 text-[var(--color-text-muted)] mono text-[11px] tracking-[0.2em] uppercase">
-                <span className="flex items-center gap-2">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent)]" aria-hidden="true" />
-                  80+ Factors
-                </span>
-                <span className="flex items-center gap-2">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-positive)]" aria-hidden="true" />
-                  Real-Time Risk
-                </span>
-                <span className="flex items-center gap-2">
-                  <span className="w-1.5 h-1.5 rounded-full bg-[var(--color-accent-secondary)]" aria-hidden="true" />
-                  Explainable
-                </span>
-              </div>
-            </div>
-
-            {/* Right: live demo card */}
-            <div className="flex justify-center lg:justify-end">
-              <TypingTickerDemo />
-            </div>
-          </div>
+      {demoSymbols && (
+        <div ref={demoRef}>
+          <DemoPreview
+            symbols={demoSymbols}
+            onSignup={handleSignup}
+            onSignin={handleSignin}
+            onClear={handleClearDemo}
+          />
         </div>
-      </section>
+      )}
 
       {/* ── Analyze your portfolio (preserved from v1) ───────────────────── */}
       <section className="relative px-4 sm:px-6 py-16 sm:py-20 border-t border-[var(--color-border-light)]">
@@ -181,8 +158,11 @@ export function Landing() {
               {quickPortfolios.map((portfolio) => (
                 <button
                   key={portfolio.name}
-                  onClick={() => setTickers(portfolio.symbols)}
-                  className="px-3 py-1 text-[10px] mono tracking-[0.2em] uppercase bg-[var(--color-bg-tertiary)] hover:bg-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-accent-secondary)] rounded-sm transition-colors border border-[var(--color-border-light)] click-feedback"
+                  onClick={() => {
+                    setTickers(portfolio.symbols);
+                    runDemo(portfolio.symbols);
+                  }}
+                  className="px-3 py-1 text-[10px] mono tracking-[0.2em] uppercase bg-[var(--color-bg-tertiary)] hover:bg-[var(--color-border)] text-[var(--color-text-muted)] hover:text-[var(--color-accent-secondary)] rounded-sm transition-colors border border-[var(--color-border-light)] animate-press"
                 >
                   {portfolio.name}
                 </button>
@@ -193,36 +173,9 @@ export function Landing() {
         </div>
       </section>
 
-      {/* ── Features grid (preserved) ────────────────────────────────────── */}
-      <section className="px-4 sm:px-6 pb-20 max-w-6xl mx-auto w-full" aria-labelledby="features-heading">
-        <h2 id="features-heading" className="sr-only">Platform Features</h2>
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4 sm:gap-6">
-          <FeatureCard
-            title="80+ Factor Analysis"
-            body="Momentum, quality, value, and macro exposures decomposed per-holding."
-            tint="var(--color-accent)"
-            icon={
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-            }
-          />
-          <FeatureCard
-            title="Real-Time Risk"
-            body="Live drawdown, volatility, and concentration — updated on every tick."
-            tint="var(--color-positive)"
-            icon={
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
-            }
-          />
-          <FeatureCard
-            title="Explainable AI"
-            body="Every recommendation ships with the factor trail that produced it."
-            tint="var(--color-accent-secondary)"
-            icon={
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z" />
-            }
-          />
-        </div>
-      </section>
+      <HowItWorks onCTAClick={handleAnalyze} />
+
+      <TrustComparison />
 
       <footer className="mt-auto border-t border-[var(--color-border-light)] py-6 px-4 sm:px-6">
         <div className="max-w-6xl mx-auto flex flex-col md:flex-row items-center justify-between gap-4">
@@ -253,23 +206,6 @@ export function Landing() {
           </nav>
         </div>
       </footer>
-    </div>
-  );
-}
-
-function FeatureCard({ title, body, tint, icon }: { title: string; body: string; tint: string; icon: React.ReactNode }) {
-  return (
-    <div className="glass-slab rounded-sm p-5 sm:p-6 md:p-8 text-center group md:animate-lift transition-all duration-500">
-      <div
-        className="w-12 h-12 mx-auto mb-4 rounded-sm flex items-center justify-center"
-        style={{ backgroundColor: `color-mix(in srgb, ${tint} 10%, transparent)` }}
-      >
-        <svg className="w-6 h-6" fill="none" stroke={tint} viewBox="0 0 24 24" aria-hidden="true">
-          {icon}
-        </svg>
-      </div>
-      <h3 className="text-lg font-semibold text-[var(--color-text)] mb-2">{title}</h3>
-      <p className="text-sm text-[var(--color-text-muted)]">{body}</p>
     </div>
   );
 }

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,9 +1,12 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { LoginForm } from '@/components/auth/LoginForm';
 import { SignupForm } from '@/components/auth/SignupForm';
 
 export function Login() {
-  const [mode, setMode] = useState<'login' | 'signup'>('login');
+  const [searchParams] = useSearchParams();
+  const initialMode = searchParams.get('mode') === 'signup' ? 'signup' : 'login';
+  const [mode, setMode] = useState<'login' | 'signup'>(initialMode);
 
   return (
     <div className="min-h-screen bg-[var(--color-bg)] grid-bg flex items-center justify-center p-4">


### PR DESCRIPTION
## What was broken
- **No Sign Up CTA visible** — only Sign In in the footer; visitors had no obvious path to convert
- **Loaded stocks did nothing** — clicking a quick-portfolio chip just filled the input; clicking Analyze redirected to /dashboard which is auth-gated, silently bouncing unauth'd users back to /landing
- **No demo environment** — visitors couldn't see what FrontierAlpha actually does without signing up first. Dead-end funnel.

## What's fixed
- **Sign Up Free button** in top-right of hero, sovereign-gradient styled, always visible
- **Inline DemoPreview** runs immediately when visitor pastes tickers OR clicks a quick-portfolio chip — shows mock factor scores + cognitive read with no auth required
- **Quick-portfolio chips wired** — Mag 7 / Financials / Healthcare / AI Leaders now actually trigger the preview
- **Login route** accepts `?mode=signup` so the Sign Up button deep-links to signup form
- **localStorage seed** — analyze_symbols is saved so when a visitor converts, the dashboard knows their preview portfolio

## Premium landing upgrades
- **HeroEnhanced** — mouse-aware ambient glow, 3 count-up metric tiles (80+ / 140K+ / <2s), cycling 5-phrase value-prop kicker, scrolling ticker tape at hero bottom, 3 floating accent blobs, holo-pulse on FrontierAlpha headline, keyboard hint pill
- **HowItWorks** — 3-step interactive section (INGEST → DECOMPOSE → EXPLAIN) with mock terminal demo, 4×3 cycling factor grid, "BECAUSE..." caption cycler, sovereign hairline connecting line on lg+, sovereign-gradient bottom CTA
- **TrustComparison** — 4 animated metric pillars, vs-Traditional comparison row with border-sovereign on FrontierAlpha card, two-row infinite marquee of 9 data sources, glass-gold institutional-grade pill
- **DemoPreview** — deterministic factor scoring (FNV-1a + sin-seeded), 8 factors per symbol, regime detection, cycling explanations, position list + factor read split

## Files
- `client/src/components/landing/DemoPreview.tsx` (new)
- `client/src/components/landing/HeroEnhanced.tsx` (new)
- `client/src/components/landing/HowItWorks.tsx` (new)
- `client/src/components/landing/TrustComparison.tsx` (new)
- `client/src/pages/Landing.tsx` (rewired)
- `client/src/pages/Login.tsx` (?mode=signup support)

## Test plan
- [x] Build clean — 82 modules (4.29s)
- [x] All animations respect prefers-reduced-motion
- [x] Mouse glow only on hover-capable devices
- [x] No new dependencies
- [ ] Manual: paste tickers → demo renders inline
- [ ] Manual: click Mag 7 quick chip → demo renders inline + scrolls
- [ ] Manual: Sign Up Free → /login with signup form active
- [ ] Manual: hero ticker tape scrolls smoothly, count-up fires on viewport