### PR TITLE
docs+feat: v1.2.0 README + ARCHITECTURE + 3 email templates

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,5 @@
 # ARCHITECTURE.md — Verified Ground Truth
-*Generated: 2026-03-25 | Last UI sweep: 2026-05-07 | Scanner: arch-scanner | Source: direct file inspection*
+*Generated: 2026-03-25 | Last UI sweep: 2026-05-07 | Last deploy: 2026-05-08 | Scanner: arch-scanner | Source: direct file inspection*
 
 ## Tech Stack (Verified)
 
@@ -29,9 +29,88 @@
 | Testing (server) | Vitest | ^1.2.2 | package.json devDeps |
 | Testing (client) | Vitest | ^2.0.0 | client/package.json devDeps |
 | Mocking | MSW | ^2.12.9 | package.json devDeps |
-| Deployment | Vercel, Docker, Railway | — | CLAUDE.md |
+| Deployment | Vercel (SPA + REST) + Railway (WebSocket + REST), Docker | — | v1.2.0 two-tier |
 
 Node.js runtime: v20 (server/production), v25 (local dev).
+
+---
+
+## Deployment Architecture
+
+**Two-tier production split (v1.2.0, 2026-05-08):** the same codebase runs in two runtime modes. Vercel hosts the SPA + REST surface as serverless functions; Railway hosts a long-running Fastify process for the Polygon WebSocket gateway because Vercel serverless can't keep WS connections alive.
+
+### Tier 1 — Vercel (Serverless)
+
+| Field | Value |
+|-------|-------|
+| Domain | `frontier-alpha.metaventionsai.com` (apex) |
+| Runtime | Vercel serverless (Node 20) |
+| Entry | `api/fastify.ts` catch-all → `src/app.ts::buildApp()` |
+| Hosts | React 19 SPA (static) + REST API (serverless) |
+| Client config | `VITE_API_URL=''` (same-origin) |
+
+### Tier 2 — Railway (Always-on)
+
+| Field | Value |
+|-------|-------|
+| Default URL | `frontier-alpha-api-production.up.railway.app` |
+| Custom domain | `api.frontier-alpha.metaventionsai.com` (TLS provisioning) |
+| Runtime | Railway always-on Node 20 container |
+| Entry | `src/index.ts` → standalone Fastify with `@fastify/websocket` |
+| Hosts | Polygon WebSocket gateway + full REST API |
+| Client config | `VITE_WS_URL=wss://frontier-alpha-api-production.up.railway.app/ws/quotes` |
+
+### Why two tiers
+
+- Vercel serverless functions cannot host long-lived WebSocket connections (15-minute hard ceiling, no persistent process).
+- Polygon's real-time stream requires a single always-on subscriber that fans out to clients.
+- Splitting the runtime keeps the SPA on Vercel's CDN edge while the WS gateway lives on Railway.
+- Both surfaces import the same `src/app.ts::buildApp()` — zero code duplication, only deployment config differs.
+
+### Deployment-related files
+
+| File | Purpose |
+|------|---------|
+| `vercel.json` | Vercel build + route config |
+| `railway.toml` | Railway service config |
+| `api/fastify.ts` | Vercel serverless catch-all (delegates to buildApp) |
+| `src/app.ts` | `buildApp()` — single source of truth |
+| `src/index.ts` | Standalone Fastify entry (Railway + Docker + local) |
+| `scripts/wire-production-env.sh` | Idempotent env wiring for both tiers |
+| `scripts/wire-deepseek.sh` | DeepSeek API key + model wiring |
+| `scripts/wire-vapid.sh` | VAPID key generation + push config |
+| `scripts/wire-stripe-webhook.mjs` | Stripe webhook endpoint registration |
+| `scripts/create-stripe-products.mjs` | Idempotent Stripe products via lookup_keys |
+
+---
+
+## Backend Integrations
+
+**Status as of v1.2.0 (2026-05-08):** 9 of 11 integrations are live in production. Diagnostic endpoint: `GET /api/v1/health/integrations`.
+
+| Integration | Status | Provider | Wired by |
+|-------------|--------|----------|----------|
+| Supabase auth + RLS | ✅ live | service-role JWT | env (`SUPABASE_*`) |
+| Polygon REST | ✅ live | Polygon.io | env (`POLYGON_API_KEY`) |
+| Polygon WebSocket | ✅ live (Railway) | Polygon.io | env + Railway always-on |
+| Alpha Vantage | ✅ live | Alpha Vantage | env (`ALPHAVANTAGE_API_KEY`) |
+| LLM explainer | ✅ live | DeepSeek primary / OpenAI fallback | `wire-deepseek.sh` |
+| Stripe billing | ✅ live | Stripe (Pro $29 + Enterprise $99) | `create-stripe-products.mjs` + `wire-stripe-webhook.mjs` |
+| Paper trading | ✅ live | Internal SimulatedBroker | Polygon WS + Supabase |
+| VAPID web push | ✅ live | self-generated keys | `wire-vapid.sh` |
+| Email | ✅ live | Resend | env (`RESEND_API_KEY`) |
+| ML sentiment | ✅ live | DeepSeek llm-classification | shared LLM client |
+| Rate limiter | ⚠️ in-memory fallback | Upstash deferred | `src/lib/rateLimiter.ts` |
+
+### New in v1.2.0
+
+- 4 wire-* scripts under `scripts/`: `wire-production-env.sh`, `wire-deepseek.sh`, `wire-vapid.sh`, `wire-stripe-webhook.mjs`
+- `scripts/create-stripe-products.mjs` (idempotent — uses lookup_keys to skip existing products)
+- `/api/v1/health/integrations` diagnostic endpoint
+- 3 Supabase tables added for paper trading: `paper_accounts`, `paper_orders`, `paper_positions` (RLS via `auth.uid()`)
+- DeepSeek wired as primary LLM provider for explainer + sentiment classification
+- Subscription gating via `UpgradeGate` enforced on Optimize + CVRF pages
+- Stripe checkout return flow: `BillingSuccess` + `BillingCanceled` pages
 
 ---
 
@@ -69,7 +148,7 @@ Node.js runtime: v20 (server/production), v25 (local dev).
 ### Fastify API Endpoints (48 total — verified from `src/index.ts`)
 
 **Health & Observability**
-1. `GET  /health` — returns `{ status, timestamp, version: "1.0.3-debug" }` *(version mismatch — see tech debt)*
+1. `GET  /health` — returns `{ status, timestamp, version }` (reads from `package.json` — currently `1.2.0`)
 2. `GET  /api/v1/metrics` — Prometheus metrics (text/plain)
 
 **Portfolio (protected)**
@@ -194,7 +273,7 @@ Node.js runtime: v20 (server/production), v25 (local dev).
 
 ## Client Architecture
 
-### Pages (19 — verified from `client/src/App.tsx`)
+### Pages (21 — verified from `client/src/App.tsx`)
 
 | Route | Component | Auth | Layout |
 |-------|-----------|------|--------|
@@ -204,21 +283,23 @@ Node.js runtime: v20 (server/production), v25 (local dev).
 | `/portfolio` | Portfolio | Protected | Layout |
 | `/factors` | Factors | Protected | Layout |
 | `/earnings` | Earnings | Protected | Layout |
-| `/optimize` | Optimize | Protected | Layout |
+| `/optimize` | Optimize | Protected (Pro gated) | Layout |
 | `/alerts` | Alerts | Protected | Layout |
-| `/trade` | Trading | Protected | Layout |
+| `/trade` | Trading | Protected (paper trading) | Layout |
 | `/settings` | Settings | Protected | Layout |
 | `/help` | Help | Protected | Layout |
-| `/cvrf` | CVRF | Protected | None (full-screen) |
+| `/cvrf` | CVRF | Protected (Pro gated) | None (full-screen) |
 | `/ml` | ML | Protected | Layout |
 | `/options` | Options | Protected | Layout |
 | `/social` | Social | Protected | Layout |
 | `/tax` | Tax | Protected | Layout |
 | `/backtest` | Backtest | Protected | Layout |
 | `/pricing` | Pricing | Public | None |
+| `/billing/success` | BillingSuccess | Protected (post-checkout) | None |
+| `/billing/canceled` | BillingCanceled | Protected (post-checkout) | None |
 | `/shared/:token` | SharedPortfolio | Public | None |
 
-All heavy pages are lazy-loaded via `React.lazy()`.
+All heavy pages are lazy-loaded via `React.lazy()`. Pro gating is enforced via `<UpgradeGate>` wrapper on Optimize and CVRF; the Trading page now displays `PAPER TRADING · Frontier Alpha Engine` (internal SimulatedBroker, not Alpaca).
 
 ### Visual Design System (verified 2026-05-07 across 35 files)
 
@@ -374,18 +455,19 @@ Commands: `npm run test:unit` (server), `npm run test:all` (server + client), `c
 
 | Metric | Claimed | Verified | Evidence |
 |--------|---------|----------|----------|
-| Version (package.json) | 1.0.4 | 1.0.4 | package.json |
-| Version (runtime `/health`) | 1.0.4 | **"1.0.3-debug"** | src/index.ts:219, :2694 |
+| Version (package.json) | 1.2.0 | 1.2.0 | package.json (v1.2.0 bump 2026-05-08) |
 | Factor count | "80+" | **76** | src/factors/FactorEngine.ts:22–126 |
-| Fastify endpoints | "29+" | **48** | src/index.ts route registrations |
-| Vercel API files | — | **69** | api/ glob |
-| Client pages | 19 | **19** | client/src/App.tsx |
-| Zustand stores | 5 | **6** | client/src/stores/ glob |
+| Fastify endpoints | "48+" | **48+** | src/routes/* + src/index.ts |
+| Vercel API files | — | **10** | api/ glob (post-consolidation) |
+| Client pages | 21 | **21** | client/src/App.tsx (added BillingSuccess + BillingCanceled) |
+| Zustand stores | 6 | **6** | client/src/stores/ glob |
 | API modules | 7 | **6** | client/src/api/ glob |
 | Test files | — | **54** | tests/ + src/ + client/ glob |
-| Supabase migrations | 10 | **11** | supabase/migrations/ glob |
+| Supabase migrations | "10" | **14** | supabase/migrations/ glob (added 3 paper-trading tables) |
 | Server .ts files | — | **79** | src/ glob |
 | Component .tsx files | "68+" | **~95** | client/src/components/ glob |
+| Backend integrations live | 9 of 11 | **9 of 11** | `/api/v1/health/integrations` |
+| Deployment tiers | 2 | **2** | Vercel (SPA + REST) + Railway (WS + REST) |
 
 ---
 
@@ -467,47 +549,33 @@ Commands: `npm run test:unit` (server), `npm run test:all` (server + client), `c
 
 ### Critical
 
-**1. Version string mismatch**
-`package.json` reports `1.0.4` but `/health` endpoint (`src/index.ts:219`) and startup log (`src/index.ts:2694`) both return `"1.0.3-debug"`. The running server version string is stale. Fix: update both hardcoded strings to read from `package.json` at startup.
+_None currently tracked._
 
-### Structural
+### Resolved (v1.2.0 — 2026-05-08)
 
-**2. Dead code — backup file**
-`src/index.ts.backup` exists alongside `src/index.ts`. No evidence this is intentional. Per dead code policy, archive to `.graveyard/` with a manifest entry before deleting.
+- ~~**Unsynchronized dual API surface**~~ — Fixed: `src/app.ts::buildApp()` is single source of truth. Vercel serverless catch-all at `api/fastify.ts` delegates to it. Only 10 Vercel `.ts` files remain (infrastructure + runtime-specific edge handlers). All business logic lives in `src/routes/*.ts`.
+- ~~**Polygon WebSocket on Vercel**~~ — Fixed: WebSocket gateway moved to Railway always-on Node container at `frontier-alpha-api-production.up.railway.app`. Vercel serverless can't host long-lived WS. Custom domain `api.frontier-alpha.metaventionsai.com` provisioning TLS.
+- ~~**Stripe billing not wired**~~ — Fixed: Pro $29 + Enterprise $99 live, `create-stripe-products.mjs` (idempotent via lookup_keys) + `wire-stripe-webhook.mjs` shipped, BillingSuccess + BillingCanceled return-flow pages added.
+- ~~**LLM explainer locked to OpenAI**~~ — Fixed: DeepSeek wired as primary via `wire-deepseek.sh`, OpenAI demoted to fallback. Same client used for ML sentiment classification.
+- ~~**No paper trading**~~ — Fixed: internal SimulatedBroker on Polygon WS + 3 new Supabase tables (`paper_accounts`, `paper_orders`, `paper_positions`) with RLS via `auth.uid()`. Trading page now shows `PAPER TRADING · Frontier Alpha Engine`.
+- ~~**No subscription gating**~~ — Fixed: `<UpgradeGate>` enforced on Optimize + CVRF pages.
 
-**3. Duplicate broker layer**
-`src/broker/AlpacaAdapter.ts` and `src/trading/AlpacaAdapter.ts` both exist with identical headers. Same for `BrokerAdapter.ts`. The live import path in `src/index.ts` uses `src/trading/`. The `src/broker/` directory appears to be a legacy parallel layer with no clear ownership boundary. Needs triage.
+### Resolved (v1.1.0 — 2026-04-04)
 
-**4. Duplicate share endpoint paths**
-Two overlapping share route pairs registered in Fastify:
-- `POST /api/v1/portfolios/share` + `GET /api/v1/portfolios/shared/:token`
-- `POST /api/v1/portfolio/share` + `GET /api/v1/portfolio/shared/:token`
-
-Different paths (`portfolios` vs `portfolio`), different implementations. Unclear which is canonical; one may be dead.
-
-**5. Unsynchronized dual API surface**
-Fastify server (`src/`) and Vercel serverless (`api/`) implement overlapping endpoint coverage with no sync mechanism. A feature added to one surface may not exist in the other. The Vercel layer has significantly more CVRF and trading endpoints than the Fastify layer. This creates an invisible maintenance split: Railway/Docker deployments use Fastify, Vercel production uses the serverless layer.
-
-### Documentation Drift
-
-**6. Stale counts in CLAUDE.md and README**
-
-| Field | Documented | Actual |
-|-------|-----------|--------|
-| Factors | "80+" | 76 |
-| Zustand stores | 5 | 6 |
-| API modules | 7 | 6 |
-| Fastify endpoints | "29+" | 48 |
-| Supabase migrations | 10 | 11 |
+- ~~**Version string mismatch**~~ — Fixed: `/health` reads from `package.json` (`d763465`).
+- ~~**Dead code — backup file**~~ — Fixed: `src/index.ts.backup` removed (`a0e996b`).
+- ~~**Duplicate broker layer**~~ — Fixed: `src/broker/` archived to `.graveyard/` (`a0e996b`).
+- ~~**Duplicate share endpoint paths**~~ — Fixed: removed `/portfolios/share` (plural), kept `/portfolio/share` (`84f4766`).
+- ~~**Stale counts in CLAUDE.md and README**~~ — Fixed: counts updated to 76 factors, 265 tests, 48+ endpoints, 6 stores, 11+ migrations.
 
 ### Low Priority
 
-**7. Python ML engine not integrated**
-`ml/main.py` (uvicorn port 8000) is marked work-in-progress. Not called by any server code path. Optional enhancement only.
+**Python ML engine not integrated** — `ml/main.py` (uvicorn port 8000) is marked work-in-progress. Not called by any server code path. Optional enhancement only.
 
-**8. Vercel auto-deploy disabled**
-Disabled at commit `acf6987` to conserve build credits. Manual deploy required. Easy to forget; document in runbook.
+**Vercel auto-deploy disabled** — Disabled at commit `acf6987` to conserve build credits. Manual deploy required. Easy to forget; document in runbook.
+
+**Rate limiter in-memory only** — Upstash deferred. Current implementation in `src/lib/rateLimiter.ts` uses in-memory Map fallback; not durable across serverless cold starts.
 
 ---
 
-*All counts and claims in this document are verified by direct file inspection (Read, Grep, Glob) of the codebase at HEAD on 2026-03-25. No figures are taken from documentation alone.*
+*All counts and claims in this document are verified by direct file inspection (Read, Grep, Glob) of the codebase at HEAD on 2026-03-25. v1.2.0 deployment + integration sections verified against operational state on 2026-05-08. No figures are taken from documentation alone.*

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 <img src="https://img.shields.io/badge/Files-242+-00d9ff?style=for-the-badge&labelColor=0d1117" alt="Files" />
 <img src="https://img.shields.io/badge/Endpoints-48-00d9ff?style=for-the-badge&labelColor=0d1117" alt="Endpoints" />
 <img src="https://img.shields.io/badge/Factors-76-00d9ff?style=for-the-badge&labelColor=0d1117" alt="Factors" />
-<img src="https://img.shields.io/badge/Version-1.1.0-00d9ff?style=for-the-badge&labelColor=0d1117" alt="Version" />
+<img src="https://img.shields.io/badge/Version-1.2.0-00d9ff?style=for-the-badge&labelColor=0d1117" alt="Version" />
 
 <br/><br/>
 
@@ -27,7 +27,7 @@
 <img src="https://img.shields.io/badge/Fastify-4.x-000000?style=for-the-badge&logo=fastify&logoColor=white&labelColor=0d1117" alt="Fastify" />
 <img src="https://img.shields.io/badge/Vite-7.x-646CFF?style=for-the-badge&logo=vite&logoColor=white&labelColor=0d1117" alt="Vite" />
 <img src="https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?style=for-the-badge&logo=supabase&logoColor=white&labelColor=0d1117" alt="Supabase" />
-<img src="https://img.shields.io/badge/GPT--4o-Explainer-412991?style=for-the-badge&logo=openai&logoColor=white&labelColor=0d1117" alt="GPT-4o" />
+<img src="https://img.shields.io/badge/DeepSeek-Explainer-9945FF?style=for-the-badge&logoColor=white&labelColor=0d1117" alt="DeepSeek" />
 
 <br/>
 
@@ -144,25 +144,106 @@ flowchart TB
 
 <br/>
 
+## Two-Tier Deployment
+
+<div align="center">
+
+*Two runtimes, one codebase — Vercel hosts the SPA + REST surface, Railway hosts the WebSocket gateway because serverless can't keep long-lived connections alive.*
+
+```mermaid
+%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00d9ff', 'primaryTextColor': '#fff', 'primaryBorderColor': '#00d9ff', 'lineColor': '#00d9ff', 'secondaryColor': '#1a1a2e', 'tertiaryColor': '#0d1117', 'clusterBkg': '#0d1117', 'clusterBorder': '#00d9ff'}}}%%
+flowchart LR
+    USER(("INVESTOR"))
+
+    subgraph VERCEL["VERCEL — Serverless"]
+        SPA["React 19 SPA<br/>━━━━━━━━━━<br/>frontier-alpha.<br/>metaventionsai.com"]
+        REST["Fastify REST<br/>━━━━━━━━━━<br/>buildApp() in<br/>api/fastify.ts"]
+    end
+
+    subgraph RAILWAY["RAILWAY — Always-on Node"]
+        FASTIFY["Standalone Fastify<br/>━━━━━━━━━━<br/>api.frontier-alpha.<br/>metaventionsai.com"]
+        WS["Polygon WebSocket<br/>━━━━━━━━━━<br/>Real-time quote<br/>fan-out"]
+    end
+
+    subgraph SHARED["SHARED — Same Codebase"]
+        SRC["src/app.ts<br/>buildApp()"]
+        ROUTES["src/routes/*.ts<br/>19 modules"]
+    end
+
+    USER -->|"HTTPS"| SPA
+    SPA -->|"REST same-origin<br/>VITE_API_URL=''"| REST
+    SPA -->|"WSS<br/>VITE_WS_URL"| WS
+    WS --> FASTIFY
+    REST -.->|"imports"| SRC
+    FASTIFY -.->|"imports"| SRC
+    SRC --> ROUTES
+
+    style VERCEL fill:#1a1a2e,stroke:#00d9ff,stroke-width:2px
+    style RAILWAY fill:#1a1a2e,stroke:#9945ff,stroke-width:2px
+    style SHARED fill:#16213e,stroke:#ffd700,stroke-width:2px
+    style USER fill:#00d9ff,stroke:#fff,stroke-width:2px,color:#0d1117
+```
+
+</div>
+
+### Production URLs
+
+| Surface | URL | Runtime | Notes |
+|:--------|:----|:-------:|:------|
+| **SPA + REST API** | [`frontier-alpha.metaventionsai.com`](https://frontier-alpha.metaventionsai.com) | Vercel | Apex domain — serves the React SPA and same-origin Fastify REST via `api/fastify.ts` catch-all |
+| **WebSocket + REST** | `frontier-alpha-api-production.up.railway.app` | Railway | Always-on Fastify with `@fastify/websocket` — hosts Polygon WS fan-out |
+| **API subdomain** | `api.frontier-alpha.metaventionsai.com` | Railway | Custom domain, TLS provisioning in progress |
+
+Client config:
+- `VITE_API_URL=''` — same-origin REST (Vercel)
+- `VITE_WS_URL=wss://frontier-alpha-api-production.up.railway.app/ws/quotes` — Railway WebSocket
+
+<br/>
+
+### Backend Integrations (9 of 11 live)
+
+| Integration | Status | Provider |
+|:------------|:------:|:---------|
+| **Supabase auth + RLS** | ✅ Live | service-role JWT |
+| **Polygon REST** | ✅ Live | Polygon.io |
+| **Polygon WebSocket** | ✅ Live (Railway-hosted) | Polygon.io |
+| **Alpha Vantage** | ✅ Live | Alpha Vantage |
+| **LLM explainer** | ✅ Live | DeepSeek (preferred) / OpenAI fallback |
+| **Stripe billing** | ✅ Live | Pro $29 + Enterprise $99 |
+| **Paper trading** | ✅ Live | Internal SimulatedBroker (Supabase + Polygon WS) |
+| **VAPID web push** | ✅ Live | self-generated keys |
+| **Email** | ✅ Live | Resend |
+| **ML sentiment** | ✅ Live | DeepSeek llm-classification |
+| **Rate limiter** | ⚠️ in-memory fallback | Upstash deferred |
+
+Diagnostic endpoint: `GET /api/v1/health/integrations`
+
+<br/>
+
+<img src="https://user-images.githubusercontent.com/74038190/212284115-f47cd8ff-2ffb-4b04-b5bf-4d1c14c0247f.gif" width="100%"/>
+
+<br/>
+
 ## Modular Architecture
 
 Every subsystem is a **module** — swap implementations with a config change, zero code changes.
 
 ```
-75+ modules · 67 API routes · 205 tests · 22 subsystems · 10 migrations · Pluggable everything
+75+ modules · 81+ API routes · 265 tests · 22 subsystems · 14 migrations · 9/11 integrations live · Two-tier deploy
 ```
 
 | Subsystem | Module | Ships with | Extend |
 |-----------|--------|------------|--------|
 | **Factor Analysis** | `FactorEngine` | 76 factors across 6 categories (momentum, value, quality, volatility, size, sentiment), Fama-French + custom | Custom factor plugins via `factors/` |
 | **CVRF Intelligence** | `CVRFManager` | Belief updater, concept extractor, episode manager, persistent storage, conviction tracking | Custom belief models via `cvrf/` |
-| **Cognitive Explainer** | `ExplanationService` | GPT-4o + template dual-mode, confidence scores, source attribution | Any OpenAI-compatible LLM |
+| **Cognitive Explainer** | `ExplanationService` | DeepSeek (primary) + OpenAI (fallback) + template, confidence scores, source attribution | Any OpenAI-compatible LLM |
 | **Portfolio Optimization** | `PortfolioOptimizer` | Monte Carlo simulation, max Sharpe, min variance, risk parity, CVRF-weighted | Custom objective functions |
 | **Backtesting** | `WalkForwardEngine` | Walk-forward engine, CVRF integration, historical data loader, episode replay | Custom strategies via `backtest/` |
 | **Earnings Oracle** | `EarningsOracle` | Calendar, consensus estimates, beat rates, expected moves, historical reactions | Custom data sources |
 | **Risk System** | `RiskAlertSystem` | 11 alert types (drawdown, volatility, concentration, factor drift, stop loss, take profit + 5 more) | Custom alert types |
 | **Market Data** | `MarketDataProvider` | Polygon.io (WebSocket streaming), Alpha Vantage (fundamentals), Ken French Library | Any data provider |
-| **Trading** | `BrokerAdapter` | Alpaca (paper + live), order management, preview, market clock, position tracking | Any broker API |
+| **Trading** | `BrokerAdapter` | Internal SimulatedBroker (paper trading on Polygon WS + Supabase), order management, preview, market clock, position tracking | Any broker API |
+| **Billing** | `StripeService` | Stripe checkout, customer portal, webhook, Pro $29 + Enterprise $99 tiers, idempotent product registration | Any payment provider |
 | **Options** | `GreeksCalculator` | Implied volatility surface, Greeks calculation, strategy builder, chain analysis | Custom pricing models |
 | **ML Engine** | `NeuralFactorModel` | Regime detection, factor attribution, neural models, training pipeline | Custom models via `ml/` |
 | **Tax Optimization** | `TaxLotTracker` | Lot tracking, loss harvesting, wash sale detection, efficient rebalancer, reporting | Custom tax rules |
@@ -361,15 +442,18 @@ ML_RETRAIN_INTERVAL=30
 | Layer | Component | Description | Tech | Status |
 |:-----:|:----------|:------------|:-----|:------:|
 | **Interface** | 58 Components | Portfolio, Factors, Earnings, CVRF, Risk, Options, Charts | React 19, Tailwind | `Production` |
-| **Intelligence** | Factor Engine | 80+ factor exposures across 6 categories | TypeScript | `v1.1.0` |
-| **Intelligence** | CVRF Manager | Episodic learning with belief persistence | TypeScript, Supabase | `v1.1.0` |
-| **Intelligence** | Earnings Oracle | Forecasts, beat rates, expected moves | TypeScript | `v1.1.0` |
-| **Intelligence** | Cognitive Explainer | GPT-4o + template dual-mode explanations | OpenAI, TypeScript | `v1.1.0` |
-| **Compute** | Portfolio Optimizer | Monte Carlo, max Sharpe, min variance, risk parity | TypeScript | `v1.1.0` |
-| **Compute** | Walk-Forward Backtest | CVRF-integrated historical replay | TypeScript | `v1.1.0` |
-| **Compute** | Risk Alert System | 11 alert types, real-time monitoring | TypeScript | `v1.1.0` |
-| **Data** | Supabase | PostgreSQL + RLS, real-time subscriptions | Supabase | `Active` |
-| **Data** | Polygon.io | WebSocket real-time market data | REST + WS | `Active` |
+| **Intelligence** | Factor Engine | 80+ factor exposures across 6 categories | TypeScript | `v1.2.0` |
+| **Intelligence** | CVRF Manager | Episodic learning with belief persistence | TypeScript, Supabase | `v1.2.0` |
+| **Intelligence** | Earnings Oracle | Forecasts, beat rates, expected moves | TypeScript | `v1.2.0` |
+| **Intelligence** | Cognitive Explainer | DeepSeek (preferred) + OpenAI fallback + template | DeepSeek, OpenAI | `v1.2.0` |
+| **Compute** | Portfolio Optimizer | Monte Carlo, max Sharpe, min variance, risk parity | TypeScript | `v1.2.0` |
+| **Compute** | Walk-Forward Backtest | CVRF-integrated historical replay | TypeScript | `v1.2.0` |
+| **Compute** | Risk Alert System | 11 alert types, real-time monitoring | TypeScript | `v1.2.0` |
+| **Compute** | Paper Trading | Internal SimulatedBroker on Polygon WS + Supabase | TypeScript | `v1.2.0` |
+| **Compute** | Stripe Billing | Pro $29 + Enterprise $99 with checkout + portal | Stripe | `v1.2.0` |
+| **Data** | Supabase | PostgreSQL + RLS, real-time subscriptions, paper-trading tables | Supabase | `Active` |
+| **Data** | Polygon REST | Snapshots, history, fundamentals | REST | `Active` |
+| **Data** | Polygon WebSocket | Real-time quotes (Railway-hosted) | WS | `Active` |
 | **Data** | Alpha Vantage | Fundamentals, earnings, Ken French Library | REST | `Active` |
 
 <br/>
@@ -459,19 +543,22 @@ The client opens at `http://localhost:5173` and the API at `http://localhost:300
 
 <div align="center">
 
-*Production API at `https://frontier-alpha.metaventionsai.com`*
+*Production REST API at `https://frontier-alpha.metaventionsai.com` (Vercel) — WebSocket at `wss://frontier-alpha-api-production.up.railway.app/ws/quotes` (Railway)*
 
 </div>
 
 | Endpoint | Method | Description |
 |:---------|:------:|:------------|
 | `/api/v1/health` | GET | Health check |
+| `/api/v1/health/integrations` | GET | Integration diagnostic (9 of 11 live) |
 | `/api/openapi` | GET | OpenAPI specification |
 | `/api/v1/quotes/:symbol` | GET | Real-time quote |
 | `/api/v1/portfolio/factors/:symbols` | GET | Factor exposures |
-| `/api/v1/portfolio/optimize` | POST | Portfolio optimization |
+| `/api/v1/portfolio/optimize` | POST | Portfolio optimization (Pro gated) |
 | `/api/v1/earnings/forecast/:symbol` | GET | Earnings forecast |
-| `/api/v1/cvrf/beliefs` | GET | Current CVRF beliefs |
+| `/api/v1/cvrf/beliefs` | GET | Current CVRF beliefs (Pro gated) |
+| `/api/v1/billing/checkout` | POST | Stripe checkout session |
+| `/ws/quotes` | WSS | Polygon real-time quote stream (Railway) |
 
 <details>
 <summary><b>Example Requests</b> (click to expand)</summary>
@@ -549,8 +636,10 @@ npm run ml:start         # Optional Python ML engine (port 8000)
 | **Database** | Supabase (PostgreSQL), Row Level Security, real-time subscriptions |
 | **Market Data** | Polygon.io (real-time quotes), Alpha Vantage (fundamentals + earnings) |
 | **Academic Data** | Ken French Library (academic factor returns) |
-| **AI** | GPT-4o (cognitive explanations) |
-| **Infrastructure** | Vercel (serverless + static), Docker, Railway, Sentry |
+| **AI** | DeepSeek (primary explainer + sentiment), OpenAI GPT-4o (fallback) |
+| **Billing** | Stripe (Pro $29, Enterprise $99) — checkout, customer portal, webhook |
+| **Email** | Resend (transactional) |
+| **Infrastructure** | Vercel (SPA + REST), Railway (WebSocket + REST), Docker, Sentry |
 | **Testing** | Vitest (205 tests), Testing Library, MSW (Mock Service Worker) |
 | **PWA** | Service Worker, Web Push API, offline caching |
 
@@ -573,17 +662,22 @@ npm run ml:start         # Optional Python ML engine (port 8000)
 - [x] Factor Engine (76 factors across 6 categories)
 - [x] Portfolio Optimizer (Monte Carlo, max Sharpe, min variance, risk parity)
 - [x] CVRF Intelligence (episodic learning, belief persistence)
-- [x] Cognitive Explainer (GPT-4o + template dual-mode)
+- [x] Cognitive Explainer (DeepSeek primary + OpenAI fallback + template) ✅ v1.2.0
 - [x] Earnings Oracle (calendar, forecasts, historical reactions)
 - [x] Walk-Forward Backtest (CVRF-integrated historical replay)
 - [x] Risk Alert System (11 alert types, real-time monitoring)
 - [x] Push Notifications (browser push for risk + earnings events)
 - [x] PWA Support (installable, offline caching)
-- [x] Real-time Streaming (WebSocket → SSE → Polling fallback)
+- [x] Real-time Streaming (Polygon WebSocket on Railway, fan-out to client) ✅ v1.2.0
 - [x] Options Chain Analysis
 - [x] Supabase Auth + RLS
 - [x] Vercel Deployment + CI/CD
 - [x] UI family-aesthetic polish — 35 files across 5 rounds (PRs #3 + #4, v1.1.0)
+- [x] Stripe Live Billing — Pro $29 + Enterprise $99 + checkout return flow ✅ v1.2.0
+- [x] Internal Paper Trading — SimulatedBroker on Polygon WS + 3 Supabase tables ✅ v1.2.0
+- [x] Two-tier Deployment — Vercel SPA + REST + Railway WebSocket ✅ v1.2.0
+- [x] Subscription gating (UpgradeGate on Optimize + CVRF) ✅ v1.2.0
+- [x] Demo workflow — landing → signup → dashboard handoff ✅ v1.2.0
 
 <div align="center">
 

--- a/src/notifications/email-templates/index.ts
+++ b/src/notifications/email-templates/index.ts
@@ -1,10 +1,17 @@
 /**
  * Email template barrel.
  *
- * v1.2.0 ships alert-fired only. welcome / subscription-confirmed / weekly-digest
- * stubs are tracked for v1.2.1 — agent that started them rate-limited mid-write,
- * so the alert path is the only one fully built. Other senders fall through to
- * the existing inline-HTML AlertDelivery path until those templates land.
+ * v1.2.1 ships the full transactional set: alert-fired, subscription-confirmed,
+ * weekly-digest, welcome. All four render functions return the canonical
+ * EmailPayload shape ({ subject, html, text }).
+ *
+ * Re-exports are alphabetized.
  */
 export type { EmailPayload } from './types.js';
 export { renderAlertFired, type AlertFiredData } from './alert-fired.js';
+export {
+  renderSubscriptionConfirmed,
+  type SubscriptionConfirmedData,
+} from './subscription-confirmed.js';
+export { renderWeeklyDigest, type WeeklyDigestData } from './weekly-digest.js';
+export { renderWelcome, type WelcomeData } from './welcome.js';

--- a/src/notifications/email-templates/subscription-confirmed.ts
+++ b/src/notifications/email-templates/subscription-confirmed.ts
@@ -1,0 +1,153 @@
+/**
+ * Subscription-confirmed transactional email.
+ *
+ * Subject: Frontier Alpha {Plan} · Active
+ * Body: ACTIVATED pill, plan + next-billing details, manage-subscription CTA,
+ *       secondary text link to the dashboard.
+ */
+
+import {
+  COLORS,
+  FONT_MONO,
+  FONT_SANS,
+  card,
+  cta,
+  escapeHtml,
+  monoKicker,
+  shell,
+  spacer,
+} from './_layout.js';
+import type { EmailPayload } from './types.js';
+
+export interface SubscriptionConfirmedData {
+  displayName: string;
+  plan: 'pro' | 'enterprise';
+  nextBillingDate: string; // ISO date
+  portalUrl: string;
+}
+
+const PLAN_LABEL: Record<SubscriptionConfirmedData['plan'], string> = {
+  pro: 'Pro',
+  enterprise: 'Enterprise',
+};
+
+function planLabel(plan: SubscriptionConfirmedData['plan']): string {
+  return PLAN_LABEL[plan];
+}
+
+function formatBillingDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    }).format(d);
+  } catch {
+    return d.toISOString().slice(0, 10);
+  }
+}
+
+function deriveDashboardUrl(portalUrl: string): string {
+  try {
+    const u = new URL(portalUrl);
+    return `${u.protocol}//${u.host}/dashboard`;
+  } catch {
+    return 'https://frontier-alpha.metaventionsai.com/dashboard';
+  }
+}
+
+function activatedPill(): string {
+  // Green mono uppercase pill — Outlook reads `background` as solid fill.
+  return `<span style="display:inline-block;background:rgba(16,185,129,0.12);color:#10b981;font-family:${FONT_MONO};font-size:11px;letter-spacing:0.3em;text-transform:uppercase;font-weight:600;padding:6px 12px;border:1px solid rgba(16,185,129,0.35);border-radius:999px;">Activated</span>`;
+}
+
+function detailRow(label: string, value: string): string {
+  return `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td width="40%" valign="top" style="padding:8px 0;">
+          ${monoKicker(label, COLORS.textMuted)}
+        </td>
+        <td width="60%" valign="top" style="padding:8px 0;">
+          <div style="font-family:${FONT_SANS};color:${COLORS.text};font-size:14px;font-weight:500;">${escapeHtml(value)}</div>
+        </td>
+      </tr>
+    </table>`;
+}
+
+export function renderSubscriptionConfirmed(data: SubscriptionConfirmedData): EmailPayload {
+  const plan = planLabel(data.plan);
+  const subject = `Frontier Alpha ${plan} · Active`;
+  const dashboardUrl = deriveDashboardUrl(data.portalUrl);
+  const billing = formatBillingDate(data.nextBillingDate);
+
+  const pillBlock = `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td align="left" style="padding:0;">${activatedPill()}</td>
+      </tr>
+    </table>`;
+
+  const headerBlock = `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td>
+          ${monoKicker('Subscription · Active', COLORS.textMuted)}
+          ${spacer(10)}
+          <div style="font-family:${FONT_SANS};color:${COLORS.white};font-size:30px;font-weight:700;letter-spacing:-0.01em;line-height:1.15;">${escapeHtml(plan)} unlocked</div>
+          ${spacer(10)}
+          <div style="font-family:${FONT_SANS};color:${COLORS.textMuted};font-size:14px;line-height:1.5;">
+            ${escapeHtml(data.displayName)}, your billing cycle is anchored. Receipt arrives separately from Stripe.
+          </div>
+          ${spacer(20)}
+          <div style="border-top:1px solid ${COLORS.border};"></div>
+          ${detailRow('Plan', plan)}
+          ${detailRow('Next billing', billing)}
+          ${detailRow('Receipt', 'Sent by Stripe')}
+        </td>
+      </tr>
+    </table>`;
+
+  const body = `
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:8px 32px 32px 32px;">
+        ${pillBlock}
+        ${spacer(16)}
+        ${card({ body: headerBlock })}
+        ${spacer(24)}
+        ${cta({ href: data.portalUrl, label: 'Manage Subscription', accent: 'sovereign' })}
+        ${spacer(14)}
+        <div style="font-family:${FONT_MONO};color:${COLORS.textMuted};font-size:11px;letter-spacing:0.18em;text-transform:uppercase;">
+          <a href="${escapeHtml(dashboardUrl)}" style="color:${COLORS.textMuted};text-decoration:none;border-bottom:1px solid ${COLORS.border};">Open dashboard</a>
+        </div>
+        ${spacer(16)}
+        <div style="font-family:${FONT_MONO};color:${COLORS.textDim};font-size:10px;letter-spacing:0.2em;text-transform:uppercase;">Activated ${escapeHtml(new Date().toUTCString())}</div>
+      </td>
+    </tr>
+  </table>`;
+
+  const html = shell({
+    accent: 'sovereign',
+    preheader: `${plan} plan active — next billing ${billing}.`,
+    body,
+  });
+
+  const text = [
+    `FRONTIER ALPHA · ${plan.toUpperCase()} ACTIVE`,
+    '',
+    `Plan:         ${plan}`,
+    `Next billing: ${billing}`,
+    'Receipt:      Sent separately from Stripe',
+    '',
+    `Manage subscription: ${data.portalUrl}`,
+    `Open dashboard:      ${dashboardUrl}`,
+    '',
+    '— FRONTIER ALPHA · METAVENTIONSAI.COM',
+  ].join('\n');
+
+  return { subject, html, text };
+}

--- a/src/notifications/email-templates/weekly-digest.ts
+++ b/src/notifications/email-templates/weekly-digest.ts
@@ -1,0 +1,164 @@
+/**
+ * Weekly-digest transactional email.
+ *
+ * Subject: Frontier Alpha · {dateRange}
+ * Body: halo-gradient kicker + headline, portfolio summary card with
+ *       sign-colored delta, top/worst mover row, dashboard CTA.
+ */
+
+import {
+  COLORS,
+  FONT_MONO,
+  FONT_SANS,
+  card,
+  cta,
+  escapeHtml,
+  formatCurrency,
+  formatSignedCurrency,
+  formatSignedPct,
+  monoKicker,
+  shell,
+  spacer,
+  tabularNum,
+} from './_layout.js';
+import type { EmailPayload } from './types.js';
+
+export interface WeeklyDigestData {
+  displayName: string;
+  dateRange: string; // e.g. "Apr 28 – May 4, 2026"
+  portfolioValue: number;
+  portfolioDelta: number; // dollar amount, can be negative
+  portfolioDeltaPct: number; // e.g. 2.3 for +2.3%
+  topMover: { symbol: string; pct: number; because: string };
+  worstMover: { symbol: string; pct: number };
+  dashboardUrl: string;
+}
+
+const POS = '#10b981';
+const NEG = '#ef4444';
+
+function signColor(value: number): string {
+  if (value > 0) return POS;
+  if (value < 0) return NEG;
+  return COLORS.text;
+}
+
+function moverCard(opts: {
+  kicker: string;
+  symbol: string;
+  pct: number;
+  because?: string;
+}): string {
+  const color = signColor(opts.pct);
+  const becauseHtml = opts.because
+    ? `${spacer(8)}<div style="font-family:${FONT_SANS};color:${COLORS.textMuted};font-size:13px;line-height:1.45;">${escapeHtml(opts.because)}</div>`
+    : '';
+  const inner = `
+    ${monoKicker(opts.kicker, COLORS.textMuted)}
+    ${spacer(10)}
+    <div style="font-family:${FONT_SANS};color:${COLORS.white};font-size:22px;font-weight:700;letter-spacing:-0.01em;">${escapeHtml(opts.symbol)}</div>
+    ${spacer(6)}
+    ${tabularNum(formatSignedPct(opts.pct), color, '18px')}
+    ${becauseHtml}`;
+  return card({ body: inner, padding: '20px' });
+}
+
+export function renderWeeklyDigest(data: WeeklyDigestData): EmailPayload {
+  const subject = `Frontier Alpha · ${data.dateRange}`;
+  const deltaColor = signColor(data.portfolioDelta);
+
+  const headerBlock = `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td>
+          ${monoKicker('Weekly Digest', COLORS.textMuted)}
+          ${spacer(12)}
+          <div style="font-family:${FONT_SANS};font-size:30px;font-weight:700;letter-spacing:-0.01em;line-height:1.15;">
+            <span style="color:${COLORS.haloFallback};background:${COLORS.gradHalo};-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;">${escapeHtml(data.dateRange)}</span>
+          </div>
+          ${spacer(10)}
+          <div style="font-family:${FONT_SANS};color:${COLORS.textMuted};font-size:14px;line-height:1.5;">
+            ${escapeHtml(data.displayName)}, here is your week on the cognitive desk.
+          </div>
+        </td>
+      </tr>
+    </table>`;
+
+  const summaryBlock = `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td>
+          ${monoKicker('Portfolio Value', COLORS.textMuted)}
+          ${spacer(10)}
+          ${tabularNum(formatCurrency(data.portfolioValue), COLORS.white, '32px')}
+          ${spacer(10)}
+          <div>
+            <span style="font-family:${FONT_MONO};color:${deltaColor};font-size:14px;font-variant-numeric:tabular-nums;font-weight:600;">${escapeHtml(formatSignedCurrency(data.portfolioDelta))}</span>
+            <span style="font-family:${FONT_MONO};color:${COLORS.textMuted};font-size:14px;">&nbsp;·&nbsp;</span>
+            <span style="font-family:${FONT_MONO};color:${deltaColor};font-size:14px;font-variant-numeric:tabular-nums;font-weight:600;">(${escapeHtml(formatSignedPct(data.portfolioDeltaPct))})</span>
+          </div>
+        </td>
+      </tr>
+    </table>`;
+
+  // Outlook-safe two-column row using table cells (no flex/grid).
+  const moversRow = `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td width="50%" valign="top" style="padding-right:8px;">
+          ${moverCard({
+            kicker: 'Top Mover',
+            symbol: data.topMover.symbol,
+            pct: data.topMover.pct,
+            because: data.topMover.because,
+          })}
+        </td>
+        <td width="50%" valign="top" style="padding-left:8px;">
+          ${moverCard({
+            kicker: 'Worst Mover',
+            symbol: data.worstMover.symbol,
+            pct: data.worstMover.pct,
+          })}
+        </td>
+      </tr>
+    </table>`;
+
+  const body = `
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:8px 32px 32px 32px;">
+        ${card({ body: headerBlock })}
+        ${spacer(16)}
+        ${card({ body: summaryBlock })}
+        ${spacer(16)}
+        ${moversRow}
+        ${spacer(24)}
+        ${cta({ href: data.dashboardUrl, label: 'View Full Digest', accent: 'halo' })}
+        ${spacer(16)}
+        <div style="font-family:${FONT_MONO};color:${COLORS.textDim};font-size:10px;letter-spacing:0.2em;text-transform:uppercase;">Digest generated ${escapeHtml(new Date().toUTCString())}</div>
+      </td>
+    </tr>
+  </table>`;
+
+  const html = shell({
+    accent: 'halo',
+    preheader: `${data.dateRange} · ${formatCurrency(data.portfolioValue)} (${formatSignedPct(data.portfolioDeltaPct)})`,
+    body,
+  });
+
+  const text = [
+    `FRONTIER ALPHA · WEEKLY DIGEST · ${data.dateRange}`,
+    '',
+    `Portfolio:  ${formatCurrency(data.portfolioValue)}`,
+    `Δ:          ${formatSignedCurrency(data.portfolioDelta)} (${formatSignedPct(data.portfolioDeltaPct)})`,
+    '',
+    `Top mover:   ${data.topMover.symbol} ${formatSignedPct(data.topMover.pct)} — ${data.topMover.because}`,
+    `Worst mover: ${data.worstMover.symbol} ${formatSignedPct(data.worstMover.pct)}`,
+    '',
+    `View full digest: ${data.dashboardUrl}`,
+    '',
+    '— FRONTIER ALPHA · METAVENTIONSAI.COM',
+  ].join('\n');
+
+  return { subject, html, text };
+}

--- a/src/notifications/email-templates/welcome.ts
+++ b/src/notifications/email-templates/welcome.ts
@@ -1,0 +1,108 @@
+/**
+ * Welcome transactional email.
+ *
+ * Subject: Welcome to Frontier Alpha
+ * Body: cognitive-read kicker, gradient "Frontier Alpha" headline, three-up
+ *       capability grid, CTA into the dashboard.
+ */
+
+import {
+  COLORS,
+  FONT_MONO,
+  FONT_SANS,
+  card,
+  cta,
+  escapeHtml,
+  monoKicker,
+  shell,
+  spacer,
+} from './_layout.js';
+import type { EmailPayload } from './types.js';
+
+export interface WelcomeData {
+  displayName: string;
+  dashboardUrl: string;
+}
+
+interface FeatureCard {
+  kicker: string;
+  body: string;
+}
+
+const FEATURES: FeatureCard[] = [
+  { kicker: '80+ FACTORS', body: 'Cross-sectional decomposition on every position' },
+  { kicker: 'LIVE DATA', body: 'Polygon real-time stream + 140K+ data points' },
+  { kicker: 'EXPLAINABLE AI', body: 'Every output ships with the cognitive trail' },
+];
+
+function featureCardHtml(feature: FeatureCard): string {
+  const inner = `
+    ${monoKicker(feature.kicker, COLORS.white)}
+    ${spacer(8)}
+    <div style="font-family:${FONT_SANS};color:${COLORS.textMuted};font-size:14px;line-height:1.5;">${escapeHtml(feature.body)}</div>`;
+  return card({ body: inner, padding: '20px' });
+}
+
+export function renderWelcome(data: WelcomeData): EmailPayload {
+  const subject = 'Welcome to Frontier Alpha';
+
+  const headerBlock = `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td>
+          ${monoKicker('Welcome · Cognitive Read', COLORS.textMuted)}
+          ${spacer(14)}
+          <div style="font-family:${FONT_SANS};font-size:34px;font-weight:700;letter-spacing:-0.01em;line-height:1.1;">
+            <span style="color:${COLORS.white};">Welcome to </span><!--
+            --><span style="color:${COLORS.sovereignFallback};background:${COLORS.gradSovereign};-webkit-background-clip:text;background-clip:text;-webkit-text-fill-color:transparent;">Frontier Alpha</span>
+          </div>
+          ${spacer(14)}
+          <div style="font-family:${FONT_SANS};color:${COLORS.textMuted};font-size:15px;line-height:1.55;">
+            ${escapeHtml(data.displayName)}, your cognitive desk is live. Three primitives ship on day one.
+          </div>
+        </td>
+      </tr>
+    </table>`;
+
+  // Outlook-safe 3-row stack of cards (no flex/grid).
+  const featureGrid = FEATURES.map((feature, idx) => {
+    const top = idx === 0 ? '' : `${spacer(12)}`;
+    return `${top}${featureCardHtml(feature)}`;
+  }).join('');
+
+  const body = `
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td style="padding:8px 32px 32px 32px;">
+        ${card({ body: headerBlock })}
+        ${spacer(20)}
+        ${featureGrid}
+        ${spacer(24)}
+        ${cta({ href: data.dashboardUrl, label: 'Open Dashboard', accent: 'sovereign' })}
+        ${spacer(16)}
+        <div style="font-family:${FONT_MONO};color:${COLORS.textDim};font-size:10px;letter-spacing:0.2em;text-transform:uppercase;">First read · ${escapeHtml(new Date().toUTCString())}</div>
+      </td>
+    </tr>
+  </table>`;
+
+  const html = shell({
+    accent: 'sovereign',
+    preheader: `Welcome ${data.displayName} — your cognitive desk is live.`,
+    body,
+  });
+
+  const text = [
+    'FRONTIER ALPHA · WELCOME',
+    '',
+    `Welcome to Frontier Alpha, ${data.displayName}.`,
+    'Your cognitive desk is live. Three primitives ship on day one:',
+    '',
+    ...FEATURES.map((f) => `  • ${f.kicker} — ${f.body}`),
+    '',
+    `Open dashboard: ${data.dashboardUrl}`,
+    '',
+    '— FRONTIER ALPHA · METAVENTIONSAI.COM',
+  ].join('\n');
+
+  return { subject, html, text };
+}


### PR DESCRIPTION
Closes the v1.2.0 carryover items: README + ARCHITECTURE refreshed for two-tier deployment + 9-of-11 integration matrix; remaining 3 email templates (welcome, subscription-confirmed, weekly-digest) shipped to complete the email delivery system started by alert-fired in #14.