### PR TITLE
feat(billing): default-off BILLING_ENABLED gate prevents accidental live charges

### DIFF
--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -48,6 +48,19 @@ export async function billingRoutes(fastify: FastifyInstance, _opts: RouteContex
       const user = request.user!;
       const { priceId, successUrl, cancelUrl } = request.body || {};
 
+      // Defense-in-depth: even if the client tries to checkout, server refuses
+      // unless BILLING_ENABLED=true is explicitly set. Default-off prevents
+      // accidental live charges during dev / staging.
+      if ((process.env.BILLING_ENABLED ?? '').toLowerCase() !== 'true') {
+        return reply.status(503).send({
+          success: false,
+          error: {
+            code: 'BILLING_DISABLED',
+            message: 'Billing is not yet enabled for this environment.',
+          },
+        });
+      }
+
       if (!priceId) {
         return reply.status(400).send({
           success: false,

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -267,17 +267,29 @@ export async function healthRoutes(fastify: FastifyInstance, opts: RouteContext)
     }
 
     // --- Stripe -------------------------------------------------------------
-    if (has('STRIPE_SECRET_KEY')) {
-      integrations.stripe = {
-        status: 'live',
-        via: 'STRIPE_SECRET_KEY',
-      };
-    } else {
+    // BILLING_ENABLED gate: even when the Stripe key is wired, billing is OFF
+    // by default (BILLING_ENABLED must be explicitly 'true' to enable
+    // checkout). Triggers the Pricing page graceful-degrade UI ("Get Notified"
+    // mailto fallback) so accidental live charges aren't possible during dev.
+    const billingEnabled = (env.BILLING_ENABLED ?? '').toLowerCase() === 'true';
+    if (!has('STRIPE_SECRET_KEY')) {
       integrations.stripe = {
         status: 'degraded',
         via: null,
         reason: 'STRIPE_SECRET_KEY not set',
         impact: 'checkout endpoint returns 503',
+      };
+    } else if (!billingEnabled) {
+      integrations.stripe = {
+        status: 'degraded',
+        via: 'STRIPE_SECRET_KEY',
+        reason: 'BILLING_ENABLED is not set to "true"',
+        impact: 'Pricing CTAs fall back to mailto; live charges blocked',
+      };
+    } else {
+      integrations.stripe = {
+        status: 'live',
+        via: 'STRIPE_SECRET_KEY',
       };
     }
 


### PR DESCRIPTION
Default-off kill switch. Pricing UI gracefully degrades to 'Get Notified' mailto. /checkout returns 503 server-side. Flip BILLING_ENABLED=true on Vercel + Railway when ready to launch real billing.