### PR TITLE
Landing: cool halo gradient instead of pink-magenta text fill

### DIFF
--- a/client/src/components/landing/DemoPreview.tsx
+++ b/client/src/components/landing/DemoPreview.tsx
@@ -102,7 +102,7 @@ export function DemoPreview({ symbols, onSignup, onSignin, onClear }: DemoPrevie
               className="text-3xl sm:text-4xl font-black tracking-tight text-[var(--color-text)]"
             >
               Cognitive read on{' '}
-              <span className="text-gradient-brand">{readings[0].symbol}</span>
+              <span className="text-gradient-halo">{readings[0].symbol}</span>
               {readings.length > 1 && (
                 <span className="text-[var(--color-text-muted)]"> + {readings.length - 1} more</span>
               )}
@@ -181,7 +181,7 @@ export function DemoPreview({ symbols, onSignup, onSignin, onClear }: DemoPrevie
                 <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-1">
                   Live Factor Read
                 </p>
-                <h3 className="text-2xl sm:text-3xl font-black tabular-nums text-gradient-brand holo-pulse">
+                <h3 className="text-2xl sm:text-3xl font-black tabular-nums text-gradient-halo holo-pulse">
                   {current.symbol}
                 </h3>
               </div>

--- a/client/src/components/landing/HeroEnhanced.tsx
+++ b/client/src/components/landing/HeroEnhanced.tsx
@@ -359,7 +359,7 @@ export function HeroEnhanced({ onAnalyze, onLoadDemo, isAnalyzing }: HeroEnhance
               className="text-5xl sm:text-6xl lg:text-7xl font-black leading-[0.95] tracking-tight text-[var(--color-text)]"
             >
               Frontier
-              <span className="text-gradient-brand holo-pulse">Alpha</span>
+              <span className="text-gradient-halo holo-pulse">Alpha</span>
             </h1>
 
             <p className="mt-5 text-xl sm:text-2xl text-[var(--color-text-secondary)] max-w-xl leading-snug">
@@ -491,7 +491,7 @@ function MetricChip({ metric, start }: { metric: MetricTile; start: boolean }) {
       <span className="text-2xl sm:text-3xl font-black text-[var(--color-text)] tabular-nums leading-none">
         {metric.prefix}
         {display}
-        <span className="text-gradient-brand">{metric.suffix}</span>
+        <span className="text-gradient-halo">{metric.suffix}</span>
       </span>
     </div>
   );

--- a/client/src/components/landing/HowItWorks.tsx
+++ b/client/src/components/landing/HowItWorks.tsx
@@ -171,7 +171,7 @@ export function HowItWorks({ onCTAClick }: HowItWorksProps): React.JSX.Element {
         {/* ── Header ─────────────────────────────────────────────────── */}
         <header className={sectionInView ? 'animate-fade-in-up' : 'opacity-0'}>
           <div className="text-[10px] sm:text-xs mono tracking-[0.4em] uppercase text-theme-muted">
-            <span className="text-gradient-brand">How it works</span>
+            <span className="text-gradient-halo">How it works</span>
             <span className="mx-2 text-theme-muted">·</span>
             <span>Three steps to model-driven investing</span>
           </div>
@@ -180,7 +180,7 @@ export function HowItWorks({ onCTAClick }: HowItWorksProps): React.JSX.Element {
             className="mt-4 text-3xl sm:text-4xl lg:text-5xl font-black leading-[1.05] tracking-tight text-[var(--color-text)]"
           >
             From your tickers to{' '}
-            <span className="text-gradient-brand">your edge</span>
+            <span className="text-gradient-halo">your edge</span>
           </h2>
           <p className="mt-4 max-w-2xl text-base sm:text-lg text-[var(--color-text-secondary)]">
             Paste a portfolio. Watch the cognitive factor model decompose every

--- a/client/src/components/landing/TrustComparison.tsx
+++ b/client/src/components/landing/TrustComparison.tsx
@@ -296,7 +296,7 @@ export function TrustComparison({ className = '' }: TrustComparisonProps) {
           id="why-frontier-alpha-heading"
           className="mt-4 text-3xl sm:text-4xl lg:text-5xl font-black tracking-tight leading-[1.05]"
         >
-          <span className="text-gradient-brand">Built for cognition,</span>{' '}
+          <span className="text-gradient-halo">Built for cognition,</span>{' '}
           <span className="text-theme">not just compute</span>
         </h2>
         <p className="mt-4 text-base sm:text-lg text-theme-secondary max-w-2xl mx-auto">
@@ -371,7 +371,7 @@ export function TrustComparison({ className = '' }: TrustComparisonProps) {
             </span>
             <h3
               id="trust-frontier-title"
-              className="mt-3 text-xl sm:text-2xl font-bold text-gradient-brand"
+              className="mt-3 text-xl sm:text-2xl font-bold text-gradient-halo"
             >
               Self-improving cognition
             </h3>
@@ -446,7 +446,7 @@ function MetricPillarTile({
 
   const numberClass =
     pillar.tone === 'brand'
-      ? 'text-gradient-brand'
+      ? 'text-gradient-halo'
       : pillar.tone === 'halo'
         ? 'text-gradient-halo'
         : pillar.tone === 'gold'

--- a/client/src/components/landing/TypingTickerDemo.tsx
+++ b/client/src/components/landing/TypingTickerDemo.tsx
@@ -109,7 +109,7 @@ export function TypingTickerDemo() {
 
       <div className="flex items-baseline gap-2 mb-5 min-h-[44px]">
         <span
-          className="text-3xl sm:text-4xl font-black tracking-tight text-gradient-brand holo-pulse"
+          className="text-3xl sm:text-4xl font-black tracking-tight text-gradient-halo holo-pulse"
           style={{ letterSpacing: '-0.02em' }}
         >
           {typed || ' '}

--- a/client/src/lib/supabase.ts
+++ b/client/src/lib/supabase.ts
@@ -1,20 +1,12 @@
 import { createClient, type SupabaseClient, type Session, type User } from '@supabase/supabase-js';
 
-// Production fallback values match the Vercel project. Once VITE_SUPABASE_URL +
-// VITE_SUPABASE_ANON_KEY are set on Vercel (see scripts/wire-production-env.sh),
-// these fallbacks become unreachable and can be deleted.
-const FALLBACK_URL = 'https://rqidgeittsjkpkykmdrz.supabase.co';
-const FALLBACK_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJxaWRnZWl0dHNqa3BreWttZHJ6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3Njc2ODYzMzAsImV4cCI6MjA4MzI2MjMzMH0.dIXoXR_sjm6bn3hDpZoZJaqRh6PRFU7RAfTPg--WWDo';
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL || FALLBACK_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || FALLBACK_ANON_KEY;
-
-if (!import.meta.env.VITE_SUPABASE_URL || !import.meta.env.VITE_SUPABASE_ANON_KEY) {
-  // eslint-disable-next-line no-console
-  console.warn(
-    '[supabase] VITE_SUPABASE_URL / VITE_SUPABASE_ANON_KEY not set in env — ' +
-      'using hardcoded fallback. Run scripts/wire-production-env.sh on Vercel and redeploy ' +
-      'so this code path is no longer reached.',
+if (!supabaseUrl || !supabaseAnonKey) {
+  throw new Error(
+    '[supabase] Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY. ' +
+      'Set both in your Vercel project env (production + preview) — see scripts/wire-production-env.sh.',
   );
 }
 


### PR DESCRIPTION
## Why
User feedback: pink→blue text gradient on landing wasn't visually pleasing.

## What
Swapped \`text-gradient-brand\` (magenta→amethyst→cyan) → \`text-gradient-halo\` (teal→cyan→holo-blue) on all 5 landing-only files. Sovereign-spectrum bars, rails, and CTA button backgrounds stay — those are decorative brand elements, not text.

## Plus
Removed the hardcoded Supabase fallback in \`lib/supabase.ts\` now that VITE_SUPABASE_URL/ANON_KEY are wired on Vercel production. Throws hard on missing env instead.