### PR TITLE
feat(email): subscription-confirmed email fires from Stripe checkout webhook

### DIFF
--- a/src/notifications/AlertDelivery.ts
+++ b/src/notifications/AlertDelivery.ts
@@ -177,6 +177,18 @@ export class AlertDelivery {
   }
 
   /**
+   * Send a raw transactional email through the configured provider.
+   * Used by transactional flows (welcome, subscription-confirmed, weekly-digest)
+   * that build their own subject/html/text via the email-templates renderers.
+   *
+   * Returns the provider response shape (success + optional messageId / error)
+   * so callers can log delivery status without parsing into AlertPayload first.
+   */
+  async sendEmail(payload: EmailPayload): Promise<{ success: boolean; messageId?: string; error?: string }> {
+    return this.provider.send(payload);
+  }
+
+  /**
    * Send a single alert notification via all enabled channels (email + push).
    */
   async sendAlert(
@@ -548,4 +560,27 @@ View all alerts: ${this.appUrl}/alerts
 Manage preferences: ${this.appUrl}/settings/notifications
 `.trim();
   }
+}
+
+// ============================================================================
+// SINGLETON ACCESSOR
+// ============================================================================
+
+/**
+ * Lazy singleton — instantiated on first call so env vars are read at runtime
+ * (not at import time, which would break in Vercel serverless cold starts
+ * before env injection). Safe for transactional email sends from any route.
+ */
+let _alertDelivery: AlertDelivery | null = null;
+
+export function getAlertDelivery(): AlertDelivery {
+  if (!_alertDelivery) {
+    _alertDelivery = new AlertDelivery({
+      provider: (process.env.EMAIL_PROVIDER as 'resend' | 'sendgrid' | 'console') || 'console',
+      apiKey: process.env.EMAIL_API_KEY,
+      fromEmail: process.env.EMAIL_FROM,
+      appUrl: process.env.NEXT_PUBLIC_APP_URL,
+    });
+  }
+  return _alertDelivery;
 }

--- a/src/routes/billing.ts
+++ b/src/routes/billing.ts
@@ -252,6 +252,10 @@ export async function billingRoutes(fastify: FastifyInstance, _opts: RouteContex
             const priceId = subscription.items.data[0]?.price?.id || '';
             const plan = getPlanFromPriceId(priceId);
 
+            const periodEndIso = new Date(
+              (subscription as unknown as { current_period_end: number }).current_period_end * 1000
+            ).toISOString();
+
             await supabaseAdmin
               .from('frontier_subscriptions')
               .upsert(
@@ -261,12 +265,54 @@ export async function billingRoutes(fastify: FastifyInstance, _opts: RouteContex
                   stripe_subscription_id: subscription.id,
                   plan,
                   status: 'active',
-                  current_period_end: new Date(
-                    (subscription as unknown as { current_period_end: number }).current_period_end * 1000
-                  ).toISOString(),
+                  current_period_end: periodEndIso,
                 },
                 { onConflict: 'user_id' }
               );
+
+            // Send subscription-confirmation email — non-fatal if it fails so
+            // the webhook still 200s and Stripe doesn't retry.
+            try {
+              const { data: authUser } = await supabaseAdmin.auth.admin.getUserById(userId);
+              const email = authUser?.user?.email;
+              if (email) {
+                const { data: profile } = await supabaseAdmin
+                  .from('frontier_profiles')
+                  .select('display_name')
+                  .eq('user_id', userId)
+                  .maybeSingle();
+
+                const displayName =
+                  (profile as { display_name?: string } | null)?.display_name ||
+                  (authUser?.user?.user_metadata as { full_name?: string; name?: string } | undefined)?.full_name ||
+                  (authUser?.user?.user_metadata as { full_name?: string; name?: string } | undefined)?.name ||
+                  email.split('@')[0];
+
+                const frontendUrl = process.env.FRONTEND_URL || 'https://frontier-alpha.metaventionsai.com';
+                const portalUrl = `${frontendUrl}/settings/billing`;
+
+                const { renderSubscriptionConfirmed } = await import(
+                  '../notifications/email-templates/index.js'
+                );
+                const { getAlertDelivery } = await import('../notifications/AlertDelivery.js');
+
+                const payload = renderSubscriptionConfirmed({
+                  displayName,
+                  plan: plan as 'pro' | 'enterprise',
+                  nextBillingDate: periodEndIso,
+                  portalUrl,
+                });
+
+                await getAlertDelivery().sendEmail({
+                  to: email,
+                  subject: payload.subject,
+                  html: payload.html,
+                  text: payload.text,
+                });
+              }
+            } catch (err) {
+              logger.warn({ err, userId }, 'Failed to send subscription confirmation email');
+            }
             break;
           }
 


### PR DESCRIPTION
Subscription confirmation email auto-sends after successful Stripe checkout. Welcome + weekly-digest emails deferred (agent stalled). AlertDelivery extended with generic sendEmail() method.