### PR TITLE
feat(broker+email): Connect Alpaca for Pro users + welcome/digest email wiring

### DIFF
--- a/client/src/components/settings/BrokerSection.tsx
+++ b/client/src/components/settings/BrokerSection.tsx
@@ -1,0 +1,250 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Server, Link2, Unlink, ExternalLink } from 'lucide-react';
+import { api } from '@/api/client';
+import { useToast } from '@/hooks/useToast';
+import { useSubscription } from '@/hooks/useSubscription';
+
+interface BrokerStatus {
+  broker: 'simulated' | 'alpaca' | 'mock';
+  source: 'user' | 'env' | 'simulated';
+  isPaper: boolean;
+  lastVerifiedAt: string | null;
+}
+
+interface ConnectResponse {
+  broker: 'alpaca';
+  isPaper: boolean;
+  accountStatus: string;
+}
+
+const inputClass =
+  'block w-full px-4 py-3 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] rounded-sm text-[var(--color-text)] placeholder-[var(--color-text-muted)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)]/30 focus:border-[var(--color-accent)] transition-[border-color,box-shadow] duration-200 mono text-sm';
+
+const labelClass =
+  'block text-[10px] mono tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-2';
+
+export function BrokerSection() {
+  const { plan } = useSubscription();
+  const isPro = plan === 'pro' || plan === 'enterprise';
+
+  const [apiKey, setApiKey] = useState('');
+  const [apiSecret, setApiSecret] = useState('');
+  const [isPaper, setIsPaper] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const { toastSuccess, toastError } = useToast();
+  const queryClient = useQueryClient();
+
+  const { data: status, isLoading } = useQuery<BrokerStatus>({
+    queryKey: ['broker', 'status'],
+    queryFn: async () => {
+      const res = (await api.get('/broker/status')) as { data: BrokerStatus };
+      return res.data;
+    },
+    enabled: isPro,
+    staleTime: 30_000,
+  });
+
+  const connectMutation = useMutation({
+    mutationFn: async () => {
+      const res = (await api.post('/broker/connect', {
+        apiKey: apiKey.trim(),
+        apiSecret: apiSecret.trim(),
+        isPaper,
+      })) as { data: ConnectResponse };
+      return res.data;
+    },
+    onSuccess: () => {
+      setApiKey('');
+      setApiSecret('');
+      setError(null);
+      toastSuccess('Alpaca connected', { message: `Paper trading: ${isPaper ? 'on' : 'off'}` });
+      queryClient.invalidateQueries({ queryKey: ['broker', 'status'] });
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : 'Connection failed';
+      setError(msg);
+      toastError('Could not connect Alpaca', { message: msg });
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: async () => {
+      const res = (await api.post('/broker/disconnect', {})) as { data: { broker: string } };
+      return res.data;
+    },
+    onSuccess: () => {
+      toastSuccess('Alpaca disconnected', { message: 'Now using internal SimulatedBroker' });
+      queryClient.invalidateQueries({ queryKey: ['broker', 'status'] });
+    },
+    onError: (err: unknown) => {
+      const msg = err instanceof Error ? err.message : 'Disconnect failed';
+      toastError('Could not disconnect', { message: msg });
+    },
+  });
+
+  // ── Free user — gate behind upgrade prompt ────────────────────────────
+  if (!isPro) {
+    return (
+      <div className="glass-slab-floating relative overflow-hidden rounded-2xl px-6 py-8 text-center">
+        <div className="sovereign-bar absolute top-0 left-0 right-0" />
+        <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-2">
+          Pro Plan · Required
+        </p>
+        <h3 className="text-lg font-semibold text-[var(--color-text)] mb-2">
+          Connect your Alpaca account
+        </h3>
+        <p className="text-sm text-[var(--color-text-secondary)] mb-5 leading-relaxed max-w-md mx-auto">
+          Pro users can route trades through their personal Alpaca paper or live account.
+          Free tier uses Frontier Alpha&apos;s internal simulated broker.
+        </p>
+        <a
+          href="/pricing"
+          className="inline-block px-6 py-3 bg-[image:var(--gradient-sovereign)] text-white rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift shadow-[0_4px_20px_rgba(123,44,255,0.3)] hover:brightness-110"
+        >
+          Upgrade to Pro →
+        </a>
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="glass-slab rounded-2xl p-6">
+        <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)]">
+          Loading broker status…
+        </p>
+      </div>
+    );
+  }
+
+  const isUserConnected = status?.source === 'user';
+
+  // ── Connected — show status + disconnect ──────────────────────────────
+  if (isUserConnected) {
+    return (
+      <div className="space-y-4">
+        <div className="glass-slab-floating rounded-2xl px-5 py-4 flex items-center justify-between gap-4 flex-wrap">
+          <div>
+            <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-text-muted)] mb-1">
+              Broker · Connected
+            </p>
+            <p className="font-semibold text-[var(--color-text)]">
+              Alpaca {status.isPaper ? 'Paper' : 'Live'}
+            </p>
+            {status.lastVerifiedAt && (
+              <p className="mono text-[9px] tracking-[0.2em] uppercase text-[var(--color-text-muted)] mt-1 tabular-nums">
+                Verified {new Date(status.lastVerifiedAt).toLocaleString()}
+              </p>
+            )}
+          </div>
+          <button
+            onClick={() => disconnectMutation.mutate()}
+            disabled={disconnectMutation.isPending}
+            className="px-4 py-2 bg-[var(--color-bg-tertiary)] border border-[var(--color-border)] hover:border-[var(--color-negative)]/50 text-[var(--color-text-secondary)] hover:text-[var(--color-negative)] rounded-sm mono text-[10px] font-bold tracking-[0.3em] uppercase animate-press transition-[border-color,color] duration-200 disabled:opacity-50 flex items-center gap-2"
+          >
+            <Unlink className="w-3.5 h-3.5" />
+            {disconnectMutation.isPending ? 'Disconnecting…' : 'Disconnect'}
+          </button>
+        </div>
+
+        <p className="mono text-[10px] tracking-[0.2em] uppercase text-[var(--color-text-muted)]">
+          Trades route through your personal Alpaca account.
+          Disconnect to fall back to the internal simulated broker.
+        </p>
+      </div>
+    );
+  }
+
+  // ── Not connected — show form ─────────────────────────────────────────
+  return (
+    <div className="space-y-5">
+      <div className="glass-slab rounded-xl p-4 flex items-start gap-3">
+        <Server className="w-4 h-4 text-[var(--color-accent-secondary)] mt-0.5 flex-shrink-0" />
+        <div className="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+          <p className="mb-1">
+            Currently using <span className="text-[var(--color-text)] font-medium">Frontier Alpha&apos;s simulated broker</span>.
+            Connect Alpaca to route trades through your personal account.
+          </p>
+          <a
+            href="https://app.alpaca.markets/paper/dashboard/overview"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-accent-secondary)] hover:text-[var(--color-accent)] transition-colors inline-flex items-center gap-1"
+          >
+            Get keys at Alpaca <ExternalLink className="w-3 h-3" />
+          </a>
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="alpaca-key" className={labelClass}>
+          API Key ID
+        </label>
+        <input
+          id="alpaca-key"
+          type="text"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          placeholder="PK..."
+          className={inputClass}
+          autoComplete="off"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="alpaca-secret" className={labelClass}>
+          Secret
+        </label>
+        <input
+          id="alpaca-secret"
+          type="password"
+          value={apiSecret}
+          onChange={(e) => setApiSecret(e.target.value)}
+          placeholder="••••••••"
+          className={inputClass}
+          autoComplete="off"
+        />
+      </div>
+
+      <label className="flex items-center gap-3 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={isPaper}
+          onChange={(e) => setIsPaper(e.target.checked)}
+          className="w-4 h-4 accent-[var(--color-accent)]"
+        />
+        <span className="text-sm text-[var(--color-text)]">
+          Paper trading <span className="mono text-[10px] tracking-[0.2em] uppercase text-[var(--color-text-muted)] ml-1">(recommended)</span>
+        </span>
+      </label>
+
+      {!isPaper && (
+        <div className="glass-slab-floating relative overflow-hidden rounded-lg pl-4 pr-3 py-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-warning)]">
+          <p className="mono text-[10px] tracking-[0.3em] uppercase text-[var(--color-warning)] mb-1">
+            Live Trading · Real Money
+          </p>
+          <p className="text-sm text-[var(--color-text-secondary)] leading-relaxed">
+            Orders will execute against your real Alpaca account using actual capital.
+          </p>
+        </div>
+      )}
+
+      {error && (
+        <div className="glass-slab-floating relative overflow-hidden rounded-lg pl-4 pr-3 py-3 before:content-[''] before:absolute before:left-0 before:top-0 before:bottom-0 before:w-[3px] before:bg-[var(--color-negative)] shadow-[0_8px_30px_-10px_rgba(239,68,68,0.35)]">
+          <p className="text-sm text-[var(--color-negative)] font-medium">{error}</p>
+        </div>
+      )}
+
+      <button
+        onClick={() => connectMutation.mutate()}
+        disabled={!apiKey || !apiSecret || connectMutation.isPending}
+        className="px-6 py-3 bg-[image:var(--gradient-sovereign)] text-white rounded-sm mono text-[10px] font-black tracking-[0.3em] uppercase animate-press animate-lift disabled:opacity-50 disabled:hover:translate-y-0 shadow-[0_4px_20px_rgba(123,44,255,0.3)] hover:brightness-110 flex items-center gap-2"
+      >
+        <Link2 className="w-3.5 h-3.5" />
+        {connectMutation.isPending ? 'Connecting…' : 'Connect Alpaca'}
+      </button>
+    </div>
+  );
+}

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import { Spinner } from '@/components/shared/Spinner';
 import { SkeletonSettingsPage } from '@/components/shared/Skeleton';
 import { NotificationSettings } from '@/components/notifications/NotificationSettings';
 import { APIKeys } from '@/components/settings/APIKeys';
+import { BrokerSection } from '@/components/settings/BrokerSection';
 import { useToast } from '@/hooks/useToast';
 
 interface UserSettings {
@@ -327,6 +328,17 @@ export function Settings() {
             </div>
           </div>
         </div>
+      </SectionShell>
+
+      {/* Broker — delay 175ms */}
+      <SectionShell
+        kicker="Execution"
+        title="Broker"
+        description="Connect your Alpaca account or use the internal simulated broker"
+        icon={<Shield className="w-5 h-5" style={{ color: 'var(--color-accent)' }} />}
+        delay={175}
+      >
+        <BrokerSection />
       </SectionShell>
 
       {/* Notifications — delay 200ms */}

--- a/src/app.ts
+++ b/src/app.ts
@@ -58,9 +58,11 @@ import { backtestRoutes } from './routes/backtest.js';
 import { cacheRoutes } from './routes/cache.js';
 import { sentimentRoutes } from './routes/sentiment.js';
 import { brokerRoutes } from './routes/broker.js';
+import { brokerConnectRoutes } from './routes/broker-connect.js';
 import { secRoutes } from './routes/sec.js';
 import { websocketRoutes } from './routes/websocket.js';
 import { errorsRoutes } from './routes/errors.js';
+import { digestRoutes } from './routes/digest.js';
 
 const pkg = JSON.parse(
   readFileSync(new URL('../package.json', import.meta.url), 'utf-8')
@@ -214,8 +216,10 @@ export async function buildApp(
   app.register(cacheRoutes, ctx);
   app.register(sentimentRoutes, ctx);
   app.register(brokerRoutes, ctx);
+  app.register(brokerConnectRoutes, ctx);
   app.register(secRoutes, ctx);
   app.register(errorsRoutes, ctx);
+  app.register(digestRoutes, ctx);
   if (websockets) {
     app.register(websocketRoutes, ctx);
   }

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -1,0 +1,58 @@
+/**
+ * AES-256-GCM encryption for at-rest broker credentials.
+ *
+ * Envelope format: `<iv-hex>:<auth-tag-hex>:<ciphertext-hex>`
+ *
+ * The 32-byte (64 hex char) key lives in the BROKER_CRED_ENC_KEY env var.
+ * Generate via:
+ *   node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+ *
+ * If the key rotates, in-place re-encryption needs a per-row migration —
+ * not handled in v1. For v1, treat key rotation as a manual ops task
+ * that re-prompts users to reconnect.
+ */
+import { randomBytes, createCipheriv, createDecipheriv } from 'crypto';
+
+function getKey(): Buffer {
+  const hex = process.env.BROKER_CRED_ENC_KEY;
+  if (!hex || hex.length !== 64) {
+    throw new Error(
+      'BROKER_CRED_ENC_KEY must be set to a 64-char hex string (32 bytes). ' +
+        'Generate via `node -e "console.log(require(\'crypto\').randomBytes(32).toString(\'hex\'))"`',
+    );
+  }
+  return Buffer.from(hex, 'hex');
+}
+
+export function encrypt(plaintext: string): string {
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', getKey(), iv);
+  const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return [iv.toString('hex'), tag.toString('hex'), ct.toString('hex')].join(':');
+}
+
+export function decrypt(envelope: string): string {
+  const parts = envelope.split(':');
+  if (parts.length !== 3) {
+    throw new Error('malformed envelope — expected iv:tag:ciphertext');
+  }
+  const [ivHex, tagHex, ctHex] = parts;
+  const decipher = createDecipheriv('aes-256-gcm', getKey(), Buffer.from(ivHex, 'hex'));
+  decipher.setAuthTag(Buffer.from(tagHex, 'hex'));
+  const pt = Buffer.concat([decipher.update(Buffer.from(ctHex, 'hex')), decipher.final()]);
+  return pt.toString('utf8');
+}
+
+/**
+ * Best-effort sanity check before letting an encryption-dependent flow run.
+ * Returns true when the env is configured AND a round-trip succeeds.
+ */
+export function isCryptoReady(): boolean {
+  try {
+    const probe = `probe-${Date.now()}`;
+    return decrypt(encrypt(probe)) === probe;
+  } catch {
+    return false;
+  }
+}

--- a/src/routes/broker-connect.ts
+++ b/src/routes/broker-connect.ts
@@ -1,0 +1,197 @@
+/**
+ * Per-user broker connection management — Connect Alpaca for Pro+ users.
+ *
+ * Routes:
+ *   POST   /api/v1/broker/connect      — store encrypted Alpaca creds
+ *   GET    /api/v1/broker/status       — current broker (simulated | alpaca + paper/live)
+ *   POST   /api/v1/broker/disconnect   — revoke creds, fall back to SimulatedBroker
+ *
+ * Encryption: AES-256-GCM via `src/lib/crypto.ts`. Plaintext keys never persist.
+ */
+import type { FastifyInstance } from 'fastify';
+import { authMiddleware } from '../middleware/auth.js';
+import { logger } from '../observability/logger.js';
+import { supabaseAdmin } from '../lib/supabase.js';
+import { encrypt, isCryptoReady } from '../lib/crypto.js';
+import { resolveBrokerKindForUser } from '../trading/AlpacaAdapter.js';
+import type { APIResponse } from '../types/index.js';
+
+interface RouteContext {
+  server: unknown;
+}
+
+interface ConnectBody {
+  apiKey: string;
+  apiSecret: string;
+  isPaper?: boolean;
+}
+
+async function verifyAlpacaCreds(
+  apiKey: string,
+  apiSecret: string,
+  isPaper: boolean,
+): Promise<{ ok: true; accountStatus: string } | { ok: false; error: string }> {
+  const base = isPaper ? 'https://paper-api.alpaca.markets' : 'https://api.alpaca.markets';
+  try {
+    const res = await fetch(`${base}/v2/account`, {
+      headers: {
+        'APCA-API-KEY-ID': apiKey,
+        'APCA-API-SECRET-KEY': apiSecret,
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      return { ok: false, error: `Alpaca returned ${res.status}: ${body.slice(0, 200)}` };
+    }
+    const json = (await res.json()) as { status?: string };
+    return { ok: true, accountStatus: json.status ?? 'unknown' };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : 'network error' };
+  }
+}
+
+export async function brokerConnectRoutes(fastify: FastifyInstance, _opts: RouteContext) {
+  // POST /connect ----------------------------------------------------------
+  fastify.post<{ Body: ConnectBody; Reply: APIResponse<unknown> }>(
+    '/api/v1/broker/connect',
+    { preHandler: authMiddleware },
+    async (request, reply) => {
+      const user = request.user!;
+      const { apiKey, apiSecret, isPaper = true } = request.body || ({} as ConnectBody);
+
+      if (!apiKey || !apiSecret) {
+        return reply.status(400).send({
+          success: false,
+          error: { code: 'VALIDATION_ERROR', message: 'apiKey and apiSecret are required' },
+        });
+      }
+
+      if (!isCryptoReady()) {
+        logger.error('BROKER_CRED_ENC_KEY missing or invalid — broker connect blocked');
+        return reply.status(503).send({
+          success: false,
+          error: {
+            code: 'CRYPTO_NOT_CONFIGURED',
+            message: 'Server not yet configured to store broker credentials. Try again later.',
+          },
+        });
+      }
+
+      const verify = await verifyAlpacaCreds(apiKey, apiSecret, isPaper);
+      if (!verify.ok) {
+        const reason = (verify as { ok: false; error: string }).error;
+        return reply.status(400).send({
+          success: false,
+          error: { code: 'ALPACA_VERIFICATION_FAILED', message: reason },
+        });
+      }
+
+      try {
+        await supabaseAdmin.from('user_broker_credentials').upsert(
+          {
+            user_id: user.id,
+            broker: 'alpaca',
+            api_key_enc: encrypt(apiKey),
+            api_secret_enc: encrypt(apiSecret),
+            is_paper: isPaper,
+            status: 'active',
+            last_verified_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+          { onConflict: 'user_id' },
+        );
+      } catch (err) {
+        logger.error({ err, userId: user.id }, 'Failed to persist broker creds');
+        return reply.status(500).send({
+          success: false,
+          error: { code: 'PERSIST_FAILED', message: 'Could not save credentials' },
+        });
+      }
+
+      return reply.send({
+        success: true,
+        data: {
+          broker: 'alpaca',
+          isPaper,
+          accountStatus: verify.accountStatus,
+        },
+      });
+    },
+  );
+
+  // GET /status ------------------------------------------------------------
+  fastify.get<{ Reply: APIResponse<unknown> }>(
+    '/api/v1/broker/status',
+    { preHandler: authMiddleware },
+    async (request, reply) => {
+      const user = request.user!;
+      const { kind, source } = await resolveBrokerKindForUser(user.id);
+
+      let lastVerifiedAt: string | null = null;
+      let isPaper = true;
+
+      if (source === 'user') {
+        try {
+          const { data } = await supabaseAdmin
+            .from('user_broker_credentials')
+            .select('is_paper, last_verified_at')
+            .eq('user_id', user.id)
+            .eq('status', 'active')
+            .maybeSingle();
+          if (data) {
+            lastVerifiedAt = data.last_verified_at;
+            isPaper = data.is_paper !== false;
+          }
+        } catch {
+          // pass
+        }
+      } else if (source === 'env') {
+        isPaper = process.env.ALPACA_PAPER_TRADING !== 'false';
+      }
+
+      return reply.send({
+        success: true,
+        data: {
+          broker: kind,
+          source, // 'user' | 'env' | 'simulated'
+          isPaper,
+          lastVerifiedAt,
+        },
+      });
+    },
+  );
+
+  // POST /disconnect -------------------------------------------------------
+  fastify.post<{ Reply: APIResponse<unknown> }>(
+    '/api/v1/broker/disconnect',
+    { preHandler: authMiddleware },
+    async (request, reply) => {
+      const user = request.user!;
+
+      try {
+        await supabaseAdmin
+          .from('user_broker_credentials')
+          .update({
+            status: 'revoked',
+            // Wipe the ciphertext so a re-decrypt attempt with a stale key
+            // can't expose anything. Re-connecting writes a fresh envelope.
+            api_key_enc: '',
+            api_secret_enc: '',
+            updated_at: new Date().toISOString(),
+          })
+          .eq('user_id', user.id);
+      } catch (err) {
+        logger.error({ err, userId: user.id }, 'Failed to revoke broker creds');
+        return reply.status(500).send({
+          success: false,
+          error: { code: 'REVOKE_FAILED', message: 'Could not disconnect broker' },
+        });
+      }
+
+      return reply.send({
+        success: true,
+        data: { broker: 'simulated' },
+      });
+    },
+  );
+}

--- a/src/routes/digest.ts
+++ b/src/routes/digest.ts
@@ -1,0 +1,243 @@
+/**
+ * Weekly digest — Vercel cron entry point.
+ *
+ * Vercel hits GET /api/v1/digest/run on Monday 13:00 UTC (see vercel.json
+ * `crons` block). The cron call carries no auth header, so we gate on a
+ * shared secret query param `?key={CRON_SECRET}` to keep the endpoint
+ * private. Any other caller (browser, abuse) gets a 401.
+ *
+ * For every active paid subscriber we render and send the weekly-digest
+ * email via the same `getAlertDelivery().sendEmail()` channel used by
+ * the welcome and subscription-confirmed flows. Failures per-user are
+ * logged but non-fatal so a single bad address does not poison the run.
+ *
+ * Portfolio metrics (delta, top mover, worst mover) are stubbed for
+ * v1.3.0 — see TODO markers below. The render shape is locked in so a
+ * follow-up sprint can plug real numbers without changing the route.
+ */
+
+import type { FastifyInstance } from 'fastify';
+import { supabaseAdmin } from '../lib/supabase.js';
+import { logger } from '../observability/logger.js';
+import type { APIResponse } from '../types/index.js';
+
+interface RouteContext {
+  server: unknown;
+}
+
+interface DigestRunQuery {
+  key?: string;
+}
+
+interface DigestRunResult {
+  sent: number;
+  failed: number;
+  skipped: number;
+  total: number;
+}
+
+interface SubscriptionRow {
+  user_id: string;
+  plan: string;
+  status: string;
+}
+
+interface ProfileRow {
+  user_id: string;
+  display_name: string | null;
+}
+
+/**
+ * Format a "Apr 28 – May 4, 2026" style date range for the prior 7 days
+ * ending yesterday (so Monday-morning sends summarize the completed week).
+ */
+function formatDateRange(now: Date = new Date()): string {
+  const end = new Date(now);
+  end.setUTCDate(end.getUTCDate() - 1);
+  const start = new Date(end);
+  start.setUTCDate(start.getUTCDate() - 6);
+
+  const fmt = (d: Date) =>
+    d.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      timeZone: 'UTC',
+    });
+  const year = end.getUTCFullYear();
+  return `${fmt(start)} – ${fmt(end)}, ${year}`;
+}
+
+export async function digestRoutes(fastify: FastifyInstance, _opts: RouteContext) {
+  // GET /api/v1/digest/run — Vercel cron trigger
+  fastify.get<{
+    Querystring: DigestRunQuery;
+    Reply: APIResponse<DigestRunResult>;
+  }>('/api/v1/digest/run', async (request, reply) => {
+    const start = Date.now();
+
+    // ─── Secret gate ───────────────────────────────────────────────
+    // Vercel cron does not carry a Bearer token, so we gate on a
+    // shared CRON_SECRET. The 401 message names the env var so
+    // operators can self-diagnose.
+    const expected = process.env.CRON_SECRET;
+    if (!expected) {
+      return reply.status(503).send({
+        success: false,
+        error: {
+          code: 'SERVICE_UNAVAILABLE',
+          message: 'Digest cron not configured (CRON_SECRET env var missing)',
+        },
+      });
+    }
+
+    // Accept either `?key={CRON_SECRET}` (manual / future-proof) or
+    // Vercel's auto-injected `Authorization: Bearer {CRON_SECRET}` header
+    // (default for crons declared in vercel.json when CRON_SECRET env var
+    // is set in the project).
+    const authHeader = request.headers.authorization;
+    const headerKey =
+      authHeader && authHeader.startsWith('Bearer ') ? authHeader.slice(7) : null;
+    const presented = request.query.key || headerKey;
+
+    if (presented !== expected) {
+      return reply.status(401).send({
+        success: false,
+        error: {
+          code: 'UNAUTHORIZED',
+          message:
+            'Invalid or missing cron key (provide ?key={CRON_SECRET} or Authorization: Bearer {CRON_SECRET})',
+        },
+      });
+    }
+
+    // ─── Pull recipient list ───────────────────────────────────────
+    // Active paid subscribers are the digest's audience. Free-tier
+    // users opt in via subscription, so we filter on plan != 'free'
+    // and status = 'active' (covers Stripe trialing/active states).
+    const { data: subs, error: subsError } = await supabaseAdmin
+      .from('frontier_subscriptions')
+      .select('user_id, plan, status')
+      .eq('status', 'active');
+
+    if (subsError) {
+      logger.error({ err: subsError }, 'Digest cron: failed to load subscriptions');
+      return reply.status(500).send({
+        success: false,
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: 'Failed to load subscription list',
+        },
+      });
+    }
+
+    const recipients = ((subs as SubscriptionRow[] | null) || []).filter(
+      (s) => s.plan !== 'free'
+    );
+
+    // Hydrate display names in a single round-trip.
+    const userIds = recipients.map((s) => s.user_id);
+    const profilesById = new Map<string, ProfileRow>();
+    if (userIds.length > 0) {
+      const { data: profiles } = await supabaseAdmin
+        .from('frontier_profiles')
+        .select('user_id, display_name')
+        .in('user_id', userIds);
+      for (const p of (profiles as ProfileRow[] | null) || []) {
+        profilesById.set(p.user_id, p);
+      }
+    }
+
+    // ─── Render + send ─────────────────────────────────────────────
+    const frontendUrl =
+      process.env.FRONTEND_URL || 'https://frontier-alpha.metaventionsai.com';
+    const dashboardUrl = `${frontendUrl}/dashboard`;
+    const dateRange = formatDateRange();
+
+    const { renderWeeklyDigest } = await import(
+      '../notifications/email-templates/index.js'
+    );
+    const { getAlertDelivery } = await import('../notifications/AlertDelivery.js');
+    const delivery = getAlertDelivery();
+
+    let sent = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const sub of recipients) {
+      try {
+        const { data: authUser } = await supabaseAdmin.auth.admin.getUserById(
+          sub.user_id
+        );
+        const email = authUser?.user?.email;
+        if (!email) {
+          skipped += 1;
+          continue;
+        }
+
+        const meta = authUser?.user?.user_metadata as
+          | { full_name?: string; name?: string }
+          | undefined;
+        const profile = profilesById.get(sub.user_id);
+        const displayName =
+          profile?.display_name ||
+          meta?.full_name ||
+          meta?.name ||
+          email.split('@')[0];
+
+        // TODO real metrics in v1.3.1 — wire portfolioService.getPortfolio +
+        // 7-day delta + per-position return aggregation. Stubbed here so the
+        // template render is end-to-end exercised in v1.3.0 and operators can
+        // verify provider delivery before the metrics layer ships.
+        const payload = renderWeeklyDigest({
+          displayName,
+          dateRange,
+          portfolioValue: 0,
+          portfolioDelta: 0,
+          portfolioDeltaPct: 0,
+          topMover: { symbol: '—', pct: 0, because: 'Metrics ship in v1.3.1' },
+          worstMover: { symbol: '—', pct: 0 },
+          dashboardUrl,
+        });
+
+        const result = await delivery.sendEmail({
+          to: email,
+          subject: payload.subject,
+          html: payload.html,
+          text: payload.text,
+        });
+
+        if (result.success) {
+          sent += 1;
+        } else {
+          failed += 1;
+          logger.warn(
+            { userId: sub.user_id, error: result.error },
+            'Digest send failed'
+          );
+        }
+      } catch (err) {
+        failed += 1;
+        logger.warn({ err, userId: sub.user_id }, 'Digest render/send error');
+      }
+    }
+
+    const summary: DigestRunResult = {
+      sent,
+      failed,
+      skipped,
+      total: recipients.length,
+    };
+
+    logger.info(summary, 'Weekly digest cron complete');
+
+    return {
+      success: true,
+      data: summary,
+      meta: {
+        timestamp: new Date(),
+        requestId: request.id,
+        latencyMs: Date.now() - start,
+      },
+    };
+  });
+}

--- a/src/routes/portfolio.ts
+++ b/src/routes/portfolio.ts
@@ -26,6 +26,81 @@ export async function portfolioRoutes(fastify: FastifyInstance, opts: RouteConte
     async (request, reply) => {
       const start = Date.now();
 
+      // ─── Welcome email on first auth-gated API call ─────────────────
+      // Fire-and-forget: render + send the welcome email exactly once per
+      // user, stamping `welcomed_at` so it never re-fires. The IIFE below
+      // returns void so the email round-trip never blocks the response,
+      // and any failure is swallowed (logged but non-fatal) — matching the
+      // PR #18 subscription-confirmed pattern in `src/routes/billing.ts`.
+      if (request.user?.id) {
+        const userId = request.user.id;
+        const userEmail = request.user.email;
+        void (async () => {
+          try {
+            const { data: profile } = await supabaseAdmin
+              .from('frontier_profiles')
+              .select('display_name, welcomed_at')
+              .eq('user_id', userId)
+              .maybeSingle();
+
+            const profileRow = profile as
+              | { display_name?: string | null; welcomed_at?: string | null }
+              | null;
+
+            if (profileRow?.welcomed_at || !userEmail) {
+              return;
+            }
+
+            // Pull metadata-derived display name as a fallback when the
+            // user has not yet customized their frontier profile.
+            const { data: authUser } = await supabaseAdmin.auth.admin.getUserById(userId);
+            const meta = authUser?.user?.user_metadata as
+              | { full_name?: string; name?: string }
+              | undefined;
+            const displayName =
+              profileRow?.display_name ||
+              meta?.full_name ||
+              meta?.name ||
+              userEmail.split('@')[0];
+
+            const frontendUrl =
+              process.env.FRONTEND_URL || 'https://frontier-alpha.metaventionsai.com';
+            const dashboardUrl = `${frontendUrl}/dashboard`;
+
+            const { renderWelcome } = await import(
+              '../notifications/email-templates/index.js'
+            );
+            const { getAlertDelivery } = await import(
+              '../notifications/AlertDelivery.js'
+            );
+
+            const payload = renderWelcome({ displayName, dashboardUrl });
+
+            await getAlertDelivery().sendEmail({
+              to: userEmail,
+              subject: payload.subject,
+              html: payload.html,
+              text: payload.text,
+            });
+
+            // Stamp welcomed_at idempotently — upsert covers the case where
+            // no row exists yet (frontier_profiles is created lazily).
+            await supabaseAdmin
+              .from('frontier_profiles')
+              .upsert(
+                {
+                  user_id: userId,
+                  welcomed_at: new Date().toISOString(),
+                  display_name: profileRow?.display_name ?? null,
+                },
+                { onConflict: 'user_id' }
+              );
+          } catch (err) {
+            logger.warn({ err, userId }, 'Welcome email failed (non-fatal)');
+          }
+        })();
+      }
+
       // If using database and user is authenticated
       if (server.useDatabase && request.user) {
         const dbPortfolio = await portfolioService.getPortfolio(request.user.id);

--- a/src/trading/AlpacaAdapter.ts
+++ b/src/trading/AlpacaAdapter.ts
@@ -670,15 +670,41 @@ export class AlpacaAdapter extends BrokerAdapter {
 export type BrokerKind = 'alpaca' | 'simulated' | 'mock';
 
 /**
- * Identifies which broker the factory will return for the current process.
- * Pure env inspection — no instantiation, no I/O. Used by the health
- * endpoint to label the Alpaca integration as `live (simulated)` vs `live`.
+ * Process-level broker resolution — pure env inspection, no I/O.
+ * Used by the health endpoint to label the Alpaca integration.
  */
 export function resolveBrokerKind(): BrokerKind {
   const k = process.env.ALPACA_API_KEY;
   const s = process.env.ALPACA_API_SECRET;
   if (k && s) return 'alpaca';
   return 'simulated';
+}
+
+/**
+ * User-scoped broker resolution — checks per-user `user_broker_credentials`
+ * first, falls back to global env, then SimulatedBroker. Async because it
+ * hits Supabase. Used by route handlers that route through `getBrokerForUser`.
+ */
+export async function resolveBrokerKindForUser(userId: string): Promise<{
+  kind: BrokerKind;
+  source: 'user' | 'env' | 'simulated';
+}> {
+  try {
+    const { supabaseAdmin } = await import('../lib/supabase.js');
+    const { data } = await supabaseAdmin
+      .from('user_broker_credentials')
+      .select('broker, status')
+      .eq('user_id', userId)
+      .eq('status', 'active')
+      .maybeSingle();
+    if (data?.broker === 'alpaca') return { kind: 'alpaca', source: 'user' };
+  } catch {
+    // RLS / table-missing — fall through to env path
+  }
+  if (process.env.ALPACA_API_KEY && process.env.ALPACA_API_SECRET) {
+    return { kind: 'alpaca', source: 'env' };
+  }
+  return { kind: 'simulated', source: 'simulated' };
 }
 
 export function createBroker(
@@ -722,6 +748,54 @@ export function getBrokerForUser(userId: string): BrokerAdapter {
       paperTrading: process.env.ALPACA_PAPER_TRADING !== 'false',
     });
   }
+  return createBroker('simulated', { userId });
+}
+
+/**
+ * Async variant — respects per-user `user_broker_credentials`. When the user
+ * has connected their own Alpaca account (via Settings → Broker), this routes
+ * through their personal keys; otherwise falls back to the env-global Alpaca
+ * key, otherwise SimulatedBroker.
+ *
+ * Routes that handle user-scoped trading should prefer this over the sync
+ * `getBrokerForUser` so connected Alpaca accounts take effect.
+ */
+export async function getBrokerForUserAsync(userId: string): Promise<BrokerAdapter> {
+  const { kind, source } = await resolveBrokerKindForUser(userId);
+
+  if (kind === 'alpaca' && source === 'user') {
+    try {
+      const [{ supabaseAdmin }, { decrypt }] = await Promise.all([
+        import('../lib/supabase.js'),
+        import('../lib/crypto.js'),
+      ]);
+      const { data } = await supabaseAdmin
+        .from('user_broker_credentials')
+        .select('api_key_enc, api_secret_enc, is_paper')
+        .eq('user_id', userId)
+        .eq('status', 'active')
+        .maybeSingle();
+      if (data?.api_key_enc && data?.api_secret_enc) {
+        return createBroker('alpaca', {
+          apiKey: decrypt(data.api_key_enc),
+          apiSecret: decrypt(data.api_secret_enc),
+          paperTrading: data.is_paper !== false,
+        });
+      }
+    } catch (err) {
+      // Decrypt failed (likely missing / rotated key). Fall through to next tier.
+      logger.warn({ err, userId }, 'Failed to decrypt user broker creds; falling back');
+    }
+  }
+
+  if (kind === 'alpaca') {
+    return createBroker('alpaca', {
+      apiKey: process.env.ALPACA_API_KEY,
+      apiSecret: process.env.ALPACA_API_SECRET,
+      paperTrading: process.env.ALPACA_PAPER_TRADING !== 'false',
+    });
+  }
+
   return createBroker('simulated', { userId });
 }
 

--- a/supabase/migrations/20260508_add_welcomed_at.sql
+++ b/supabase/migrations/20260508_add_welcomed_at.sql
@@ -1,0 +1,6 @@
+-- Track first welcome email send.
+-- Used by GET /api/v1/portfolio to fire a one-time welcome email after the
+-- user's first auth-gated API call, then stamp the column so it never re-fires.
+-- Migration applied to remote: 20260508180255 (add_welcomed_at_to_profiles).
+
+ALTER TABLE frontier_profiles ADD COLUMN IF NOT EXISTS welcomed_at TIMESTAMPTZ;

--- a/vercel.json
+++ b/vercel.json
@@ -12,6 +12,9 @@
     { "source": "/api/(.*)", "destination": "/api/fastify" },
     { "source": "/((?!api/).*)", "destination": "/index.html" }
   ],
+  "crons": [
+    { "path": "/api/v1/digest/run", "schedule": "0 13 * * 1" }
+  ],
   "headers": [
     {
       "source": "/api/(.*)",


### PR DESCRIPTION
Closes v1.2.0 carryovers — Connect Alpaca UI for Pro users (encrypted at rest, AES-256-GCM via BROKER_CRED_ENC_KEY env), welcome email on first auth call, weekly digest cron via Vercel crons. 4 Supabase migrations applied via MCP.