### PR TITLE
test: vitest coverage for SimulatedBroker + ExplanationService + SentimentAnalyzer

### DIFF
--- a/tests/explanation/ExplanationService.provider-resolution.test.ts
+++ b/tests/explanation/ExplanationService.provider-resolution.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for ExplanationService LLM provider resolution.
+ *
+ * `resolveLLMProvider()` is private — we exercise it indirectly through the
+ * public `generate()` entry point (which calls `generateWithLLM` -> `fetch`)
+ * and assert on the `fetch` mock.
+ *
+ * Provider priority per resolveLLMProvider():
+ *   1. DEEPSEEK_API_KEY  -> https://api.deepseek.com/v1, model 'deepseek-chat'
+ *   2. OPENAI_API_KEY    -> https://api.openai.com/v1,   model 'gpt-4o-mini'
+ *   3. neither           -> null (template fallback path)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Hoisted env so anything that loads supabase indirectly does not blow up.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+vi.mock('../../src/lib/logger.js', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { ExplanationService } from '../../src/services/ExplanationService.js';
+import type { ExplanationRequest } from '../../src/services/ExplanationService.js';
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+function chatResponse(content: string | null, status = 200): Response {
+  const body =
+    content === null
+      ? { choices: [{ message: {} }] }
+      : { choices: [{ message: { content } }] };
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function badJsonResponse(status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => ({ choices: 'not-an-array' }), // malformed
+    text: async () => 'malformed',
+  } as unknown as Response;
+}
+
+const baseRequest: ExplanationRequest = {
+  type: 'portfolio_move',
+  symbol: 'AAPL',
+  context: {
+    factors: [
+      // Triggers significantFactors path so the prompt has substance.
+      // Shape from src/types: factor, exposure, tStat, confidence
+      { factor: 'momentum', exposure: 0.7, tStat: 2.4, confidence: 0.85 } as never,
+    ],
+  },
+};
+
+// ---------------------------------------------------------------------------
+// tests
+// ---------------------------------------------------------------------------
+
+describe('ExplanationService.generate() — LLM provider resolution', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let service: ExplanationService;
+
+  beforeEach(() => {
+    vi.unstubAllEnvs();
+    vi.stubEnv('DEEPSEEK_API_KEY', '');
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('DEEPSEEK_MODEL', '');
+    vi.stubEnv('OPENAI_MODEL', '');
+    fetchSpy = vi.spyOn(global, 'fetch');
+    service = new ExplanationService();
+    service.clearCache(); // The module-level cache is shared across tests.
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  // -------------------------------------------------------------------------
+
+  it('DEEPSEEK_API_KEY set, OPENAI not -> fetch hits deepseek.com with model=deepseek-chat', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'deep-key');
+    fetchSpy.mockResolvedValueOnce(chatResponse('LLM-narrative'));
+
+    const result = await service.generate(baseRequest);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.deepseek.com/v1/chat/completions');
+    const body = JSON.parse(init.body as string) as { model: string };
+    expect(body.model).toBe('deepseek-chat');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer deep-key');
+    expect(result.text).toBe('LLM-narrative');
+    expect(result.sources).toContain('ai_model');
+  });
+
+  it('OPENAI_API_KEY set, DEEPSEEK not -> fetch hits openai.com with model=gpt-4o-mini', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'oai-key');
+    fetchSpy.mockResolvedValueOnce(chatResponse('OAI-narrative'));
+
+    const result = await service.generate(baseRequest);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.openai.com/v1/chat/completions');
+    const body = JSON.parse(init.body as string) as { model: string };
+    expect(body.model).toBe('gpt-4o-mini');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer oai-key');
+    expect(result.text).toBe('OAI-narrative');
+  });
+
+  it('Both keys set -> DeepSeek wins (priority order)', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'deep-key');
+    vi.stubEnv('OPENAI_API_KEY', 'oai-key');
+    fetchSpy.mockResolvedValueOnce(chatResponse('priority-deepseek'));
+
+    await service.generate(baseRequest);
+
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain('api.deepseek.com');
+    expect((init.headers as Record<string, string>).Authorization).toBe('Bearer deep-key');
+  });
+
+  it('Neither key set -> no fetch, returns template-based result', async () => {
+    const result = await service.generate(baseRequest);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.text).toBeTruthy();
+    expect(result.sources).not.toContain('ai_model');
+    expect(result.sources).toContain('factor_engine');
+  });
+
+  it('DEEPSEEK_MODEL=deepseek-coder env override -> fetch body uses overridden model', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'deep-key');
+    vi.stubEnv('DEEPSEEK_MODEL', 'deepseek-coder');
+    fetchSpy.mockResolvedValueOnce(chatResponse('coder-narrative'));
+
+    await service.generate(baseRequest);
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { model: string };
+    expect(body.model).toBe('deepseek-coder');
+  });
+
+  it('HTTP 500 from LLM -> graceful fallback to template (no throw)', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'deep-key');
+    fetchSpy.mockResolvedValueOnce(chatResponse('ignored', 500));
+
+    const result = await service.generate(baseRequest);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    // Falls back to template — sources should NOT include ai_model
+    expect(result.sources).not.toContain('ai_model');
+    expect(result.text).toBeTruthy();
+  });
+
+  it('Malformed JSON in choices array -> returns null, falls back to template', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'deep-key');
+    fetchSpy.mockResolvedValueOnce(badJsonResponse(200));
+
+    const result = await service.generate(baseRequest);
+
+    // The .choices?.[0]?.message?.content?.trim() chain returns undefined on
+    // malformed shapes. generateWithLLM returns null -> template path.
+    expect(result.sources).not.toContain('ai_model');
+    expect(result.text).toBeTruthy();
+  });
+
+  it('Empty choices.message.content -> returns null, falls back to template', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'deep-key');
+    fetchSpy.mockResolvedValueOnce(chatResponse('   ')); // whitespace -> trim() -> empty
+
+    const result = await service.generate(baseRequest);
+
+    expect(result.sources).not.toContain('ai_model');
+    expect(result.text).toBeTruthy();
+  });
+});

--- a/tests/sentiment/SentimentAnalyzer.three-tier.test.ts
+++ b/tests/sentiment/SentimentAnalyzer.three-tier.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Unit tests for SentimentAnalyzer's 3-tier fallback chain:
+ *  Tier 1: ML_SENTIMENT_ENDPOINT (FinBERT)  -> if 200 OK, returns parsed score
+ *  Tier 2: DEEPSEEK_API_KEY / OPENAI_API_KEY -> calls /v1/chat/completions, parses JSON
+ *  Tier 3: keyword analysis (always succeeds, deterministic from keyword bag)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Hoisted env so the supabase module's import-time guard never trips even
+// though SentimentAnalyzer doesn't import supabase. Belt-and-suspenders.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+// Silence logger output
+vi.mock('../../src/lib/logger.js', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { SentimentAnalyzer } from '../../src/sentiment/SentimentAnalyzer.js';
+
+// ---------------------------------------------------------------------------
+// fetch helpers
+// ---------------------------------------------------------------------------
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function llmChatResponse(content: string, status = 200): Response {
+  return jsonResponse(
+    { choices: [{ message: { content } }] },
+    status,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SentimentAnalyzer.analyze() — three-tier fallback', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Wipe env BEFORE each test — constructor reads ML_SENTIMENT_ENDPOINT.
+    vi.unstubAllEnvs();
+    vi.stubEnv('ML_SENTIMENT_ENDPOINT', '');
+    vi.stubEnv('DEEPSEEK_API_KEY', '');
+    vi.stubEnv('OPENAI_API_KEY', '');
+    vi.stubEnv('DEEPSEEK_MODEL', '');
+    vi.stubEnv('OPENAI_MODEL', '');
+    fetchSpy = vi.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  // -------------------------------------------------------------------------
+  // Tier 1 — FinBERT
+  // -------------------------------------------------------------------------
+
+  it('Tier 1: FinBERT endpoint returns valid JSON -> uses ML result', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse([
+        {
+          label: 'positive',
+          confidence: 0.91,
+          scores: { positive: 0.91, neutral: 0.05, negative: 0.04 },
+        },
+      ]),
+    );
+
+    const analyzer = new SentimentAnalyzer('http://ml.local');
+    const result = await analyzer.analyze('blockbuster quarter, earnings beat');
+
+    expect(result.label).toBe('positive');
+    expect(result.confidence).toBeCloseTo(0.91, 5);
+    expect(result.scores.positive).toBeCloseTo(0.91, 5);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy.mock.calls[0][0]).toBe('http://ml.local/sentiment');
+  });
+
+  it('Tier 1 -> Tier 3: ML endpoint returns 500, falls through to keyword (no LLM key)', async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 500));
+
+    const analyzer = new SentimentAnalyzer('http://ml.local');
+    const result = await analyzer.analyze('beat beat strong rally');
+
+    // 1 call to ML, then keyword fallback (no LLM key set)
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(result.label).toBe('positive');
+    expect(result.scores.positive).toBeGreaterThan(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Tier 2 — LLM
+  // -------------------------------------------------------------------------
+
+  it('Tier 2: ML unset, DEEPSEEK_API_KEY set -> LLM tier runs and returns parsed score', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'deep-key');
+
+    fetchSpy.mockResolvedValueOnce(
+      llmChatResponse(
+        JSON.stringify({
+          label: 'negative',
+          confidence: 0.74,
+          scores: { positive: 0.1, neutral: 0.16, negative: 0.74 },
+        }),
+      ),
+    );
+
+    const analyzer = new SentimentAnalyzer();
+    const result = await analyzer.analyze('layoffs and lawsuit');
+
+    expect(result.label).toBe('negative');
+    expect(result.confidence).toBeCloseTo(0.74, 5);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const url = fetchSpy.mock.calls[0][0] as string;
+    expect(url).toContain('api.deepseek.com');
+  });
+
+  it('Tier 2: LLM returns markdown-fenced JSON ```json {...} ``` -> strips fences and parses', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'oai-key');
+
+    const fenced =
+      '```json\n' +
+      JSON.stringify({
+        label: 'positive',
+        confidence: 0.8,
+        scores: { positive: 0.8, neutral: 0.15, negative: 0.05 },
+      }) +
+      '\n```';
+
+    fetchSpy.mockResolvedValueOnce(llmChatResponse(fenced));
+
+    const analyzer = new SentimentAnalyzer();
+    const result = await analyzer.analyze('upgrade, momentum');
+
+    expect(result.label).toBe('positive');
+    expect(result.confidence).toBeCloseTo(0.8, 5);
+  });
+
+  it('Tier 2: invalid label "BULL" -> clamped to neutral, confidence preserved', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'oai-key');
+
+    fetchSpy.mockResolvedValueOnce(
+      llmChatResponse(
+        JSON.stringify({
+          label: 'BULL',
+          confidence: 0.6,
+          scores: { positive: 0.6, neutral: 0.3, negative: 0.1 },
+        }),
+      ),
+    );
+
+    const analyzer = new SentimentAnalyzer();
+    const result = await analyzer.analyze('text');
+
+    expect(result.label).toBe('neutral');
+    expect(result.confidence).toBeCloseTo(0.6, 5);
+  });
+
+  it('Tier 2: confidence > 1 from LLM -> clamped to 1', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'oai-key');
+
+    fetchSpy.mockResolvedValueOnce(
+      llmChatResponse(
+        JSON.stringify({
+          label: 'positive',
+          confidence: 7.5,
+          scores: { positive: 0.99, neutral: 0.005, negative: 0.005 },
+        }),
+      ),
+    );
+
+    const analyzer = new SentimentAnalyzer();
+    const result = await analyzer.analyze('text');
+    expect(result.confidence).toBe(1);
+  });
+
+  it('Tier 2: confidence < 0 from LLM -> clamped to 0', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'oai-key');
+
+    fetchSpy.mockResolvedValueOnce(
+      llmChatResponse(
+        JSON.stringify({
+          label: 'neutral',
+          confidence: -0.4,
+          scores: { positive: 0.2, neutral: 0.6, negative: 0.2 },
+        }),
+      ),
+    );
+
+    const analyzer = new SentimentAnalyzer();
+    const result = await analyzer.analyze('text');
+    expect(result.confidence).toBe(0);
+  });
+
+  it('Tier 2 -> Tier 3: LLM fetch throws (network error) -> falls through to keyword', async () => {
+    vi.stubEnv('DEEPSEEK_API_KEY', 'deep-key');
+    fetchSpy.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+    const analyzer = new SentimentAnalyzer();
+    const result = await analyzer.analyze('miss disappointing weak loss');
+
+    // Keyword tier always returns a valid SentimentScore
+    expect(result.label).toBe('negative');
+    expect(['positive', 'neutral', 'negative']).toContain(result.label);
+    expect(result.confidence).toBeGreaterThanOrEqual(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Tier 3 — keyword
+  // -------------------------------------------------------------------------
+
+  it('Tier 3: all 3 tiers unset -> keyword analysis returns valid SentimentScore', async () => {
+    const analyzer = new SentimentAnalyzer();
+    const result = await analyzer.analyze('robust growth, beat estimates, strong buyback');
+
+    expect(['positive', 'neutral', 'negative']).toContain(result.label);
+    expect(result.confidence).toBeGreaterThanOrEqual(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+    expect(result.scores).toHaveProperty('positive');
+    expect(result.scores).toHaveProperty('neutral');
+    expect(result.scores).toHaveProperty('negative');
+    // No fetch calls — no ML, no LLM
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/tests/trading/SimulatedBroker.test.ts
+++ b/tests/trading/SimulatedBroker.test.ts
@@ -1,0 +1,614 @@
+/**
+ * Unit tests for SimulatedBroker.
+ *
+ * Mocks:
+ *  - marketDataProvider.getQuote(): returns controlled bid/ask quotes.
+ *  - supabaseAdmin: in-memory tables (paper_accounts, paper_orders,
+ *    paper_positions) backed by Maps, with a thenable query builder that
+ *    handles select/insert/update/delete + eq/in/order/limit/single/maybeSingle.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Hoisted env so importing the supabase module never throws.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+// vi.mock() factories are hoisted to the top of the file, so the supabase
+// mock + the in-memory tables must live inside vi.hoisted() to be available
+// when the SUT module is imported.
+const h = vi.hoisted(() => {
+  // ------ in-memory tables ------
+  const accounts = new Map<string, Record<string, unknown>>();
+  const orders: Record<string, unknown>[] = [];
+  const positions = new Map<string, Record<string, unknown>>();
+
+  const posKey = (uid: string, sym: string) => `${uid}|${sym.toUpperCase()}`;
+
+  type Filter =
+    | { kind: 'eq'; col: string; val: unknown }
+    | { kind: 'in'; col: string; vals: unknown[] };
+
+  function rowMatches(row: Record<string, unknown>, filters: Filter[]): boolean {
+    for (const f of filters) {
+      if (f.kind === 'eq' && row[f.col] !== f.val) return false;
+      if (f.kind === 'in' && !f.vals.includes(row[f.col])) return false;
+    }
+    return true;
+  }
+
+  function tableRows(table: string): Record<string, unknown>[] {
+    if (table === 'paper_accounts') return Array.from(accounts.values());
+    if (table === 'paper_orders') return orders;
+    if (table === 'paper_positions') return Array.from(positions.values());
+    throw new Error(`unknown table ${table}`);
+  }
+
+  function applyInsert(table: string, row: Record<string, unknown>): Record<string, unknown> {
+    const now = new Date().toISOString();
+    if (table === 'paper_accounts') {
+      const r = {
+        user_id: row.user_id,
+        cash_usd: row.cash_usd,
+        starting_cash: row.starting_cash,
+        created_at: now,
+        updated_at: now,
+      };
+      accounts.set(r.user_id as string, r);
+      return r;
+    }
+    if (table === 'paper_orders') {
+      const r = { ...row, submitted_at: row.submitted_at ?? now };
+      orders.push(r);
+      return r;
+    }
+    if (table === 'paper_positions') {
+      const r = {
+        user_id: row.user_id,
+        symbol: (row.symbol as string).toUpperCase(),
+        qty: row.qty,
+        avg_entry_price: row.avg_entry_price,
+        cost_basis: row.cost_basis,
+        opened_at: row.opened_at ?? now,
+        updated_at: row.updated_at ?? now,
+      };
+      positions.set(posKey(r.user_id as string, r.symbol as string), r);
+      return r;
+    }
+    throw new Error(`insert: unknown table ${table}`);
+  }
+
+  function applyUpdate(table: string, patch: Record<string, unknown>, filters: Filter[]): Record<string, unknown>[] {
+    const updated: Record<string, unknown>[] = [];
+    if (table === 'paper_accounts') {
+      for (const [k, row] of accounts.entries()) {
+        if (rowMatches(row, filters)) {
+          const next = { ...row, ...patch };
+          accounts.set(k, next);
+          updated.push(next);
+        }
+      }
+    } else if (table === 'paper_orders') {
+      for (let i = 0; i < orders.length; i++) {
+        if (rowMatches(orders[i], filters)) {
+          orders[i] = { ...orders[i], ...patch };
+          updated.push(orders[i]);
+        }
+      }
+    } else if (table === 'paper_positions') {
+      for (const [k, row] of positions.entries()) {
+        if (rowMatches(row, filters)) {
+          const next = { ...row, ...patch };
+          positions.set(k, next);
+          updated.push(next);
+        }
+      }
+    }
+    return updated;
+  }
+
+  function applyDelete(table: string, filters: Filter[]): void {
+    if (table === 'paper_positions') {
+      for (const [k, row] of positions.entries()) {
+        if (rowMatches(row, filters)) positions.delete(k);
+      }
+    } else if (table === 'paper_orders') {
+      for (let i = orders.length - 1; i >= 0; i--) {
+        if (rowMatches(orders[i], filters)) orders.splice(i, 1);
+      }
+    } else if (table === 'paper_accounts') {
+      for (const [k, row] of accounts.entries()) {
+        if (rowMatches(row, filters)) accounts.delete(k);
+      }
+    }
+  }
+
+  type Op = 'select' | 'insert' | 'update' | 'delete';
+  interface BuilderState {
+    table: string;
+    op: Op;
+    filters: Filter[];
+    insertRow?: Record<string, unknown>;
+    updatePatch?: Record<string, unknown>;
+    postSelect?: boolean;
+    single?: boolean;
+    maybeSingle?: boolean;
+  }
+
+  function makeBuilder(state: BuilderState): unknown {
+    const finalize = (): { data: unknown; error: unknown } => {
+      if (state.op === 'insert') {
+        const inserted = applyInsert(state.table, state.insertRow!);
+        if (state.postSelect) {
+          if (state.single || state.maybeSingle) return { data: inserted, error: null };
+          return { data: [inserted], error: null };
+        }
+        return { data: null, error: null };
+      }
+      if (state.op === 'update') {
+        const updated = applyUpdate(state.table, state.updatePatch!, state.filters);
+        if (state.postSelect) return { data: updated, error: null };
+        return { data: null, error: null };
+      }
+      if (state.op === 'delete') {
+        applyDelete(state.table, state.filters);
+        return { data: null, error: null };
+      }
+      const matched = tableRows(state.table).filter((r) => rowMatches(r, state.filters));
+      if (state.single) {
+        if (matched.length === 0) return { data: null, error: { message: 'no rows', code: 'PGRST116' } };
+        return { data: matched[0], error: null };
+      }
+      if (state.maybeSingle) return { data: matched[0] ?? null, error: null };
+      return { data: matched, error: null };
+    };
+
+    const builder: Record<string, unknown> = {
+      select(_cols?: string) {
+        if (state.op === 'insert' || state.op === 'update') state.postSelect = true;
+        return builder;
+      },
+      insert(row: Record<string, unknown>) {
+        state.op = 'insert';
+        state.insertRow = row;
+        return builder;
+      },
+      update(patch: Record<string, unknown>) {
+        state.op = 'update';
+        state.updatePatch = patch;
+        return builder;
+      },
+      delete() {
+        state.op = 'delete';
+        return builder;
+      },
+      eq(col: string, val: unknown) {
+        state.filters.push({ kind: 'eq', col, val });
+        return builder;
+      },
+      in(col: string, vals: unknown[]) {
+        state.filters.push({ kind: 'in', col, vals });
+        return builder;
+      },
+      order(_col: string, _opts?: unknown) {
+        return builder;
+      },
+      limit(_n: number) {
+        return builder;
+      },
+      single() {
+        state.single = true;
+        return Promise.resolve(finalize());
+      },
+      maybeSingle() {
+        state.maybeSingle = true;
+        return Promise.resolve(finalize());
+      },
+      then(resolve: (v: { data: unknown; error: unknown }) => unknown, reject?: (e: unknown) => unknown) {
+        return Promise.resolve(finalize()).then(resolve, reject);
+      },
+    };
+    return builder;
+  }
+
+  const supabaseAdmin = {
+    from(table: string) {
+      return makeBuilder({ table, op: 'select', filters: [] });
+    },
+  };
+
+  const getQuoteMock = vi.fn();
+
+  return { accounts, orders, positions, posKey, supabaseAdmin, getQuoteMock };
+});
+
+// ---------------------------------------------------------------------------
+// Local types (for test seed clarity only)
+// ---------------------------------------------------------------------------
+
+interface PaperAccountRow {
+  user_id: string;
+  cash_usd: number;
+  starting_cash: number;
+  created_at: string;
+  updated_at: string;
+}
+interface PaperOrderRow {
+  id: string;
+  user_id: string;
+  symbol: string;
+  side: 'buy' | 'sell';
+  qty: number;
+  type: 'market' | 'limit' | 'stop' | 'stop_limit';
+  limit_price: number | null;
+  stop_price: number | null;
+  time_in_force: string | null;
+  status: 'pending' | 'filled' | 'partially_filled' | 'canceled' | 'rejected' | 'expired';
+  filled_qty: number | null;
+  filled_avg_price: number | null;
+  submitted_at: string;
+  filled_at: string | null;
+  canceled_at: string | null;
+  reject_reason: string | null;
+  client_order_id: string | null;
+}
+// ---------------------------------------------------------------------------
+// Mocks — vi.mock factories run before imports
+// ---------------------------------------------------------------------------
+
+vi.mock('../../src/lib/supabase.js', () => ({
+  supabaseAdmin: h.supabaseAdmin,
+}));
+
+vi.mock('../../src/data/MarketDataProvider.js', () => ({
+  marketDataProvider: { getQuote: (sym: string) => h.getQuoteMock(sym) },
+}));
+
+vi.mock('../../src/lib/logger.js', () => ({
+  logger: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+import { SimulatedBroker } from '../../src/trading/SimulatedBroker.js';
+
+// Bring hoisted state into local scope for tests.
+const accounts = h.accounts as Map<string, PaperAccountRow>;
+const orders = h.orders as unknown as PaperOrderRow[];
+const positions = h.positions as Map<string, PaperPositionRow>;
+const posKey = h.posKey;
+const getQuoteMock = h.getQuoteMock;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function quote(symbol: string, bid: number, ask: number) {
+  return {
+    symbol: symbol.toUpperCase(),
+    bid,
+    ask,
+    last: (bid + ask) / 2,
+    timestamp: new Date(),
+    change: 0,
+    changePercent: 0,
+  };
+}
+
+const UID = 'user-test-001';
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('SimulatedBroker', () => {
+  beforeEach(() => {
+    accounts.clear();
+    orders.length = 0;
+    positions.clear();
+    getQuoteMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // getAccount
+  // -------------------------------------------------------------------------
+
+  describe('getAccount', () => {
+    it('first call lazy-creates paper_accounts row with $100k starting cash', async () => {
+      getQuoteMock.mockResolvedValue(null); // no positions to mark
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+
+      expect(accounts.size).toBe(0);
+      const acct = await broker.getAccount();
+
+      expect(accounts.size).toBe(1);
+      expect(acct.cash).toBe(100_000);
+      expect(acct.buyingPower).toBe(200_000); // 2x margin
+      expect(acct.portfolioValue).toBe(100_000);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // submitOrder — fills & rejections
+  // -------------------------------------------------------------------------
+
+  describe('submitOrder', () => {
+    it('buy market fills at ask, position created with avg_entry=ask, cash decremented', async () => {
+      getQuoteMock.mockResolvedValue(quote('AAPL', 99, 101));
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+
+      const order = await broker.submitOrder({
+        symbol: 'AAPL',
+        side: 'buy',
+        type: 'market',
+        qty: 10,
+      });
+
+      expect(order.status).toBe('filled');
+      expect(order.filledAvgPrice).toBe(101);
+      expect(order.filledQty).toBe(10);
+
+      const pos = positions.get(posKey(UID, 'AAPL'));
+      expect(pos?.qty).toBe(10);
+      expect(pos?.avg_entry_price).toBe(101);
+      expect(pos?.cost_basis).toBe(1010);
+
+      expect(accounts.get(UID)?.cash_usd).toBe(100_000 - 1010);
+    });
+
+    it('sell market without position is rejected (no shorting)', async () => {
+      getQuoteMock.mockResolvedValue(quote('AAPL', 99, 101));
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+
+      await expect(
+        broker.submitOrder({ symbol: 'AAPL', side: 'sell', type: 'market', qty: 5 }),
+      ).rejects.toThrow(/insufficient position/i);
+
+      const rej = orders.find((o) => o.status === 'rejected');
+      expect(rej).toBeDefined();
+      expect(rej?.reject_reason).toMatch(/insufficient position/i);
+    });
+
+    it('buy limit at marketable price (ask <= limit) fills immediately at limit price', async () => {
+      getQuoteMock.mockResolvedValue(quote('AAPL', 99, 100));
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+
+      const order = await broker.submitOrder({
+        symbol: 'AAPL',
+        side: 'buy',
+        type: 'limit',
+        qty: 5,
+        limitPrice: 105,
+      });
+
+      expect(order.status).toBe('filled');
+      expect(order.filledAvgPrice).toBe(105); // fills at limit, not at ask
+      const pos = positions.get(posKey(UID, 'AAPL'));
+      expect(pos?.avg_entry_price).toBe(105);
+    });
+
+    it('buy limit at non-marketable price persists as pending, no position created', async () => {
+      getQuoteMock.mockResolvedValue(quote('AAPL', 99, 110));
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+
+      const order = await broker.submitOrder({
+        symbol: 'AAPL',
+        side: 'buy',
+        type: 'limit',
+        qty: 3,
+        limitPrice: 100, // ask (110) > limit (100) -> not marketable
+      });
+
+      expect(order.status).toBe('new'); // 'pending' mapped to 'new'
+      expect(positions.size).toBe(0);
+      expect(orders.find((o) => o.status === 'pending')).toBeDefined();
+    });
+
+    it('buying-power: cash 1000, 2x margin = 2000, $3000 buy is rejected', async () => {
+      getQuoteMock.mockResolvedValue(quote('AAPL', 99, 100));
+      const broker = new SimulatedBroker({
+        apiKey: '',
+        apiSecret: '',
+        userId: UID,
+        startingCash: 1000,
+      });
+
+      await expect(
+        broker.submitOrder({ symbol: 'AAPL', side: 'buy', type: 'market', qty: 30 }),
+      ).rejects.toThrow(/insufficient buying power/i);
+
+      expect(orders.some((o) => o.status === 'rejected' && /buying power/i.test(o.reject_reason ?? ''))).toBe(true);
+      expect(positions.size).toBe(0);
+    });
+
+    it('trailing_stop type is rejected with reject_reason', async () => {
+      getQuoteMock.mockResolvedValue(quote('AAPL', 99, 100));
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+
+      await expect(
+        broker.submitOrder({
+          symbol: 'AAPL',
+          side: 'buy',
+          type: 'trailing_stop',
+          qty: 5,
+          trailPercent: 5,
+        }),
+      ).rejects.toThrow(/trailing_stop/i);
+
+      const rej = orders.find((o) => o.status === 'rejected');
+      expect(rej?.reject_reason).toMatch(/trailing_stop/i);
+    });
+
+    it('position averaging: buy 100 @ $50 then 100 @ $60 -> avg=$55, qty=200, cost=$11000', async () => {
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+
+      // First buy at ask=$50
+      getQuoteMock.mockResolvedValue(quote('AAPL', 49, 50));
+      await broker.submitOrder({ symbol: 'AAPL', side: 'buy', type: 'market', qty: 100 });
+
+      // Second buy at ask=$60 — every getQuote call during this submit returns $60
+      getQuoteMock.mockResolvedValue(quote('AAPL', 59, 60));
+      await broker.submitOrder({ symbol: 'AAPL', side: 'buy', type: 'market', qty: 100 });
+
+      const pos = positions.get(posKey(UID, 'AAPL'));
+      expect(pos?.qty).toBe(200);
+      expect(pos?.avg_entry_price).toBe(55);
+      expect(pos?.cost_basis).toBe(11000);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getPositions — mark to market
+  // -------------------------------------------------------------------------
+
+  describe('getPositions', () => {
+    it('marks-to-market against current quote, unrealized P/L computed', async () => {
+      // Seed a position directly
+      positions.set(posKey(UID, 'AAPL'), {
+        user_id: UID,
+        symbol: 'AAPL',
+        qty: 10,
+        avg_entry_price: 100,
+        cost_basis: 1000,
+        opened_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      });
+
+      getQuoteMock.mockResolvedValue(quote('AAPL', 119, 121)); // last ~120
+
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+      const pos = await broker.getPositions();
+
+      expect(pos).toHaveLength(1);
+      expect(pos[0].symbol).toBe('AAPL');
+      expect(pos[0].currentPrice).toBe(120);
+      expect(pos[0].marketValue).toBe(1200);
+      expect(pos[0].unrealizedPnL).toBe(200);
+      expect(pos[0].unrealizedPnLPercent).toBeCloseTo(20, 5);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // cancelOrder
+  // -------------------------------------------------------------------------
+
+  describe('cancelOrder', () => {
+    it('pending -> canceled (status flipped, canceled_at set)', async () => {
+      orders.push({
+        id: 'ord-1',
+        user_id: UID,
+        symbol: 'AAPL',
+        side: 'buy',
+        qty: 5,
+        type: 'limit',
+        limit_price: 50,
+        stop_price: null,
+        time_in_force: 'day',
+        status: 'pending',
+        filled_qty: 0,
+        filled_avg_price: null,
+        submitted_at: new Date().toISOString(),
+        filled_at: null,
+        canceled_at: null,
+        reject_reason: null,
+        client_order_id: null,
+      });
+
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+      const ok = await broker.cancelOrder('ord-1');
+
+      expect(ok).toBe(true);
+      const row = orders.find((o) => o.id === 'ord-1')!;
+      expect(row.status).toBe('canceled');
+      expect(row.canceled_at).not.toBeNull();
+    });
+
+    it('already-filled order cannot be canceled (idempotent fail)', async () => {
+      orders.push({
+        id: 'ord-2',
+        user_id: UID,
+        symbol: 'AAPL',
+        side: 'buy',
+        qty: 5,
+        type: 'market',
+        limit_price: null,
+        stop_price: null,
+        time_in_force: 'day',
+        status: 'filled',
+        filled_qty: 5,
+        filled_avg_price: 100,
+        submitted_at: new Date().toISOString(),
+        filled_at: new Date().toISOString(),
+        canceled_at: null,
+        reject_reason: null,
+        client_order_id: null,
+      });
+
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+      const ok = await broker.cancelOrder('ord-2');
+
+      expect(ok).toBe(false);
+      const row = orders.find((o) => o.id === 'ord-2')!;
+      expect(row.status).toBe('filled'); // unchanged
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getOrders status filter
+  // -------------------------------------------------------------------------
+
+  describe('getOrders', () => {
+    function seed(id: string, status: PaperOrderRow['status']) {
+      orders.push({
+        id,
+        user_id: UID,
+        symbol: 'AAPL',
+        side: 'buy',
+        qty: 1,
+        type: 'market',
+        limit_price: null,
+        stop_price: null,
+        time_in_force: 'day',
+        status,
+        filled_qty: 0,
+        filled_avg_price: null,
+        submitted_at: new Date().toISOString(),
+        filled_at: null,
+        canceled_at: null,
+        reject_reason: null,
+        client_order_id: null,
+      });
+    }
+
+    it("status='open' returns pending orders", async () => {
+      seed('p1', 'pending');
+      seed('p2', 'partially_filled');
+      seed('f1', 'filled');
+      seed('c1', 'canceled');
+
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+      const open = await broker.getOrders('open');
+
+      const ids = open.map((o) => o.id).sort();
+      expect(ids).toEqual(['p1']); // 'open' maps to status='pending'
+    });
+
+    it("status='closed' returns filled+canceled+rejected+expired orders", async () => {
+      seed('f1', 'filled');
+      seed('c1', 'canceled');
+      seed('r1', 'rejected');
+      seed('e1', 'expired');
+      seed('p1', 'pending');
+
+      const broker = new SimulatedBroker({ apiKey: '', apiSecret: '', userId: UID });
+      const closed = await broker.getOrders('closed');
+
+      const ids = closed.map((o) => o.id).sort();
+      expect(ids).toEqual(['c1', 'e1', 'f1', 'r1']);
+    });
+  });
+});


### PR DESCRIPTION
30 tests / 30 passing / 467ms. Closes the test carryover from PR #14. Pre-existing CVRF E2E failures flagged (legacy Vercel handler imports) but out of scope.