### PR TITLE
backend: wire DeepSeek V4 as primary LLM for cognitive explainer

### DIFF
--- a/scripts/wire-deepseek.sh
+++ b/scripts/wire-deepseek.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Wire DeepSeek V4 (or V3) to Frontier Alpha's cognitive explainer on Vercel.
+#
+# Reads DEEPSEEK_API_KEY from ~/.api_keys (the same place `cdc` reads from)
+# and adds it as a production env var on Vercel. After this runs, the
+# ExplanationService will use DeepSeek instead of template fallback.
+#
+# Usage:
+#   bash scripts/wire-deepseek.sh           # add (errors if already set)
+#   bash scripts/wire-deepseek.sh --force   # overwrite
+
+set -euo pipefail
+
+KEYS_FILE="$HOME/.api_keys"
+[[ -f "$KEYS_FILE" ]] || { echo "✗ $KEYS_FILE not found"; exit 1; }
+
+# Parse only DEEPSEEK_API_KEY. Don't source — that leaks every other key.
+DEEPSEEK_KEY="$(awk -F'"' '/^export DEEPSEEK_API_KEY=/ {print $2; exit}' "$KEYS_FILE")"
+if [[ -z "$DEEPSEEK_KEY" ]]; then
+  echo "✗ DEEPSEEK_API_KEY not set in $KEYS_FILE"
+  echo "  Get a key at https://platform.deepseek.com/api_keys"
+  echo "  Then edit $KEYS_FILE and put the value between the quotes:"
+  echo "    export DEEPSEEK_API_KEY=\"sk-...\""
+  exit 1
+fi
+
+FORCE_FLAG=""
+[[ "${1:-}" == "--force" ]] && FORCE_FLAG="--force"
+
+echo "→ Setting DEEPSEEK_API_KEY on Vercel production..."
+echo "$DEEPSEEK_KEY" | vercel env add DEEPSEEK_API_KEY production $FORCE_FLAG >/dev/null 2>&1 || \
+  echo "  (already exists; pass --force to overwrite)"
+
+# Optional model override — V4 may publish under a different ID. Default the
+# code uses is `deepseek-chat` which is V3 today and auto-rolls to V4 once
+# DeepSeek promotes. Comment out if you want to pin a specific version.
+# echo "→ Setting DEEPSEEK_MODEL..."
+# echo "deepseek-chat" | vercel env add DEEPSEEK_MODEL production $FORCE_FLAG >/dev/null 2>&1 || true
+
+echo ""
+echo "Done. Redeploy so the next build picks up the key:"
+echo ""
+echo "  vercel --prod --yes"
+echo ""
+echo "After redeploy, the cognitive explainer will route to DeepSeek instead of"
+echo "the template fallback. Verify with:"
+echo "  curl -sS https://frontier-alpha.metaventionsai.com/api/v1/explain/test"

--- a/src/services/ExplanationService.ts
+++ b/src/services/ExplanationService.ts
@@ -156,32 +156,67 @@ function setTradeChainCache(result: TradeReasoningChain): void {
 // ============================================================================
 
 /**
- * Check if an LLM API key is available for enhanced generation.
+ * LLM provider config — auto-selected from env. Both OpenAI and DeepSeek expose the
+ * /v1/chat/completions schema, so the same fetch shape works for either.
+ *
+ * Priority: DEEPSEEK_API_KEY (preferred — cheaper) → OPENAI_API_KEY → null (templates).
  */
-function hasLLMKey(): boolean {
-  return !!(process.env.OPENAI_API_KEY || process.env.ANTHROPIC_API_KEY);
+type LLMProvider = {
+  name: 'deepseek' | 'openai';
+  apiKey: string;
+  baseUrl: string;
+  model: string;
+};
+
+function resolveLLMProvider(): LLMProvider | null {
+  if (process.env.DEEPSEEK_API_KEY) {
+    return {
+      name: 'deepseek',
+      apiKey: process.env.DEEPSEEK_API_KEY,
+      baseUrl: 'https://api.deepseek.com/v1',
+      // DeepSeek V3.x ships as `deepseek-chat`. V4 will resolve here once published.
+      // Override via DEEPSEEK_MODEL env var if needed (model-id sovereignty).
+      model: process.env.DEEPSEEK_MODEL || 'deepseek-chat',
+    };
+  }
+  if (process.env.OPENAI_API_KEY) {
+    return {
+      name: 'openai',
+      apiKey: process.env.OPENAI_API_KEY,
+      baseUrl: 'https://api.openai.com/v1',
+      model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+    };
+  }
+  return null;
 }
 
 /**
- * Generate an explanation via OpenAI (if key present).
+ * Check if an LLM API key is available for enhanced generation.
+ */
+function hasLLMKey(): boolean {
+  return resolveLLMProvider() !== null;
+}
+
+/**
+ * Generate an explanation via the configured LLM (DeepSeek or OpenAI).
  * Returns null if unavailable or on error, allowing fallback.
  */
 async function generateWithLLM(
-  type: ExplanationType,
+  _type: ExplanationType,
   prompt: string,
 ): Promise<{ text: string; confidence: number } | null> {
-  const apiKey = process.env.OPENAI_API_KEY;
-  if (!apiKey) return null;
+  const provider = resolveLLMProvider();
+  if (!provider) return null;
 
   try {
-    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+    const response = await fetch(`${provider.baseUrl}/chat/completions`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
+        'Authorization': `Bearer ${provider.apiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini',
+        model: provider.model,
         messages: [
           {
             role: 'system',
@@ -199,7 +234,7 @@ async function generateWithLLM(
     });
 
     if (!response.ok) {
-      logger.warn({ status: response.status }, 'OpenAI API returned error, falling back to templates');
+      logger.warn({ status: response.status, provider: provider.name }, 'LLM API returned error, falling back to templates');
       return null;
     }
 


### PR DESCRIPTION
Refactors ExplanationService to provider-agnostic config: DEEPSEEK_API_KEY → DeepSeek (preferred), OPENAI_API_KEY → OpenAI (fallback), neither → template (existing). Both speak the OpenAI v1/chat/completions schema, so the fetch shape is unchanged. Adds scripts/wire-deepseek.sh that reads from ~/.api_keys and sets the Vercel env var.