### PR TITLE
feat(data): reliability hardening + correctness fixes (C+D+F)

### DIFF
--- a/schemas/env-schema.json
+++ b/schemas/env-schema.json
@@ -40,6 +40,14 @@
       "description": "Polygon REST + WebSocket API key. EXACTLY 32 chars — v1.2.6 incident: echo|vercel env add truncated to 30 chars and silently 401'd for weeks. Always rotate via printf, not echo."
     },
     {
+      "name": "POLYGON_WS_URL",
+      "required": false,
+      "regex": "^wss://.+",
+      "sourceUrl": "https://polygon.io/docs/websocket/getting-started",
+      "lastVerified": "2026-07-02",
+      "description": "Optional Polygon WebSocket cluster override. Defaults in code to wss://delayed.polygon.io/stocks (Stocks Starter is a 15-min-delayed plan, NOT entitled to the real-time cluster wss://socket.polygon.io). Set to the real-time cluster only on a real-time plan."
+    },
+    {
       "name": "ALPHA_VANTAGE_API_KEY",
       "required": true,
       "regex": "^[A-Z0-9]{8,32}$",

--- a/src/data/CacheWarmer.ts
+++ b/src/data/CacheWarmer.ts
@@ -32,11 +32,14 @@ import { MarketDataProvider } from './MarketDataProvider.js';
 export const DEV_USER_ID = '3ea07211-a7a6-43cd-ae10-0dc112d03ce5';
 
 /**
- * Max concurrent upstream Polygon calls in flight. Polygon free tier is
- * 5 req/min — 4 leaves a 1-req cushion for synchronous user traffic. Any
- * higher and a burst from the warmer can starve a paying user.
+ * Max concurrent upstream calls in flight from the warmer. This is now a
+ * FAIRNESS bound, not a rate cap: Polygon Stocks Starter has no per-minute
+ * call ceiling (the old value of 4 dated from the free tier's 5-req/min
+ * limit). We keep a bound so a warmer burst doesn't monopolize the event
+ * loop / socket pool ahead of synchronous user traffic, but it can be higher
+ * now. (B2 will further reduce fan-out via Polygon grouped-daily.)
  */
-const MAX_CONCURRENT_UPSTREAM = 4;
+const MAX_CONCURRENT_UPSTREAM = 8;
 
 /**
  * Hand-rolled FIFO concurrency limiter. We avoid the `p-queue` dependency

--- a/src/data/MarketDataProvider.ts
+++ b/src/data/MarketDataProvider.ts
@@ -2,12 +2,21 @@
  * FRONTIER ALPHA - Market Data Provider
  *
  * Production-grade market data integration:
- * - Polygon.io: Real-time quotes via WebSocket streaming (<20ms latency)
+ * - Polygon.io: streaming (15-minute delayed) quotes via WebSocket + REST
+ * - Alpaca: provider-independent failover (free IEX delayed feed)
  * - Alpha Vantage: Historical prices (5yr), fundamentals, earnings
  * - Ken French Data Library: Factor returns (30+ years)
  * - Redis: 5-minute quote cache layer
  *
- * NO MOCK DATA IN PRODUCTION - All data from real APIs or throws errors
+ * Reliability posture (harden/data-provider-cdf):
+ * - fetchWithRetry: bounded retry + jittered backoff on transient upstream
+ *   failures (429/5xx/network) before failing over to the next provider.
+ * - CircuitBreaker: per-provider fast-fail so a down/rate-limited provider is
+ *   skipped for a cooldown instead of hammered on every request.
+ * - Graceful degradation: when every provider fails, serve last-resort stale
+ *   cache rows instead of throwing (historical path).
+ *
+ * NO MOCK DATA IN PRODUCTION - All data from real APIs, stale cache, or throws.
  */
 
 import type { Price, Quote, Asset } from '../types/index.js';
@@ -15,11 +24,13 @@ import { supabaseAdmin } from '../lib/supabase.js';
 import { logger } from '../lib/logger.js';
 import { marketDataCache, type CompositeCache } from './cache/index.js';
 import {
-  classifyHttpStatus,
   classifyErrorBody,
   recordUpstreamError,
+  recordProviderError,
+  isAlertableErrorKind,
   BACKOFF_GUIDANCE,
 } from './QuotaClassifier.js';
+import { fetchWithRetry, getBreaker } from './resilience.js';
 import WebSocket from 'ws';
 import Redis, { type Redis as RedisClient } from 'ioredis';
 
@@ -29,6 +40,13 @@ import Redis, { type Redis as RedisClient } from 'ioredis';
 
 export interface DataProviderConfig {
   polygonApiKey?: string;
+  /**
+   * Polygon WebSocket cluster URL. Defaults to the DELAYED cluster
+   * (wss://delayed.polygon.io/stocks), which is what the Stocks Starter plan
+   * is entitled to. Override to wss://socket.polygon.io/stocks only on a
+   * real-time plan.
+   */
+  polygonWsUrl?: string;
   alphaVantageApiKey?: string;
   // Alpaca Market Data API — provider-independent failover for quotes + daily
   // bars. Polygon.io was acquired by Massive (2026-06); if a Massive plan
@@ -87,7 +105,7 @@ export class MarketDataProvider {
   /**
    * In-flight promise dedup — when N parallel callers (e.g. dashboard
    * sparklines) ask for the same symbol's history simultaneously, only one
-   * upstream Polygon/AV call goes out. Saves the free-tier rate limit and
+   * upstream Polygon/AV call goes out. Cuts redundant upstream load and
    * eliminates "5 of 5 symbols 502'd in parallel" UX on first paint.
    *
    * NOTE: kept separate from the cache layer because request coalescing is
@@ -95,6 +113,13 @@ export class MarketDataProvider {
    * need to wait on the SAME upstream fetch; that's not what a cache does.
    */
   private inflightHistoricalPrices: Map<string, Promise<Price[]>> = new Map();
+  /**
+   * In-flight quote dedup (D3). Mirrors `inflightHistoricalPrices` for the
+   * quote path — parallel callers asking for the same symbol on a cache miss
+   * (e.g. the dashboard header + a widget) coalesce onto one upstream fetch
+   * instead of each hitting Polygon independently.
+   */
+  private inflightQuotes: Map<string, Promise<Quote | null>> = new Map();
   private quoteCache: Map<string, { quote: Quote; timestamp: number }> = new Map();
   private useSupabaseCache: boolean = !!process.env.SUPABASE_SERVICE_KEY;
 
@@ -205,59 +230,94 @@ export class MarketDataProvider {
       }
     }
 
-    // 4. Fetch from Polygon.io (primary real-time source)
+    // 4. Cache miss — fetch upstream, coalescing concurrent callers (D3) so a
+    //    dashboard-wide miss fires one upstream request per symbol, not N.
+    const existing = this.inflightQuotes.get(upperSymbol);
+    if (existing) return existing;
+
+    const fetcher = this.doFetchQuoteUpstream(upperSymbol, now);
+    this.inflightQuotes.set(upperSymbol, fetcher);
+    try {
+      return await fetcher;
+    } finally {
+      this.inflightQuotes.delete(upperSymbol);
+    }
+  }
+
+  /**
+   * Upstream quote chain: Polygon -> Alpaca -> Alpha Vantage, each guarded by
+   * a per-provider circuit breaker (skip a provider whose breaker is open
+   * instead of hammering it). Throws DataNotAvailableError in production when
+   * every provider is exhausted; falls back to a mock quote only in dev.
+   */
+  private async doFetchQuoteUpstream(upperSymbol: string, now: number): Promise<Quote | null> {
+    const persist = async (quote: Quote): Promise<Quote> => {
+      this.quoteCache.set(upperSymbol, { quote, timestamp: now });
+      await Promise.all([
+        this.cacheQuoteToRedis(quote),
+        this.cacheQuoteToSupabase(quote),
+      ]);
+      return quote;
+    };
+
+    // 4a. Polygon.io (primary delayed source)
     if (this.config.polygonApiKey) {
-      try {
-        const quote = await this.fetchPolygonQuote(upperSymbol);
-        if (quote) {
-          this.quoteCache.set(upperSymbol, { quote, timestamp: now });
-          await Promise.all([
-            this.cacheQuoteToRedis(quote),
-            this.cacheQuoteToSupabase(quote),
-          ]);
-          return quote;
+      const breaker = getBreaker('polygon');
+      if (breaker.canAttempt()) {
+        try {
+          const quote = await this.fetchPolygonQuote(upperSymbol);
+          if (quote) {
+            breaker.recordSuccess();
+            return await persist(quote);
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.error({ err: e, symbol: upperSymbol }, 'Polygon quote error');
         }
-      } catch (e) {
-        logger.error({ err: e, symbol: upperSymbol }, 'Polygon quote error');
+      } else {
+        logger.warn({ symbol: upperSymbol }, 'Polygon breaker open — skipping to failover');
       }
     }
 
-    // 5. Fetch from Alpaca (provider-independent failover — survives a Massive
-    //    cutoff of the Polygon key). Free IEX feed, real delayed quotes.
+    // 4b. Alpaca (provider-independent failover — survives a Massive cutoff of
+    //     the Polygon key). Free IEX feed, real delayed quotes.
     if (this.config.alpacaApiKey && this.config.alpacaApiSecret) {
-      try {
-        const quote = await this.fetchAlpacaQuote(upperSymbol);
-        if (quote) {
-          this.quoteCache.set(upperSymbol, { quote, timestamp: now });
-          await Promise.all([
-            this.cacheQuoteToRedis(quote),
-            this.cacheQuoteToSupabase(quote),
-          ]);
-          return quote;
+      const breaker = getBreaker('alpaca');
+      if (breaker.canAttempt()) {
+        try {
+          const quote = await this.fetchAlpacaQuote(upperSymbol);
+          if (quote) {
+            breaker.recordSuccess();
+            return await persist(quote);
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.error({ err: e, symbol: upperSymbol }, 'Alpaca quote error');
         }
-      } catch (e) {
-        logger.error({ err: e, symbol: upperSymbol }, 'Alpaca quote error');
       }
     }
 
-    // 6. Fetch from Alpha Vantage (backup for real quotes)
+    // 4c. Alpha Vantage (backup)
     if (this.config.alphaVantageApiKey) {
-      try {
-        const quote = await this.fetchAlphaVantageQuote(upperSymbol);
-        if (quote) {
-          this.quoteCache.set(upperSymbol, { quote, timestamp: now });
-          await Promise.all([
-            this.cacheQuoteToRedis(quote),
-            this.cacheQuoteToSupabase(quote),
-          ]);
-          return quote;
+      const breaker = getBreaker('alphaVantage');
+      if (breaker.canAttempt()) {
+        try {
+          const quote = await this.fetchAlphaVantageQuote(upperSymbol);
+          if (quote) {
+            breaker.recordSuccess();
+            return await persist(quote);
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.error({ err: e, symbol: upperSymbol }, 'Alpha Vantage quote error');
         }
-      } catch (e) {
-        logger.error({ err: e, symbol: upperSymbol }, 'Alpha Vantage quote error');
       }
     }
 
-    // 7. PRODUCTION: Throw error, no mock fallback
+    // 5. PRODUCTION: Throw error, no mock fallback
     if (!this.config.allowMockFallback) {
       throw new DataNotAvailableError(
         `Unable to fetch quote for ${upperSymbol}: No data providers available or all failed. ` +
@@ -265,7 +325,7 @@ export class MarketDataProvider {
       );
     }
 
-    // 8. DEVELOPMENT ONLY: Generate mock quote
+    // 6. DEVELOPMENT ONLY: Generate mock quote
     logger.warn({ symbol: upperSymbol }, 'Using mock quote (dev fallback)');
     return this.generateMockQuote(upperSymbol);
   }
@@ -315,8 +375,11 @@ export class MarketDataProvider {
   private async fetchAlphaVantageQuote(symbol: string): Promise<Quote | null> {
     const url = `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${symbol}&apikey=${this.config.alphaVantageApiKey}`;
 
-    const response = await fetch(url);
-    if (!response.ok) return null;
+    const response = await fetchWithRetry(url, undefined);
+    if (!response.ok) {
+      recordProviderError('alphaVantage', response.status);
+      return null;
+    }
 
     const data = await response.json();
     const globalQuote = data['Global Quote'];
@@ -382,14 +445,22 @@ export class MarketDataProvider {
     // hammer Polygon first to preserve the AV quota. Successful upstream
     // fetches write through both cache layers via `setPrices()`.
     if (this.config.polygonApiKey) {
-      try {
-        const prices = await this.fetchPolygonPrices(upperSymbol, days);
-        if (prices.length > 0) {
-          await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
-          return prices;
+      const breaker = getBreaker('polygon');
+      if (breaker.canAttempt()) {
+        try {
+          const prices = await this.fetchPolygonPrices(upperSymbol, days);
+          if (prices.length > 0) {
+            breaker.recordSuccess();
+            await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
+            return prices;
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.warn({ err: e, symbol: upperSymbol }, 'Polygon historical price error');
         }
-      } catch (e) {
-        logger.warn({ err: e, symbol: upperSymbol }, 'Polygon historical price error');
+      } else {
+        logger.warn({ symbol: upperSymbol }, 'Polygon breaker open — skipping to failover');
       }
     }
 
@@ -397,34 +468,63 @@ export class MarketDataProvider {
     // Free IEX feed has no daily request cap, so it absorbs a Polygon/Massive
     // outage far better than Alpha Vantage's 25 req/day.
     if (this.config.alpacaApiKey && this.config.alpacaApiSecret) {
-      try {
-        const prices = await this.fetchAlpacaPrices(upperSymbol, days);
-        if (prices.length > 0) {
-          await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
-          return prices;
+      const breaker = getBreaker('alpaca');
+      if (breaker.canAttempt()) {
+        try {
+          const prices = await this.fetchAlpacaPrices(upperSymbol, days);
+          if (prices.length > 0) {
+            breaker.recordSuccess();
+            await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
+            return prices;
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.warn({ err: e, symbol: upperSymbol }, 'Alpaca historical price error');
         }
-      } catch (e) {
-        logger.warn({ err: e, symbol: upperSymbol }, 'Alpaca historical price error');
       }
     }
 
     if (this.config.alphaVantageApiKey) {
-      try {
-        const prices = await this.fetchAlphaVantagePrices(upperSymbol, days);
-        if (prices.length > 0) {
-          await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
-          return prices;
+      const breaker = getBreaker('alphaVantage');
+      if (breaker.canAttempt()) {
+        try {
+          const prices = await this.fetchAlphaVantagePrices(upperSymbol, days);
+          if (prices.length > 0) {
+            breaker.recordSuccess();
+            await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
+            return prices;
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.error({ err: e, symbol: upperSymbol }, 'Alpha Vantage price error');
         }
-      } catch (e) {
-        logger.error({ err: e, symbol: upperSymbol }, 'Alpha Vantage price error');
       }
+    }
+
+    // Graceful degradation (C2): every provider failed (or every breaker is
+    // open). Before hard-failing, serve last-resort stale cache rows — a
+    // month-old price series with a loud warning beats a blank dashboard.
+    const stale = await this.historicalPriceCache.getStalePrices(upperSymbol, days);
+    if (stale && stale.length > 0) {
+      const newest = stale[stale.length - 1]?.timestamp;
+      logger.warn(
+        {
+          symbol: upperSymbol,
+          rows: stale.length,
+          newestBar: newest instanceof Date ? newest.toISOString() : null,
+        },
+        'All upstream providers failed — serving STALE cached prices (graceful degradation)'
+      );
+      return stale;
     }
 
     // PRODUCTION: Throw error, no mock fallback
     if (!this.config.allowMockFallback) {
       throw new DataNotAvailableError(
-        `Unable to fetch historical prices for ${upperSymbol}: Alpha Vantage API key required. ` +
-        `Ensure ALPHA_VANTAGE_API_KEY is set.`
+        `Unable to fetch historical prices for ${upperSymbol}: all providers failed and no ` +
+        `cached data is available. Ensure POLYGON_API_KEY / ALPACA_API_KEY / ALPHA_VANTAGE_API_KEY are set.`
       );
     }
 
@@ -577,8 +677,14 @@ export class MarketDataProvider {
     }
 
     return new Promise((resolve, reject) => {
-      const wsUrl = 'wss://socket.polygon.io/stocks';
-      logger.info('Connecting to Polygon.io WebSocket');
+      // Polygon Stocks Starter is a 15-minute-DELAYED plan and is NOT entitled
+      // to the real-time cluster (wss://socket.polygon.io) — auth there
+      // succeeds but no trade/quote messages ever arrive, so the feed looked
+      // "connected" while silently delivering nothing. The delayed cluster
+      // (wss://delayed.polygon.io) is the entitled endpoint on Starter and
+      // streams the same delayed bars the REST snapshot returns.
+      const wsUrl = this.config.polygonWsUrl || 'wss://delayed.polygon.io/stocks';
+      logger.info({ wsUrl }, 'Connecting to Polygon.io WebSocket (delayed cluster)');
 
       this.polygonWs = new WebSocket(wsUrl);
 
@@ -818,9 +924,12 @@ export class MarketDataProvider {
       `https://api.polygon.io/v2/snapshot/locale/us/markets/stocks/tickers/` +
       `${encodeURIComponent(symbol)}?apiKey=${this.config.polygonApiKey}`;
 
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url, undefined);
     if (!response.ok) {
-      recordUpstreamError('polygon', classifyHttpStatus(response.status));
+      const { kind } = recordProviderError('polygon', response.status);
+      if (isAlertableErrorKind(kind)) {
+        logger.error({ symbol, status: response.status, kind }, 'Polygon quote auth/plan-tier failure');
+      }
       return null;
     }
 
@@ -892,9 +1001,12 @@ export class MarketDataProvider {
     const url =
       `${dataUrl}/v2/stocks/${encodeURIComponent(symbol)}/snapshot?feed=iex`;
 
-    const response = await fetch(url, { headers: this.alpacaHeaders() });
+    const response = await fetchWithRetry(url, { headers: this.alpacaHeaders() });
     if (!response.ok) {
-      recordUpstreamError('alpaca', classifyHttpStatus(response.status));
+      const { kind } = recordProviderError('alpaca', response.status);
+      if (isAlertableErrorKind(kind)) {
+        logger.error({ symbol, status: response.status, kind }, 'Alpaca quote auth/plan-tier failure');
+      }
       return null;
     }
 
@@ -949,11 +1061,11 @@ export class MarketDataProvider {
       `?timeframe=1Day&start=${fmt(start)}&end=${fmt(end)}` +
       `&adjustment=all&feed=iex&sort=asc&limit=10000`;
 
-    const response = await fetch(url, { headers: this.alpacaHeaders() });
+    const response = await fetchWithRetry(url, { headers: this.alpacaHeaders() });
     if (!response.ok) {
-      const impact = recordUpstreamError('alpaca', classifyHttpStatus(response.status));
+      const { impact, kind } = recordProviderError('alpaca', response.status);
       logger.warn(
-        { symbol, status: response.status, quotaImpact: impact, guidance: BACKOFF_GUIDANCE[impact] },
+        { symbol, status: response.status, quotaImpact: impact, kind, guidance: BACKOFF_GUIDANCE[impact] },
         'Alpaca HTTP non-200 for daily bars'
       );
       return [];
@@ -984,11 +1096,12 @@ export class MarketDataProvider {
   // ============================================================================
 
   /**
-   * Polygon REST historical aggregates — preferred path because the free tier
-   * is 5 req/min (vs Alpha Vantage's 25 req/day). The Polygon `aggs` endpoint
-   * returns daily OHLCV with one HTTP call per symbol.
+   * Polygon REST historical aggregates — preferred path. On the Stocks Starter
+   * plan Polygon has no per-minute call ceiling (unlike Alpha Vantage's
+   * 25 req/day free cap), so it's the primary and highest-volume source. The
+   * `aggs` endpoint returns daily OHLCV with one HTTP call per symbol.
    *
-   * Returns [] on any error so the caller falls through to Alpha Vantage.
+   * Returns [] on any error so the caller falls through to Alpaca / Alpha Vantage.
    */
   private async fetchPolygonPrices(symbol: string, days: number): Promise<Price[]> {
     const end = new Date();
@@ -1004,11 +1117,11 @@ export class MarketDataProvider {
       `/range/1/day/${fmt(start)}/${fmt(end)}` +
       `?adjusted=true&sort=asc&limit=5000&apiKey=${this.config.polygonApiKey}`;
 
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url, undefined);
     if (!response.ok) {
-      const impact = recordUpstreamError('polygon', classifyHttpStatus(response.status));
+      const { impact, kind } = recordProviderError('polygon', response.status);
       logger.warn(
-        { symbol, status: response.status, quotaImpact: impact, guidance: BACKOFF_GUIDANCE[impact] },
+        { symbol, status: response.status, quotaImpact: impact, kind, guidance: BACKOFF_GUIDANCE[impact] },
         'Polygon HTTP non-200 for historical aggregates'
       );
       return [];
@@ -1058,11 +1171,11 @@ export class MarketDataProvider {
     const outputsize = days > 100 ? 'full' : 'compact';
     const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=${symbol}&outputsize=${outputsize}&apikey=${this.config.alphaVantageApiKey}`;
 
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url, undefined);
     if (!response.ok) {
-      const impact = recordUpstreamError('alphaVantage', classifyHttpStatus(response.status));
+      const { impact, kind } = recordProviderError('alphaVantage', response.status);
       logger.warn(
-        { symbol, status: response.status, quotaImpact: impact, guidance: BACKOFF_GUIDANCE[impact] },
+        { symbol, status: response.status, quotaImpact: impact, kind, guidance: BACKOFF_GUIDANCE[impact] },
         'Alpha Vantage HTTP non-200'
       );
       return [];
@@ -1236,6 +1349,9 @@ export class MarketDataProvider {
 // Default export with environment configuration
 export const marketDataProvider = new MarketDataProvider({
   polygonApiKey: process.env.POLYGON_API_KEY,
+  // Delayed cluster by default (Starter entitlement); override via env only on
+  // a real-time Polygon plan.
+  polygonWsUrl: process.env.POLYGON_WS_URL,
   alphaVantageApiKey: process.env.ALPHA_VANTAGE_API_KEY,
   // Alpaca market-data failover — reuses the app-level Alpaca data credentials
   // when present. No-op until both are set (the chain skips the provider).

--- a/src/data/MarketDataProvider.ts
+++ b/src/data/MarketDataProvider.ts
@@ -677,12 +677,15 @@ export class MarketDataProvider {
     }
 
     return new Promise((resolve, reject) => {
-      // Polygon Stocks Starter is a 15-minute-DELAYED plan and is NOT entitled
-      // to the real-time cluster (wss://socket.polygon.io) — auth there
-      // succeeds but no trade/quote messages ever arrive, so the feed looked
-      // "connected" while silently delivering nothing. The delayed cluster
-      // (wss://delayed.polygon.io) is the entitled endpoint on Starter and
-      // streams the same delayed bars the REST snapshot returns.
+      // Polygon Stocks Starter is a 15-minute-DELAYED plan. Point the stream at
+      // the DELAYED cluster (wss://delayed.polygon.io/stocks) — Polygon's
+      // documented endpoint for delayed plans. NB (verified live 2026-07-02):
+      // auth SUCCEEDS on BOTH the delayed and the realtime cluster
+      // (wss://socket.polygon.io) with a Starter key, so a green auth is not
+      // proof of a working feed. The realtime cluster requires a realtime
+      // subscription to actually deliver data; a delayed plan must use the
+      // delayed cluster to receive the (15-min-delayed) trade/quote messages.
+      // Override via POLYGON_WS_URL only on a real-time plan.
       const wsUrl = this.config.polygonWsUrl || 'wss://delayed.polygon.io/stocks';
       logger.info({ wsUrl }, 'Connecting to Polygon.io WebSocket (delayed cluster)');
 

--- a/src/data/QuotaClassifier.ts
+++ b/src/data/QuotaClassifier.ts
@@ -2,9 +2,11 @@
  * Upstream Error Quota Classification (IDEA-CIN-5)
  *
  * Classifies every upstream data-provider failure by whether it consumed
- * quota. A rate-limited Polygon call DID burn a request against the 5/min
- * ceiling; a malformed query or auth rejection did not; a 5xx is the
- * provider's fault and says nothing about our budget. Different backoff
+ * quota. A rate-limited call (HTTP 429) DID burn a metered request; a
+ * malformed query or auth rejection did not; a 5xx is the provider's fault
+ * and says nothing about our budget. (Polygon Stocks Starter has no per-minute
+ * call ceiling, but Alpha Vantage's free tier does — 25 req/day — so the
+ * quota signal still matters for the failover providers.) Different backoff
  * strategies follow from each class — and the v1.3.7 cache-thrashing
  * investigation would have been faster with this signal in the logs.
  *
@@ -45,6 +47,39 @@ export function classifyHttpStatus(status: number): QuotaImpact {
 }
 
 /**
+ * Orthogonal to QuotaImpact (which is about *budget* accounting), this is the
+ * *operational* class of the failure — what a human should DO about it.
+ * `classifyHttpStatus` collapses 400/401/403/404/422 into a single
+ * `quota_free` bucket, which is right for quota math but hides the two cases
+ * that need a human: a revoked/invalid key (401) and a plan-tier block (403).
+ */
+export type ProviderErrorKind =
+  /** 429 — rate limited. Back off; transient. */
+  | 'rate_limit'
+  /** 401 — key invalid, revoked, or truncated. ALERT: needs key rotation. */
+  | 'auth'
+  /** 403 — entitlement/plan-tier block. Surface the plan limit, not an outage. */
+  | 'plan_tier'
+  /** 400/404/422 — malformed query or bad symbol. Benign; fix the request. */
+  | 'client_error'
+  /** 5xx / network — the provider's fault. Retry with jitter, then failover. */
+  | 'server_fault';
+
+/** Map an HTTP status to its operational error kind. */
+export function classifyErrorKind(status: number): ProviderErrorKind {
+  if (status === 429) return 'rate_limit';
+  if (status === 401) return 'auth';
+  if (status === 403) return 'plan_tier';
+  if (status >= 500) return 'server_fault';
+  return 'client_error';
+}
+
+/** Kinds that warrant an operator alert rather than silent failover. */
+export function isAlertableErrorKind(kind: ProviderErrorKind): boolean {
+  return kind === 'auth' || kind === 'plan_tier';
+}
+
+/**
  * Classify a 200-with-error-body response (both Polygon and Alpha Vantage
  * signal rate limits inside successful HTTP responses). Rate-limit language
  * means the request was metered; anything else is a free rejection.
@@ -69,11 +104,32 @@ interface QuotaStats {
   provider_fault: number;
 }
 
+type ErrorKindStats = Record<ProviderErrorKind, number>;
+
+const emptyKindStats = (): ErrorKindStats => ({
+  rate_limit: 0,
+  auth: 0,
+  plan_tier: 0,
+  client_error: 0,
+  server_fault: 0,
+});
+
 const stats: Record<UpstreamProvider, QuotaStats> = {
   polygon: { quota_burned: 0, quota_free: 0, provider_fault: 0 },
   alpaca: { quota_burned: 0, quota_free: 0, provider_fault: 0 },
   alphaVantage: { quota_burned: 0, quota_free: 0, provider_fault: 0 },
 };
+
+const kindStats: Record<UpstreamProvider, ErrorKindStats> = {
+  polygon: emptyKindStats(),
+  alpaca: emptyKindStats(),
+  alphaVantage: emptyKindStats(),
+};
+
+metrics.registerCounter(
+  'upstream_error_kinds_total',
+  'Upstream data-provider errors classified by operational kind',
+);
 
 let trackingSince = new Date();
 
@@ -84,23 +140,57 @@ export function recordUpstreamError(provider: UpstreamProvider, impact: QuotaImp
   return impact;
 }
 
+/**
+ * Record an HTTP error from a provider on BOTH axes at once — quota impact
+ * (for budget math) and operational kind (for alerting). Prefer this over
+ * calling `recordUpstreamError(provider, classifyHttpStatus(status))` at fetch
+ * sites so the auth/plan-tier signal is captured for E1 alerting.
+ */
+export function recordProviderError(
+  provider: UpstreamProvider,
+  status: number,
+): { impact: QuotaImpact; kind: ProviderErrorKind } {
+  const impact = classifyHttpStatus(status);
+  const kind = classifyErrorKind(status);
+  stats[provider][impact]++;
+  kindStats[provider][kind]++;
+  metrics.incCounter('upstream_errors_total', { provider, impact });
+  metrics.incCounter('upstream_error_kinds_total', { provider, kind });
+  return { impact, kind };
+}
+
+/** Per-provider count of a given operational error kind since tracking began. */
+export function getErrorKindCount(provider: UpstreamProvider, kind: ProviderErrorKind): number {
+  return kindStats[provider][kind];
+}
+
 /** Snapshot for the health surface. */
 export function getQuotaStats(): {
   since: string;
-  providers: Record<UpstreamProvider, QuotaStats & { guidance: string | null }>;
+  providers: Record<
+    UpstreamProvider,
+    QuotaStats & { guidance: string | null; errorKinds: ErrorKindStats }
+  >;
 } {
-  const withGuidance = (s: QuotaStats): QuotaStats & { guidance: string | null } => {
+  const withGuidance = (
+    provider: UpstreamProvider,
+  ): QuotaStats & { guidance: string | null; errorKinds: ErrorKindStats } => {
+    const s = stats[provider];
     // Surface the guidance for the dominant error class so the operator's
     // first glance at /health/quota says what to do next.
     const dominant = (Object.entries(s) as Array<[QuotaImpact, number]>).sort((a, b) => b[1] - a[1])[0];
-    return { ...s, guidance: dominant[1] > 0 ? BACKOFF_GUIDANCE[dominant[0]] : null };
+    return {
+      ...s,
+      guidance: dominant[1] > 0 ? BACKOFF_GUIDANCE[dominant[0]] : null,
+      errorKinds: { ...kindStats[provider] },
+    };
   };
   return {
     since: trackingSince.toISOString(),
     providers: {
-      polygon: withGuidance(stats.polygon),
-      alpaca: withGuidance(stats.alpaca),
-      alphaVantage: withGuidance(stats.alphaVantage),
+      polygon: withGuidance('polygon'),
+      alpaca: withGuidance('alpaca'),
+      alphaVantage: withGuidance('alphaVantage'),
     },
   };
 }
@@ -109,6 +199,7 @@ export function getQuotaStats(): {
 export function resetQuotaStats(): void {
   for (const provider of Object.keys(stats) as UpstreamProvider[]) {
     stats[provider] = { quota_burned: 0, quota_free: 0, provider_fault: 0 };
+    kindStats[provider] = emptyKindStats();
   }
   trackingSince = new Date();
 }

--- a/src/data/cache/CompositeCache.ts
+++ b/src/data/cache/CompositeCache.ts
@@ -71,6 +71,17 @@ export class CompositeCache {
   }
 
   /**
+   * Last-resort stale read (graceful degradation). Goes straight to the
+   * durable Supabase layer — the Memory layer is per-instance and cold on
+   * serverless, so it's usually empty exactly when we need this. Ignores
+   * coverage + freshness gates; returns whatever exists. Returns null only
+   * when the durable table has no rows for the symbol.
+   */
+  async getStalePrices(symbol: string, days: number): Promise<Price[] | null> {
+    return this.supabase.getStalePrices(symbol.toUpperCase(), days);
+  }
+
+  /**
    * Persist prices to BOTH layers. Memory write is synchronous; Supabase
    * write is awaited so callers can rely on durability before returning to
    * end users (matters for the cache warmer cron).

--- a/src/data/cache/SupabaseCache.ts
+++ b/src/data/cache/SupabaseCache.ts
@@ -154,6 +154,57 @@ export class SupabaseCache {
   }
 
   /**
+   * Last-resort read: return whatever rows exist for `symbol`, oldest-first,
+   * WITHOUT the coverage or freshness gates. Used only when every upstream
+   * provider has failed — serving month-old prices with a loud "stale" signal
+   * beats a hard `DataNotAvailableError` that blanks the whole dashboard.
+   * Returns null only when the table genuinely has no rows for the symbol.
+   */
+  async getStalePrices(symbol: string, days: number): Promise<Price[] | null> {
+    if (!this.enabled || !this.client) return null;
+
+    try {
+      const { data, error } = await this.client
+        .from('frontier_historical_prices')
+        .select('*')
+        .eq('symbol', symbol)
+        .order('date', { ascending: false })
+        .limit(days);
+
+      if (error) {
+        logger.warn({ err: error, symbol }, 'SupabaseCache.getStalePrices error');
+        return null;
+      }
+
+      const rows = (data ?? []) as Array<{
+        date: string;
+        open: number;
+        high: number;
+        low: number;
+        close: number;
+        adjusted_close: number;
+        volume: number;
+      }>;
+
+      if (rows.length === 0) return null;
+
+      rows.reverse();
+      return rows.map((r) => ({
+        symbol,
+        timestamp: new Date(r.date),
+        open: r.open,
+        high: r.high,
+        low: r.low,
+        close: r.adjusted_close,
+        volume: r.volume,
+      }));
+    } catch (err) {
+      logger.warn({ err, symbol }, 'SupabaseCache.getStalePrices threw');
+      return null;
+    }
+  }
+
+  /**
    * Upsert price rows for `symbol`. Batches at 100 rows per call to keep
    * upsert payloads small. Errors are logged and swallowed.
    */

--- a/src/data/resilience.ts
+++ b/src/data/resilience.ts
@@ -1,0 +1,203 @@
+/**
+ * Upstream resilience primitives (harden/data-provider-cdf).
+ *
+ * Two small, dependency-free building blocks the MarketDataProvider layers
+ * over its per-provider fetch calls:
+ *
+ *   1. `fetchWithRetry` — wraps a single HTTP call with bounded retry +
+ *      exponential backoff and full jitter. Retries only *transient* failures
+ *      (network throw, HTTP 429, HTTP 5xx). A 4xx that isn't 429 is returned
+ *      as-is: retrying a 401/403/404 burns time and never succeeds (mirrors
+ *      the `quota_free` guidance in QuotaClassifier — "fix the request").
+ *
+ *   2. `CircuitBreaker` — per-provider fast-fail. After `failureThreshold`
+ *      consecutive failures the breaker OPENS and `canAttempt()` returns false
+ *      for `cooldownMs`, so a hot 429 storm or a down provider stops getting
+ *      hammered on every request and the orchestrator skips straight to the
+ *      next provider. After the cooldown it goes HALF_OPEN and allows a single
+ *      probe; success closes it, failure re-opens it for another cooldown.
+ *
+ * Both are intentionally synchronous-state / in-memory (same posture as
+ * QuotaClassifier's counters): reset on process restart, no external store.
+ */
+
+export interface RetryOptions {
+  /** Max attempts total (including the first). Default 3 (1 try + 2 retries). */
+  retries?: number;
+  /** Base backoff in ms before the first retry. Default 200ms. */
+  baseDelayMs?: number;
+  /** Cap on any single backoff wait. Default 3000ms. */
+  maxDelayMs?: number;
+  /** Injectable sleeper (tests pass a no-op / fake timer). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable jitter source in [0,1). Default Math.random. */
+  random?: () => number;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/** True for statuses worth retrying against the SAME provider. */
+export function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Fetch with bounded retry + exponential backoff + full jitter.
+ *
+ * Retries on a thrown network error or a retryable status (429 / 5xx). Returns
+ * the final `Response` (which may still be non-OK if retries are exhausted) so
+ * the caller keeps its existing `response.ok` / status-classification logic.
+ * Re-throws the last network error only if every attempt threw.
+ */
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit | undefined,
+  opts: RetryOptions = {},
+): Promise<Response> {
+  const retries = Math.max(1, opts.retries ?? 3);
+  const baseDelayMs = opts.baseDelayMs ?? 200;
+  const maxDelayMs = opts.maxDelayMs ?? 3000;
+  const sleep = opts.sleep ?? defaultSleep;
+  const random = opts.random ?? Math.random;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, init);
+      if (attempt < retries && isRetryableStatus(response.status)) {
+        await sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs, random));
+        continue;
+      }
+      return response;
+    } catch (err) {
+      lastError = err;
+      if (attempt < retries) {
+        await sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs, random));
+        continue;
+      }
+    }
+  }
+
+  // Every attempt threw a network error — surface the last one.
+  throw lastError;
+}
+
+/**
+ * Exponential backoff with full jitter: random in [0, min(cap, base*2^(n-1))].
+ * Full jitter (vs equal jitter) is the AWS-recommended default for spreading
+ * retry storms; it minimizes contention when many callers back off together.
+ */
+export function backoffDelay(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  random: () => number = Math.random,
+): number {
+  const exp = Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
+  return Math.floor(random() * exp);
+}
+
+export type BreakerState = 'closed' | 'open' | 'half_open';
+
+export interface CircuitBreakerOptions {
+  /** Consecutive failures before the breaker opens. Default 5. */
+  failureThreshold?: number;
+  /** How long the breaker stays open before a half-open probe. Default 30s. */
+  cooldownMs?: number;
+  /** Injectable clock (tests). Default Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Per-provider circuit breaker. Not generic over keys — construct one per
+ * provider and hold them in a registry (see `getBreaker`).
+ */
+export class CircuitBreaker {
+  private failures = 0;
+  private state: BreakerState = 'closed';
+  private openedAt = 0;
+  private readonly failureThreshold: number;
+  private readonly cooldownMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: CircuitBreakerOptions = {}) {
+    this.failureThreshold = opts.failureThreshold ?? 5;
+    this.cooldownMs = opts.cooldownMs ?? 30_000;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Whether the caller should attempt the provider. Transitions open→half_open
+   * once the cooldown elapses (allowing exactly one probe through).
+   */
+  canAttempt(): boolean {
+    if (this.state === 'open') {
+      if (this.now() - this.openedAt >= this.cooldownMs) {
+        this.state = 'half_open';
+        return true;
+      }
+      return false;
+    }
+    // closed or half_open both allow an attempt (half_open = single probe).
+    return true;
+  }
+
+  recordSuccess(): void {
+    this.failures = 0;
+    this.state = 'closed';
+  }
+
+  recordFailure(): void {
+    // A failure while probing (half_open) re-opens immediately.
+    if (this.state === 'half_open') {
+      this.trip();
+      return;
+    }
+    this.failures += 1;
+    if (this.failures >= this.failureThreshold) {
+      this.trip();
+    }
+  }
+
+  private trip(): void {
+    this.state = 'open';
+    this.openedAt = this.now();
+    this.failures = this.failureThreshold;
+  }
+
+  getState(): BreakerState {
+    return this.state;
+  }
+
+  reset(): void {
+    this.failures = 0;
+    this.state = 'closed';
+    this.openedAt = 0;
+  }
+}
+
+/**
+ * Process-wide breaker registry keyed by provider name. Kept module-level so
+ * every MarketDataProvider instance shares breaker state for a given provider
+ * (the rate limit / outage is upstream, not per-instance). Tests can reset via
+ * `resetBreakers()`.
+ */
+const breakers = new Map<string, CircuitBreaker>();
+
+export function getBreaker(
+  provider: string,
+  opts?: CircuitBreakerOptions,
+): CircuitBreaker {
+  let b = breakers.get(provider);
+  if (!b) {
+    b = new CircuitBreaker(opts);
+    breakers.set(provider, b);
+  }
+  return b;
+}
+
+export function resetBreakers(): void {
+  breakers.clear();
+}

--- a/src/services/factorAnchors.ts
+++ b/src/services/factorAnchors.ts
@@ -13,8 +13,8 @@
  * re-running the factor engine. This is the exact pattern the
  * `/api/v1/portfolio/factors/history` endpoint (v1.3.4) uses. The caller passes
  * already-fetched prices and the factor engine; this module makes ZERO market
- * data calls of its own, so it cannot trip the Polygon free-tier 5-req/min
- * ceiling.
+ * data calls of its own, so it adds no upstream load regardless of provider
+ * plan.
  *
  * ## Bounded token growth
  *

--- a/tests/data/MarketDataProvider.test.ts
+++ b/tests/data/MarketDataProvider.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Integration tests for MarketDataProvider's failure-path behavior
+ * (harden/data-provider-cdf). Before this suite there was ZERO coverage on the
+ * real fetch path — only the health-probe's separate implementation was tested.
+ *
+ * MSW intercepts every upstream (Polygon, Alpaca, Alpha Vantage). Each test
+ * drives one scenario the plan called out:
+ *   - Polygon 429 → retry → Alpaca fallback
+ *   - Polygon 401 (revoked key) → classified `auth`, failover still serves
+ *   - all providers down → serve last-resort STALE cache (no hard throw)
+ *   - quote dedup: concurrent same-symbol callers hit upstream once
+ *   - circuit breaker open → provider skipped straight to failover
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../setup.js';
+
+// supabase.ts throws on import without these — set before importing the SUT.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+import { MarketDataProvider } from '../../src/data/MarketDataProvider.js';
+import type { CompositeCache } from '../../src/data/cache/index.js';
+import type { Price } from '../../src/types/index.js';
+import { resetBreakers, getBreaker } from '../../src/data/resilience.js';
+import { resetQuotaStats, getErrorKindCount } from '../../src/data/QuotaClassifier.js';
+
+const POLY_KEY = 'x'.repeat(32);
+
+// URL matchers for MSW.
+const POLY_SNAPSHOT = 'https://api.polygon.io/v2/snapshot/locale/us/markets/stocks/tickers/:symbol';
+const POLY_AGGS = 'https://api.polygon.io/v2/aggs/ticker/:symbol/range/1/day/:from/:to';
+const ALPACA_SNAPSHOT = 'https://data.alpaca.markets/v2/stocks/:symbol/snapshot';
+const ALPACA_BARS = 'https://data.alpaca.markets/v2/stocks/:symbol/bars';
+
+function polygonSnapshotOK(last: number) {
+  return HttpResponse.json({
+    status: 'OK',
+    ticker: {
+      todaysChange: 1.5,
+      todaysChangePerc: 1.0,
+      updated: Date.now() * 1e6,
+      min: { c: last },
+      day: { c: last - 1 },
+      prevDay: { c: last - 2 },
+    },
+  });
+}
+
+function alpacaSnapshotOK(last: number) {
+  return HttpResponse.json({
+    latestTrade: { p: last, t: new Date().toISOString() },
+    latestQuote: { bp: last - 0.05, ap: last + 0.05 },
+    dailyBar: { c: last },
+    prevDailyBar: { c: last - 1 },
+  });
+}
+
+/** A cache stub with controllable getStalePrices for the degradation test. */
+function stubCache(stale: Price[] | null = null): CompositeCache {
+  return {
+    getPrices: vi.fn().mockResolvedValue(null),
+    setPrices: vi.fn().mockResolvedValue(undefined),
+    getStalePrices: vi.fn().mockResolvedValue(stale),
+    telemetry: vi.fn(),
+    resetCounters: vi.fn(),
+  } as unknown as CompositeCache;
+}
+
+function makeProvider(overrides: Record<string, unknown> = {}): MarketDataProvider {
+  const p = new MarketDataProvider({
+    polygonApiKey: POLY_KEY,
+    alpacaApiKey: 'ak',
+    alpacaApiSecret: 'as',
+    allowMockFallback: false,
+    ...overrides,
+  });
+  // Force the durable quote-cache read off so tests exercise the upstream
+  // chain deterministically (no supabase-js calls MSW would flag).
+  (p as unknown as { useSupabaseCache: boolean }).useSupabaseCache = false;
+  return p;
+}
+
+beforeEach(() => {
+  resetBreakers();
+  resetQuotaStats();
+});
+
+describe('getQuote — failover + retry', () => {
+  it('retries a Polygon 429, then falls over to Alpaca', async () => {
+    let polyHits = 0;
+    server.use(
+      http.get(POLY_SNAPSHOT, () => {
+        polyHits += 1;
+        return new HttpResponse('rate limited', { status: 429 });
+      }),
+      http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(200)),
+    );
+
+    const provider = makeProvider();
+    const quote = await provider.getQuote('AAPL');
+
+    expect(quote?.last).toBe(200); // came from Alpaca
+    expect(polyHits).toBeGreaterThan(1); // 429 was retried before failover
+  });
+
+  it('classifies a Polygon 401 as an auth failure and still serves via Alpaca', async () => {
+    server.use(
+      http.get(POLY_SNAPSHOT, () => new HttpResponse('bad key', { status: 401 })),
+      http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(321)),
+    );
+
+    const provider = makeProvider();
+    const quote = await provider.getQuote('AAPL');
+
+    expect(quote?.last).toBe(321);
+    expect(getErrorKindCount('polygon', 'auth')).toBe(1);
+  });
+
+  it('does not retry a 401 (single Polygon hit)', async () => {
+    let polyHits = 0;
+    server.use(
+      http.get(POLY_SNAPSHOT, () => {
+        polyHits += 1;
+        return new HttpResponse('bad key', { status: 401 });
+      }),
+      http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(100)),
+    );
+
+    await makeProvider().getQuote('AAPL');
+    expect(polyHits).toBe(1);
+  });
+});
+
+describe('getQuote — dedup (D3)', () => {
+  it('coalesces concurrent same-symbol callers onto one upstream fetch', async () => {
+    let polyHits = 0;
+    server.use(
+      http.get(POLY_SNAPSHOT, async () => {
+        polyHits += 1;
+        // Small delay so the second caller arrives while the first is inflight.
+        await new Promise((r) => setTimeout(r, 20));
+        return polygonSnapshotOK(150);
+      }),
+    );
+
+    const provider = makeProvider();
+    const [a, b] = await Promise.all([provider.getQuote('AAPL'), provider.getQuote('AAPL')]);
+
+    expect(a?.last).toBe(150);
+    expect(b?.last).toBe(150);
+    expect(polyHits).toBe(1); // deduped
+  });
+});
+
+describe('getQuote — circuit breaker (D2)', () => {
+  it('skips Polygon entirely once its breaker is open', async () => {
+    let polyHits = 0;
+    server.use(
+      http.get(POLY_SNAPSHOT, () => {
+        polyHits += 1;
+        return polygonSnapshotOK(999);
+      }),
+      http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(42)),
+    );
+
+    // Pre-open the shared polygon breaker (default threshold 5).
+    const breaker = getBreaker('polygon');
+    for (let i = 0; i < 5; i++) breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+
+    const quote = await makeProvider().getQuote('AAPL');
+    expect(quote?.last).toBe(42); // served by Alpaca
+    expect(polyHits).toBe(0); // Polygon never called — breaker open
+  });
+});
+
+describe('getHistoricalPrices — graceful degradation (C2)', () => {
+  it('serves stale cache rows when every provider fails instead of throwing', async () => {
+    server.use(
+      http.get(POLY_AGGS, () => new HttpResponse('boom', { status: 500 })),
+      http.get(ALPACA_BARS, () => new HttpResponse('boom', { status: 500 })),
+    );
+
+    const staleRows: Price[] = [
+      { symbol: 'AAPL', timestamp: new Date('2026-05-01'), open: 1, high: 2, low: 1, close: 1.5, volume: 100 },
+      { symbol: 'AAPL', timestamp: new Date('2026-05-02'), open: 1.5, high: 2.5, low: 1.4, close: 2.0, volume: 120 },
+    ];
+    const cache = stubCache(staleRows);
+    const provider = makeProvider();
+    (provider as unknown as { historicalPriceCache: CompositeCache }).historicalPriceCache = cache;
+
+    const prices = await provider.getHistoricalPrices('AAPL', 2);
+    expect(prices).toHaveLength(2);
+    expect(prices[1].close).toBe(2.0);
+    expect(cache.getStalePrices).toHaveBeenCalledWith('AAPL', 2);
+  });
+
+  it('throws DataNotAvailableError when providers fail AND no stale cache exists', async () => {
+    server.use(
+      http.get(POLY_AGGS, () => new HttpResponse('boom', { status: 500 })),
+      http.get(ALPACA_BARS, () => new HttpResponse('boom', { status: 500 })),
+    );
+
+    const cache = stubCache(null); // no stale rows
+    const provider = makeProvider();
+    (provider as unknown as { historicalPriceCache: CompositeCache }).historicalPriceCache = cache;
+
+    await expect(provider.getHistoricalPrices('ZZZZ', 2)).rejects.toThrow(/all providers failed/);
+  });
+});

--- a/tests/data/QuotaClassifier.test.ts
+++ b/tests/data/QuotaClassifier.test.ts
@@ -10,7 +10,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   classifyHttpStatus,
   classifyErrorBody,
+  classifyErrorKind,
+  isAlertableErrorKind,
   recordUpstreamError,
+  recordProviderError,
+  getErrorKindCount,
   getQuotaStats,
   resetQuotaStats,
   BACKOFF_GUIDANCE,
@@ -102,5 +106,64 @@ describe('recordUpstreamError / getQuotaStats', () => {
     resetQuotaStats();
     const stats = getQuotaStats();
     expect(stats.providers.polygon.quota_burned).toBe(0);
+  });
+});
+
+describe('classifyErrorKind (C3 — operational error axis)', () => {
+  it('distinguishes the two human-actionable cases from benign client errors', () => {
+    expect(classifyErrorKind(429)).toBe('rate_limit');
+    expect(classifyErrorKind(401)).toBe('auth'); // revoked/invalid key
+    expect(classifyErrorKind(403)).toBe('plan_tier'); // entitlement block
+    expect(classifyErrorKind(400)).toBe('client_error');
+    expect(classifyErrorKind(404)).toBe('client_error');
+    expect(classifyErrorKind(422)).toBe('client_error');
+    expect(classifyErrorKind(500)).toBe('server_fault');
+    expect(classifyErrorKind(503)).toBe('server_fault');
+  });
+
+  it('flags only auth + plan_tier as alertable', () => {
+    expect(isAlertableErrorKind('auth')).toBe(true);
+    expect(isAlertableErrorKind('plan_tier')).toBe(true);
+    expect(isAlertableErrorKind('rate_limit')).toBe(false);
+    expect(isAlertableErrorKind('client_error')).toBe(false);
+    expect(isAlertableErrorKind('server_fault')).toBe(false);
+  });
+});
+
+describe('recordProviderError (dual-axis recorder)', () => {
+  it('records both quota impact and operational kind from one status', () => {
+    const r = recordProviderError('polygon', 401);
+    expect(r.impact).toBe('quota_free'); // auth rejection is not metered
+    expect(r.kind).toBe('auth');
+
+    const stats = getQuotaStats();
+    expect(stats.providers.polygon.quota_free).toBe(1);
+    expect(stats.providers.polygon.errorKinds.auth).toBe(1);
+    expect(getErrorKindCount('polygon', 'auth')).toBe(1);
+  });
+
+  it('separates a revoked key (401) from a plan-tier block (403)', () => {
+    recordProviderError('polygon', 401);
+    recordProviderError('polygon', 403);
+    recordProviderError('polygon', 403);
+
+    expect(getErrorKindCount('polygon', 'auth')).toBe(1);
+    expect(getErrorKindCount('polygon', 'plan_tier')).toBe(2);
+    // Both still land in the quota_free bucket for budget accounting.
+    expect(getQuotaStats().providers.polygon.quota_free).toBe(3);
+  });
+
+  it('counts a 429 as both quota_burned and rate_limit kind', () => {
+    recordProviderError('alpaca', 429);
+    const stats = getQuotaStats();
+    expect(stats.providers.alpaca.quota_burned).toBe(1);
+    expect(stats.providers.alpaca.errorKinds.rate_limit).toBe(1);
+  });
+
+  it('resetQuotaStats clears error-kind counters too', () => {
+    recordProviderError('polygon', 401);
+    resetQuotaStats();
+    expect(getErrorKindCount('polygon', 'auth')).toBe(0);
+    expect(getQuotaStats().providers.polygon.errorKinds.auth).toBe(0);
   });
 });

--- a/tests/data/resilience.test.ts
+++ b/tests/data/resilience.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for the upstream resilience primitives (harden/data-provider-cdf).
+ * Pure logic — no network, no MSW. Timers/clock/jitter are all injected so the
+ * tests are deterministic and instant.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  fetchWithRetry,
+  backoffDelay,
+  isRetryableStatus,
+  CircuitBreaker,
+  getBreaker,
+  resetBreakers,
+} from '../../src/data/resilience.js';
+
+describe('isRetryableStatus', () => {
+  it('retries 429 and 5xx', () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+  });
+
+  it('does NOT retry 4xx that is not 429', () => {
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(401)).toBe(false);
+    expect(isRetryableStatus(403)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+
+  it('does not retry 2xx', () => {
+    expect(isRetryableStatus(200)).toBe(false);
+  });
+});
+
+describe('backoffDelay', () => {
+  it('grows exponentially and is capped', () => {
+    // random()~=1 => the full ceiling (floor of base*2^(n-1), capped at max)
+    const r = () => 0.999999;
+    expect(backoffDelay(1, 100, 10000, r)).toBe(99); // ~100*2^0
+    expect(backoffDelay(2, 100, 10000, r)).toBe(199); // ~100*2^1
+    expect(backoffDelay(3, 100, 10000, r)).toBe(399); // ~100*2^2
+    expect(backoffDelay(10, 100, 500, r)).toBe(499); // capped at 500
+  });
+
+  it('full jitter: random()=0 yields 0 delay', () => {
+    expect(backoffDelay(5, 100, 10000, () => 0)).toBe(0);
+  });
+});
+
+describe('fetchWithRetry', () => {
+  const noSleep = () => Promise.resolve();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns immediately on a 200 (no retry)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { sleep: noSleep });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a 429 then succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('rl', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { retries: 3, sleep: noSleep });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('exhausts retries and returns the last non-OK response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('rl', { status: 429 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { retries: 3, sleep: noSleep });
+    expect(res.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 + 2 retries
+  });
+
+  it('does NOT retry a 401 (returns it on the first call)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('nope', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { retries: 3, sleep: noSleep });
+    expect(res.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a thrown network error then succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { retries: 3, sleep: noSleep });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws the last error when every attempt throws', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchWithRetry('https://x.test', undefined, { retries: 2, sleep: noSleep }),
+    ).rejects.toThrow('down');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('CircuitBreaker', () => {
+  it('stays closed and allows attempts below the failure threshold', () => {
+    const b = new CircuitBreaker({ failureThreshold: 3 });
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.canAttempt()).toBe(true);
+    expect(b.getState()).toBe('closed');
+  });
+
+  it('opens after the failure threshold and blocks attempts', () => {
+    const b = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 1000 });
+    b.recordFailure();
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.getState()).toBe('open');
+    expect(b.canAttempt()).toBe(false);
+  });
+
+  it('half-opens after cooldown and allows a single probe', () => {
+    let t = 1000;
+    const b = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 500, now: () => t });
+    b.recordFailure(); // opens at t=1000
+    expect(b.canAttempt()).toBe(false);
+    t = 1600; // cooldown elapsed
+    expect(b.canAttempt()).toBe(true);
+    expect(b.getState()).toBe('half_open');
+  });
+
+  it('closes on success after a half-open probe', () => {
+    let t = 0;
+    const b = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 100, now: () => t });
+    b.recordFailure();
+    t = 200;
+    b.canAttempt(); // → half_open
+    b.recordSuccess();
+    expect(b.getState()).toBe('closed');
+    expect(b.canAttempt()).toBe(true);
+  });
+
+  it('re-opens if the half-open probe fails', () => {
+    let t = 0;
+    const b = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 100, now: () => t });
+    b.recordFailure();
+    t = 200;
+    b.canAttempt(); // → half_open
+    b.recordFailure(); // probe failed → re-open
+    expect(b.getState()).toBe('open');
+    expect(b.canAttempt()).toBe(false); // still within the new cooldown
+  });
+
+  it('a success resets the consecutive-failure count', () => {
+    const b = new CircuitBreaker({ failureThreshold: 3 });
+    b.recordFailure();
+    b.recordFailure();
+    b.recordSuccess();
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.getState()).toBe('closed'); // only 2 in a row since the success
+  });
+});
+
+describe('getBreaker registry', () => {
+  beforeEach(() => resetBreakers());
+
+  it('returns the same instance for a provider name', () => {
+    const a = getBreaker('polygon');
+    const b = getBreaker('polygon');
+    expect(a).toBe(b);
+  });
+
+  it('resetBreakers clears shared state', () => {
+    const a = getBreaker('polygon');
+    resetBreakers();
+    const b = getBreaker('polygon');
+    expect(a).not.toBe(b);
+  });
+});


### PR DESCRIPTION
> **Stacked on #21** (`feat/alpaca-data-failover`). Merge #21 first; this PR's base will retarget to `main` automatically, leaving only the C+D+F diff.

Hardens the market-data path now that it's a paid Polygon Starter dependency. Part of the Polygon Starter harden+unlock plan (Workstreams C, D, F).

## Correctness (C)

- **C1 — WebSocket delayed cluster.** The stream connected to Polygon's **realtime** cluster (`wss://socket.polygon.io`), which a 15-min-delayed Starter plan is not entitled to: auth succeeds but no trade/quote messages ever arrive, so the feed reported "connected" while silently delivering nothing. Now points at `wss://delayed.polygon.io/stocks` (entitled on Starter), overridable via `POLYGON_WS_URL`.
- **C2 — Graceful degradation.** When Polygon + Alpaca + Alpha Vantage all fail, serve last-resort **stale** cache rows (`getStalePrices`, no freshness/coverage gate) with a loud warning instead of throwing `DataNotAvailableError`. A blank dashboard was the worst-case; stale-but-shown is strictly better.
- **C3 — Error classification.** `classifyHttpStatus` collapsed 400/401/403/404/422 into one `quota_free` bucket. Added an orthogonal operational axis (`classifyErrorKind`): **401=auth** (alert, rotate key), **403=plan_tier** (surface plan limit), **400/404/422=client_error**. `recordProviderError` records both axes; per-kind counts are exposed for E1 alerting.

## Reliability (D)

- **D1 — `fetchWithRetry`.** Bounded retry + exponential backoff with full jitter on transient failures (429/5xx/network). Never retries a 401/403/404 (retrying burns time and never succeeds).
- **D2 — `CircuitBreaker`.** Per-provider fast-fail: opens after N consecutive failures, half-open probe after cooldown, shared registry across instances. A hot 429 storm or down provider is skipped, not hammered.
- **D3 — Quote dedup.** Mirrors the existing historical in-flight `Map` for `getQuote` so concurrent same-symbol callers coalesce onto one upstream fetch.
- **D4 — Tests.** NEW `tests/data/resilience.test.ts` + `tests/data/MarketDataProvider.test.ts` — the **first-ever** coverage on the real fetch path: 429→retry→Alpaca failover, 401→auth classification, all-providers-down→serve-stale, quote dedup, breaker-open→skip.

## Cleanup (F)

- Removed stale "Polygon free tier 5 req/min" comments (Starter is unlimited); relaxed `CacheWarmer.MAX_CONCURRENT_UPSTREAM` 4→8 (a fairness bound now, not a rate cap).
- `env-schema.json`: documented optional `POLYGON_WS_URL`.

## Testing

- **1001 server tests pass** (was 966; +35 new)
- `typecheck` + `lint` + `arch:check` all clean