### PR TITLE
feat(earnings): use 5 years of history (Polygon Starter entitlement)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ tests/visual/playwright-report/
 # Local AI context — kept on disk, never published
 CLAUDE.md
 CLAUDE-DESIGN-BRIEF.md
+
+# Supabase CLI local temp
+supabase/.temp/

--- a/client/index.html
+++ b/client/index.html
@@ -11,19 +11,28 @@
     <link rel="icon" type="image/png" href="/metaventions-logo.png" />
     <link rel="manifest" href="/manifest.json" />
     <link rel="apple-touch-icon" href="/metaventions-logo.png" />
+    <link rel="canonical" href="https://frontier-alpha.metaventionsai.com/" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#0F1219" media="(prefers-color-scheme: dark)" />
     <meta name="theme-color" content="#F8FAFC" media="(prefers-color-scheme: light)" />
-    <meta name="description" content="Frontier Alpha by Metaventions AI — 💎 Cognitive Factor Intelligence Platform. Institutional-grade portfolio analytics with AI-powered explanations." />
+    <meta name="description" content="Frontier Alpha by Metaventions AI is an institutional-grade portfolio analysis platform: cognitive factor intelligence across 76 factor exposures, with explainable AI explanations for every signal." />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-title" content="Frontier Alpha" />
 
     <!-- Open Graph / Social sharing -->
     <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="Metaventions AI" />
+    <meta property="og:url" content="https://frontier-alpha.metaventionsai.com" />
     <meta property="og:title" content="Frontier Alpha | Metaventions AI" />
-    <meta property="og:description" content="💎 AI-Powered cognitive factor intelligence with institutional-grade portfolio analytics." />
-    <meta property="og:image" content="/metaventions-logo.png" />
+    <meta property="og:description" content="Institutional-grade portfolio analysis with cognitive factor intelligence and explainable AI. Score a portfolio across 76 factors and read the model's plain-English explanation for every signal." />
+    <meta property="og:image" content="https://frontier-alpha.metaventionsai.com/metaventions-logo.png" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Frontier Alpha | Metaventions AI" />
+    <meta name="twitter:description" content="Institutional-grade portfolio analysis with cognitive factor intelligence and explainable AI. Score a portfolio across 76 factors and read the model's plain-English explanation for every signal." />
+    <meta name="twitter:image" content="https://frontier-alpha.metaventionsai.com/metaventions-logo.png" />
 
     <title>Frontier Alpha | Metaventions AI</title>
     <style>

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -1,8 +1,7 @@
 # Robots.txt for Frontier Alpha
-# https://frontier-alpha-ruby.vercel.app
+# https://frontier-alpha.metaventionsai.com
 
 User-agent: *
 Allow: /
 
-# Sitemap (if available)
-# Sitemap: https://frontier-alpha-ruby.vercel.app/sitemap.xml
+Sitemap: https://frontier-alpha.metaventionsai.com/sitemap.xml

--- a/client/public/sitemap.xml
+++ b/client/public/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://frontier-alpha.metaventionsai.com/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://frontier-alpha.metaventionsai.com/landing</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://frontier-alpha.metaventionsai.com/dashboard</loc>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://frontier-alpha.metaventionsai.com/pricing</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.7</priority>
+  </url>
+</urlset>

--- a/client/src/components/auth/ProtectedRoute.test.tsx
+++ b/client/src/components/auth/ProtectedRoute.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * Tests for ProtectedRoute — locks in the OPEN FRONT DOOR contract (2026-06-23).
+ *
+ * The three auth-lifecycle states the component branches on:
+ *   1. !isReady              -> spinner only, NO children, NO demo banner.
+ *   2. isReady && !session   -> children AND the demo banner (the open door —
+ *                               unauthed visitors get the full app, not /landing).
+ *   3. isReady && session    -> children, NO demo banner, clearDemoMode() called.
+ *
+ * The auth store uses selector reads (`useAuthStore((s) => s.isReady)`), so the
+ * mock invokes the selector against a controllable state object.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { ProtectedRoute } from './ProtectedRoute';
+
+// Controllable auth state the selector mock reads from.
+const authState: { isReady: boolean; session: unknown } = {
+  isReady: false,
+  session: null,
+};
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: <T,>(selector: (state: typeof authState) => T): T =>
+    selector(authState),
+}));
+
+// Spy on clearDemoMode so the authed branch's latch-drop is observable.
+const clearDemoMode = vi.fn();
+vi.mock('@/lib/demoMode', () => ({
+  clearDemoMode: () => clearDemoMode(),
+}));
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <ProtectedRoute>
+        <div data-testid="protected-children">protected content</div>
+      </ProtectedRoute>
+    </MemoryRouter>
+  );
+}
+
+describe('ProtectedRoute', () => {
+  beforeEach(() => {
+    authState.isReady = false;
+    authState.session = null;
+    clearDemoMode.mockClear();
+  });
+
+  it('pre-hydration (!isReady): renders only the spinner, no children, no banner', () => {
+    authState.isReady = false;
+    authState.session = null;
+    renderRoute();
+
+    // Spinner renders a Loader2 SVG with the animate-spin class.
+    expect(document.querySelector('svg.animate-spin')).toBeInTheDocument();
+    expect(screen.queryByTestId('protected-children')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('demo-mode-banner')).not.toBeInTheDocument();
+  });
+
+  it('ready + no session: OPEN DOOR — renders children AND the demo banner', () => {
+    authState.isReady = true;
+    authState.session = null;
+    renderRoute();
+
+    // The critical open-door assertion: app is reachable without an account.
+    expect(screen.getByTestId('protected-children')).toBeInTheDocument();
+    const banner = screen.getByTestId('demo-mode-banner');
+    expect(banner).toBeInTheDocument();
+    expect(banner).toHaveTextContent(/Demo Mode: exploring without an account/i);
+    // Banner offers the signup escape hatch.
+    expect(screen.getByRole('link', { name: /sign up free/i })).toHaveAttribute(
+      'href',
+      '/login'
+    );
+    // No spinner once hydrated.
+    expect(document.querySelector('svg.animate-spin')).not.toBeInTheDocument();
+  });
+
+  it('ready + session: renders children, no banner, drops the demo latch', () => {
+    authState.isReady = true;
+    authState.session = { access_token: 'token', user: { id: 'u1' } };
+    renderRoute();
+
+    expect(screen.getByTestId('protected-children')).toBeInTheDocument();
+    expect(screen.queryByTestId('demo-mode-banner')).not.toBeInTheDocument();
+    expect(document.querySelector('svg.animate-spin')).not.toBeInTheDocument();
+    expect(clearDemoMode).toHaveBeenCalled();
+  });
+});

--- a/client/src/components/auth/ProtectedRoute.tsx
+++ b/client/src/components/auth/ProtectedRoute.tsx
@@ -19,10 +19,10 @@
  * State predicates documented there — keep that section in sync with this
  * component's branch logic.
  */
-import { Navigate, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import { useAuthStore } from '@/stores/authStore';
 import { Spinner } from '@/components/shared/Spinner';
-import { detectDemoMode, clearDemoMode } from '@/lib/demoMode';
+import { clearDemoMode } from '@/lib/demoMode';
 
 interface ProtectedRouteProps {
   children: React.ReactNode;
@@ -42,18 +42,22 @@ export function ProtectedRoute({ children }: ProtectedRouteProps) {
     );
   }
 
-  // Verified-unauthed: demo mode (IDEA-FF-6) mounts the tree anyway under a
-  // persistent banner; otherwise redirect. A real session always wins.
+  // Verified-unauthed: OPEN FRONT DOOR (2026-06-23). Render the full app for
+  // every unauthenticated visitor under a persistent demo banner, instead of
+  // redirecting to /landing. Pre-revenue, discoverability beats gating — when
+  // the app was openly reachable, people actually found it and reached out.
+  // Safe to open: the only usage-metered path (the LLM explainer) stays gated
+  // behind auth + Pro (`requirePlan('pro')`), and public data reads fail to
+  // free-tier rate limits, not to a bill. The marketing page still lives at
+  // /landing; `?demo=true` remains a valid shareable entry. A real session
+  // always wins (this branch only runs when there is none).
   if (!session) {
-    if (detectDemoMode()) {
-      return (
-        <>
-          <DemoModeBanner />
-          {children}
-        </>
-      );
-    }
-    return <Navigate to="/landing" replace />;
+    return (
+      <>
+        <DemoModeBanner />
+        {children}
+      </>
+    );
   }
 
   // Verified-authed: render protected tree (and drop any stale demo latch).
@@ -74,7 +78,7 @@ function DemoModeBanner() {
       style={{ boxShadow: '0 2px 16px color-mix(in srgb, var(--color-accent) 25%, transparent)' }}
     >
       <p className="mono text-[10px] sm:text-xs tracking-[0.2em] uppercase text-theme">
-        Demo Mode — exploring without an account
+        Demo Mode: exploring without an account
       </p>
       <Link
         to="/login"

--- a/client/src/components/layout/Header.test.tsx
+++ b/client/src/components/layout/Header.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * Tests for Header's live index-quote tile (2026-06-23).
+ *
+ * `useHeaderQuote()` calls `GET /api/v1/quotes/SPY` through the shared axios
+ * client (which unwraps to the JSON body, so `api.get` resolves to the
+ * endpoint's `{ data: HeaderQuote }`). The tile renders only while LOADING or
+ * when a real quote is present; on a failed/empty fetch it renders NOTHING —
+ * no dead "—" placeholder.
+ *
+ * The contract this file locks in:
+ *   1. Valid SPY payload  -> "SPY" + price + change%, colored up/down.
+ *   2. select() returns null (no `data`) -> tile gone, no dead dash.
+ *   3. Query errors        -> tile gone, no dead dash.
+ *   4. In-flight           -> tile shows the "Loading" placeholder (not a dash).
+ *
+ * Header also mounts AlertDropdown (reads the auth store + api) so both
+ * `@/api/client` and `@/stores/authStore` are mocked, and the component is
+ * wrapped in the providers it needs (QueryClientProvider + MemoryRouter for
+ * its <Link>s).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { Header } from './Header';
+
+// Mock the shared axios client. Header's quote query and AlertDropdown's
+// alerts query both go through `api.get`.
+vi.mock('@/api/client', () => ({
+  api: {
+    get: vi.fn(),
+  },
+  getErrorMessage: vi.fn(() => 'An error occurred'),
+}));
+
+// AlertDropdown reads `useAuthStore()` (object destructure).
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => ({ user: null, session: null }),
+}));
+
+// themeStore calls `window.matchMedia(...)` at module top-level, which runs at
+// import time — before the test-setup `beforeAll` installs the matchMedia
+// polyfill. Mock the store to a stable toggle so the real module never loads.
+vi.mock('@/stores/themeStore', () => ({
+  useThemeStore: () => ({ resolved: 'dark', toggle: vi.fn() }),
+}));
+
+const VALID_QUOTE = {
+  symbol: 'SPY',
+  last: 612.34,
+  change: 4.21,
+  changePercent: 0.69,
+};
+
+const VALID_QUOTE_DOWN = {
+  symbol: 'SPY',
+  last: 598.1,
+  change: -7.5,
+  changePercent: -1.24,
+};
+
+function renderHeader() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <Header />
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// The header quote tile is the role="status" region whose accessible name
+// references the SPY symbol (the "Live connection active" status is separate).
+function getQuoteTile(): HTMLElement | null {
+  const statuses = screen.queryAllByRole('status');
+  return (
+    statuses.find((el) =>
+      /SPY|Loading SPY/i.test(el.getAttribute('aria-label') ?? '')
+    ) ?? null
+  );
+}
+
+async function mockGet(impl: (url: string) => unknown) {
+  const { api } = await import('@/api/client');
+  (api.get as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+    if (url.startsWith('/quotes/')) return impl(url);
+    // AlertDropdown's /alerts query — keep it benign.
+    return Promise.resolve({ data: [] });
+  });
+}
+
+describe('Header quote tile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders SPY, price, and a positive change% in the up color on a valid payload', async () => {
+    await mockGet(() => Promise.resolve({ data: VALID_QUOTE }));
+    renderHeader();
+
+    // Price appears once the query resolves.
+    expect(await screen.findByText('612.34')).toBeInTheDocument();
+
+    const tile = getQuoteTile();
+    expect(tile).not.toBeNull();
+    expect(tile!).toHaveTextContent('SPY');
+    expect(tile!).toHaveTextContent('612.34');
+
+    // Positive change is prefixed "+" and colored with --color-positive.
+    const change = screen.getByText('+0.69%');
+    expect(change).toBeInTheDocument();
+    expect(change).toHaveStyle({ color: 'var(--color-positive)' });
+  });
+
+  it('colors a negative change% with the down color and no "+" prefix', async () => {
+    await mockGet(() => Promise.resolve({ data: VALID_QUOTE_DOWN }));
+    renderHeader();
+
+    const change = await screen.findByText('-1.24%');
+    expect(change).toBeInTheDocument();
+    expect(change).toHaveStyle({ color: 'var(--color-negative)' });
+    // No erroneous "+" on a down move.
+    expect(screen.queryByText('+-1.24%')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing (no dead "—") when the quote payload is empty/null', async () => {
+    // No `data` field -> select() returns null -> tile must not render.
+    await mockGet(() => Promise.resolve({ data: undefined }));
+    renderHeader();
+
+    // Let the query settle; the tile should never appear.
+    await waitFor(() => {
+      expect(getQuoteTile()).toBeNull();
+    });
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+    // The unrelated "Live" connection status still renders, proving the
+    // header mounted and only the quote tile was suppressed.
+    expect(screen.getByLabelText('Live connection active')).toBeInTheDocument();
+  });
+
+  it('renders nothing (no dead "—") when the quote query errors', async () => {
+    await mockGet(() => Promise.reject(new Error('upstream 429')));
+    renderHeader();
+
+    // The test QueryClient sets retry:false and the query no longer overrides
+    // it, so the failing query settles to error immediately and the tile is
+    // suppressed without waiting on a retry backoff.
+    await waitFor(() => {
+      expect(getQuoteTile()).toBeNull();
+    });
+    expect(screen.queryByText('—')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Live connection active')).toBeInTheDocument();
+  });
+
+  it('shows the "Loading" placeholder (not a dash) while the quote is in flight', async () => {
+    // A never-resolving promise keeps the query in its loading state.
+    await mockGet(() => new Promise(() => {}));
+    renderHeader();
+
+    const tile = await waitFor(() => {
+      const t = getQuoteTile();
+      expect(t).not.toBeNull();
+      return t!;
+    });
+    expect(tile).toHaveTextContent('SPY');
+    expect(tile).toHaveTextContent('Loading');
+    expect(tile).not.toHaveTextContent('—');
+  });
+});

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -1,8 +1,44 @@
 import { Link, useLocation } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
 import { Settings, Menu, HelpCircle, Moon, Sun } from 'lucide-react';
 import { AlertDropdown } from '@/components/alerts/AlertDropdown';
 import { HelpKeyboardHint } from '@/components/help';
 import { useThemeStore } from '@/stores/themeStore';
+import { api } from '@/api/client';
+
+/** Default index ticker shown in the header quote tile. */
+const HEADER_QUOTE_SYMBOL = 'SPY';
+
+interface HeaderQuote {
+  symbol: string;
+  last: number;
+  change: number;
+  changePercent: number;
+}
+
+/**
+ * Live delayed quote for the header tile (default: SPY).
+ *
+ * Hits the public REST endpoint `GET /api/v1/quotes/:symbol` (Polygon Stocks
+ * Starter, delayed) rather than the WebSocket stream, so it works on the
+ * Vercel tier where `polygonWebSocket` is degraded by design. The shared axios
+ * client unwraps the response to the JSON body, so `response.data` is the
+ * endpoint's `data` field.
+ */
+function useHeaderQuote() {
+  return useQuery({
+    queryKey: ['header-quote', HEADER_QUOTE_SYMBOL],
+    queryFn: () => api.get(`/quotes/${HEADER_QUOTE_SYMBOL}`),
+    select: (response): HeaderQuote | null => {
+      const data = (response as { data?: HeaderQuote } | undefined)?.data;
+      if (!data || typeof data.last !== 'number') return null;
+      return data;
+    },
+    staleTime: 60_000,
+    refetchInterval: 60_000,
+    retry: 1,
+  });
+}
 
 const pageTitleMap: Record<string, string> = {
   '/': 'Dashboard',
@@ -31,6 +67,8 @@ export function Header({ onMenuClick, onHelpClick }: HeaderProps) {
   const { resolved, toggle } = useThemeStore();
   const location = useLocation();
   const pageTitle = pageTitleMap[location.pathname] || '';
+  const { data: quote, isLoading: isQuoteLoading } = useHeaderQuote();
+  const quoteUp = quote ? quote.changePercent >= 0 : true;
 
   return (
     <header className="fixed top-0 left-0 right-0 h-16 glass-slab-floating z-50">
@@ -93,6 +131,43 @@ export function Header({ onMenuClick, onHelpClick }: HeaderProps) {
         </div>
 
         <div className="flex items-center gap-2 sm:gap-3">
+          {/* Live delayed index quote (default SPY) */}
+          {!(quote == null && !isQuoteLoading) && (
+            <div
+              className="hidden md:flex items-center gap-2 px-2.5 py-1 rounded-full glass-slab min-w-[150px]"
+              role="status"
+              aria-label={
+                quote
+                  ? `${quote.symbol} ${quote.last.toFixed(2)}, ${quote.changePercent >= 0 ? 'up' : 'down'} ${Math.abs(quote.changePercent).toFixed(2)} percent`
+                  : `Loading ${HEADER_QUOTE_SYMBOL} quote`
+              }
+            >
+              <span className="text-[9px] text-theme-muted mono tracking-[0.3em] uppercase">
+                {HEADER_QUOTE_SYMBOL}
+              </span>
+              {quote ? (
+                <>
+                  <span className="text-xs font-semibold text-theme tabular-nums">
+                    {quote.last.toFixed(2)}
+                  </span>
+                  <span
+                    className="text-[10px] font-medium tabular-nums"
+                    style={{
+                      color: quoteUp
+                        ? 'var(--color-positive)'
+                        : 'var(--color-negative)',
+                    }}
+                  >
+                    {quoteUp ? '+' : ''}
+                    {quote.changePercent.toFixed(2)}%
+                  </span>
+                </>
+              ) : (
+                <span className="text-xs text-theme-muted tabular-nums">Loading</span>
+              )}
+            </div>
+          )}
+
           <div
             className="hidden sm:flex items-center gap-2 px-2.5 py-1 rounded-full glass-slab"
             role="status"

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -36,7 +36,9 @@ function useHeaderQuote() {
     },
     staleTime: 60_000,
     refetchInterval: 60_000,
-    retry: 1,
+    // retry inherits the global QueryClient default (1) in production; not
+    // overridden here so tests can set retry:false for deterministic error
+    // settling without changing prod behavior.
   });
 }
 

--- a/client/src/components/layout/Sidebar.tsx
+++ b/client/src/components/layout/Sidebar.tsx
@@ -139,9 +139,13 @@ export function Sidebar({ onNavigate }: SidebarProps) {
       </nav>
 
       <div className="p-4 border-t border-theme glass-slab">
-        <div className="p-3 rounded-sm bg-[image:var(--gradient-sovereign)] text-white animate-press animate-lift shadow-[0_4px_20px_rgba(123,44,255,0.3)] hover:brightness-110 transition-[filter] duration-200 cursor-default">
-          <p className="text-[10px] font-bold mono tracking-[0.3em] uppercase">DQ Score: 0.88</p>
-          <p className="text-[10px] mono mt-1 opacity-80">Powered by 80+ factors</p>
+        {/* DQ Score chip — status surface, not a CTA. The sovereign gradient is
+            demoted to a thin left rail + the numerals only (gradient text) so
+            the brand reads as a refined accent on calm glass, not a candy fill. */}
+        <div className="relative overflow-hidden p-3 rounded-sm glass-slab-floating border border-theme-light animate-press cursor-default before:absolute before:inset-y-0 before:left-0 before:w-[3px] before:bg-[image:var(--gradient-sovereign)]">
+          <p className="mono text-[10px] font-semibold tracking-[0.3em] uppercase text-theme-muted">DQ Score</p>
+          <p className="mt-0.5 text-2xl font-semibold leading-none tabular-nums bg-[image:var(--gradient-sovereign)] bg-clip-text text-transparent">0.88</p>
+          <p className="mt-1.5 mono text-[10px] tracking-[0.15em] uppercase text-theme-muted">Powered by 80+ factors</p>
         </div>
       </div>
     </aside>

--- a/client/src/components/onboarding/OnboardingProvider.test.tsx
+++ b/client/src/components/onboarding/OnboardingProvider.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Tests for OnboardingProvider's authenticated auto-launch gate (2026-06-23).
+ *
+ * The app is now public — unauthenticated visitors land directly in the app
+ * under the demo banner (see ProtectedRoute). Onboarding (welcome modal +
+ * feature tour) must only AUTO-RUN for real signed-in users. A truthy
+ * `session` from useAuthStore is the single authenticated-visitor predicate.
+ *
+ * The contract this file locks in:
+ *   1. No session  -> the welcome modal does NOT auto-launch (even after the
+ *                     500ms delay timer, on the dashboard route, fresh user).
+ *   2. Session      -> the welcome modal DOES auto-launch (existing behavior)
+ *                     for a fresh, empty-portfolio user.
+ *   3. Manual trigger (startTour) stays ungated — works regardless of session.
+ *
+ * The auto-launch is timer-driven (500ms setTimeout) and depends on a settled
+ * portfolio query returning an empty portfolio, so we mock `portfolioApi`,
+ * mock the auth store, and drive the delay with fake timers for determinism.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { OnboardingProvider, useOnboardingContext } from './OnboardingProvider';
+
+// Controllable auth state the provider reads via useAuthStore() (object form).
+const authState: { user: unknown; session: unknown; initialized: boolean } = {
+  user: null,
+  session: null,
+  initialized: true,
+};
+
+vi.mock('@/stores/authStore', () => ({
+  useAuthStore: () => authState,
+}));
+
+// Empty portfolio -> the "fresh user" branch that auto-opens the welcome modal.
+vi.mock('@/api/portfolio', () => ({
+  portfolioApi: {
+    getPortfolio: vi.fn(() => Promise.resolve({ positions: [] })),
+  },
+}));
+
+// FeatureTour reaches into the DOM for tour anchors; stub it to a marker so the
+// provider's children render cleanly in jsdom.
+vi.mock('./FeatureTour', () => ({
+  FeatureTour: ({ isActive }: { isActive: boolean }) =>
+    isActive ? <div data-testid="feature-tour" /> : null,
+}));
+
+const AUTHENTICATED_SESSION = {
+  access_token: 'token',
+  user: { id: 'u1', email: 'real@user.com' },
+};
+
+// Consumer that surfaces the manual trigger for the ungated-path test.
+function TourTrigger() {
+  const { startTour } = useOnboardingContext();
+  return (
+    <button onClick={startTour} data-testid="start-tour">
+      start
+    </button>
+  );
+}
+
+function renderProvider() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      {/* MemoryRouter defaults to "/", one of the two auto-launch routes. */}
+      <MemoryRouter>
+        <OnboardingProvider>
+          <TourTrigger />
+        </OnboardingProvider>
+      </MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+// The welcome modal renders role="dialog" aria-label="Welcome to Frontier Alpha"
+// when showWelcome is true — but it hard short-circuits if the persistent
+// `frontier:onboarded` localStorage flag is set, so each test starts clean.
+function getWelcomeModal() {
+  return screen.queryByRole('dialog', { name: /Welcome to Frontier Alpha/i });
+}
+
+describe('OnboardingProvider auto-launch gate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    authState.user = null;
+    authState.session = null;
+    authState.initialized = true;
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it('does NOT auto-launch the welcome modal when there is no session', async () => {
+    authState.user = null;
+    authState.session = null;
+    renderProvider();
+
+    // Flush the portfolio query + advance well past the 500ms launch delay.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(getWelcomeModal()).not.toBeInTheDocument();
+  });
+
+  it('DOES auto-launch the welcome modal when a session is present', async () => {
+    authState.session = AUTHENTICATED_SESSION;
+    authState.user = AUTHENTICATED_SESSION.user;
+    renderProvider();
+
+    // Pump async cycles so the portfolio query settles, then advance past the
+    // 500ms delay timer. (waitFor spins on real timers and would hang here.)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+
+    expect(getWelcomeModal()).toBeInTheDocument();
+  });
+
+  it('keeps the manual startTour trigger ungated even with no session', async () => {
+    authState.user = null;
+    authState.session = null;
+    renderProvider();
+
+    // No auto-launch fired (gate holds)...
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(screen.queryByTestId('feature-tour')).not.toBeInTheDocument();
+
+    // ...but the manual trigger still starts the tour (handleStartTour uses a
+    // 300ms setTimeout before flipping showTour).
+    await act(async () => {
+      screen.getByTestId('start-tour').click();
+      await vi.advanceTimersByTimeAsync(500);
+    });
+
+    expect(screen.getByTestId('feature-tour')).toBeInTheDocument();
+  });
+});

--- a/client/src/components/onboarding/OnboardingProvider.tsx
+++ b/client/src/components/onboarding/OnboardingProvider.tsx
@@ -33,8 +33,18 @@ interface OnboardingProviderProps {
 export function OnboardingProvider({ children }: OnboardingProviderProps) {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, initialized } = useAuthStore();
+  const { user, session, initialized } = useAuthStore();
   const { isOnboardingComplete, completeOnboarding, resetOnboarding } = useOnboarding();
+
+  // Auto-launch gate (2026-06-23). The app is now public — unauthenticated
+  // visitors land directly in the app under the demo banner (see
+  // ProtectedRoute). Onboarding (welcome modal + feature tour) must only
+  // auto-run for REAL signed-in users; for anonymous/demo visitors it must
+  // never auto-open or auto-advance. A truthy `session` is the single
+  // authenticated-visitor predicate (`user` is derived from it). Manual
+  // triggers below (startTour / resetOnboarding / the modal's own buttons)
+  // stay ungated so the "?" help flow works for everyone.
+  const isAuthenticated = Boolean(session);
 
   const [showWelcome, setShowWelcome] = useState(false);
   const [showTour, setShowTour] = useState(false);
@@ -49,7 +59,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
   const portfolioQuery = useQuery({
     queryKey: ['portfolio'],
     queryFn: portfolioApi.getPortfolio,
-    enabled: Boolean(initialized && user && !isOnboardingComplete && !hasShownWelcome),
+    enabled: Boolean(initialized && isAuthenticated && user && !isOnboardingComplete && !hasShownWelcome),
     retry: false,
     staleTime: 5 * 60 * 1000,
   });
@@ -60,6 +70,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
   useEffect(() => {
     if (
       initialized &&
+      isAuthenticated &&
       user &&
       !isOnboardingComplete &&
       !hasShownWelcome &&
@@ -77,6 +88,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
     }
   }, [
     initialized,
+    isAuthenticated,
     user,
     isOnboardingComplete,
     hasShownWelcome,
@@ -90,6 +102,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
   useEffect(() => {
     if (
       initialized &&
+      isAuthenticated &&
       user &&
       !isOnboardingComplete &&
       portfolioReady &&
@@ -97,7 +110,7 @@ export function OnboardingProvider({ children }: OnboardingProviderProps) {
     ) {
       completeOnboarding();
     }
-  }, [initialized, user, isOnboardingComplete, portfolioReady, hasPositions, completeOnboarding]);
+  }, [initialized, isAuthenticated, user, isOnboardingComplete, portfolioReady, hasPositions, completeOnboarding]);
 
   const handleCloseWelcome = useCallback(() => {
     setShowWelcome(false);

--- a/client/src/lib/demoFixtures.ts
+++ b/client/src/lib/demoFixtures.ts
@@ -1,0 +1,49 @@
+/**
+ * Golden-state demo fixtures — the single source of truth for the data shown
+ * to unauthenticated (demo-mode) visitors on the public app.
+ *
+ * Dashboard and Portfolio (and any future public preview surface) read from
+ * here so a visitor sees the SAME holdings everywhere: NVDA 50 shares on the
+ * Dashboard is NVDA 50 shares on the Portfolio page. These are illustrative
+ * numbers, not live data — demo-mode pages always render under the persistent
+ * "Demo Mode" banner so the source is unambiguous.
+ */
+
+export interface DemoHolding {
+  symbol: string;
+  shares: number;
+  weight: number;
+  costBasis: number;
+  currentPrice: number;
+  unrealizedPnL: number;
+}
+
+/** Canonical demo holdings (sum of position values + cash = DEMO_TOTAL_VALUE). */
+export const DEMO_HOLDINGS: DemoHolding[] = [
+  { symbol: 'NVDA', shares: 50, weight: 0.22, costBasis: 450, currentPrice: 520, unrealizedPnL: 3500 },
+  { symbol: 'MSFT', shares: 30, weight: 0.18, costBasis: 380, currentPrice: 415, unrealizedPnL: 1050 },
+  { symbol: 'AAPL', shares: 100, weight: 0.15, costBasis: 175, currentPrice: 195, unrealizedPnL: 2000 },
+  { symbol: 'GOOGL', shares: 25, weight: 0.14, costBasis: 140, currentPrice: 165, unrealizedPnL: 625 },
+  { symbol: 'AMZN', shares: 40, weight: 0.12, costBasis: 180, currentPrice: 205, unrealizedPnL: 1000 },
+];
+
+export const DEMO_CASH = 15000;
+export const DEMO_TOTAL_VALUE = 125000;
+export const DEMO_SYMBOLS = DEMO_HOLDINGS.map((h) => h.symbol);
+
+export interface DemoFactor {
+  factor: string;
+  exposure: number;
+  tStat: number;
+  confidence: number;
+  contribution: number;
+}
+
+/** Canonical demo factor exposures (Dashboard factor card + future surfaces). */
+export const DEMO_FACTORS: DemoFactor[] = [
+  { factor: 'momentum_12m', exposure: 0.85, tStat: 2.31, confidence: 0.92, contribution: 0.04 },
+  { factor: 'roe', exposure: 0.62, tStat: 1.89, confidence: 0.85, contribution: 0.02 },
+  { factor: 'low_vol', exposure: -0.42, tStat: -1.45, confidence: 0.78, contribution: 0.01 },
+  { factor: 'value', exposure: -0.28, tStat: -0.92, confidence: 0.65, contribution: -0.01 },
+  { factor: 'sector_tech', exposure: 0.85, tStat: 8.5, confidence: 0.99, contribution: 0.05 },
+];

--- a/client/src/pages/Alerts.tsx
+++ b/client/src/pages/Alerts.tsx
@@ -16,6 +16,7 @@ import { MockDataBanner } from '@/components/shared/MockDataBanner';
 import { toast } from '@/components/shared/Toast';
 import { api } from '@/api/client';
 import { useEmailDeliveryStatus } from '@/hooks/useIntegrationsHealth';
+import { useAuthStore } from '@/stores/authStore';
 import type { RiskAlert } from '@/types';
 
 interface FactorExposure {
@@ -43,6 +44,15 @@ export function Alerts() {
   const [usingDemoFactors, setUsingDemoFactors] = useState(false);
   const emailStatus = useEmailDeliveryStatus();
   const emailDegraded = emailStatus === 'degraded';
+
+  // US-003 auth gate — /alerts + /portfolio + /portfolio/factors are
+  // Bearer-gated. An anonymous visitor (open front door, no session) must not
+  // fire them or they 401 and spam the public console. With no session we
+  // skip the fetch and fall straight to the "All Clear" / "Awaiting Positions"
+  // empty states below.
+  const isReady = useAuthStore((s) => s.isReady);
+  const session = useAuthStore((s) => s.session);
+  const authReady = isReady && !!session?.access_token;
 
   const loadAlerts = useCallback(async () => {
     setIsLoading(true);
@@ -121,9 +131,15 @@ export function Alerts() {
   }, []);
 
   useEffect(() => {
+    // No session (demo / open front door): don't fire Bearer-gated reads.
+    // Drop the loading skeleton so the empty states render immediately.
+    if (!authReady) {
+      setIsLoading(false);
+      return;
+    }
     loadAlerts();
     loadFactorExposures();
-  }, [loadAlerts, loadFactorExposures]);
+  }, [authReady, loadAlerts, loadFactorExposures]);
 
   // Handle new alerts from factor drift monitor
   const handleFactorDriftAlerts = (newAlerts: Array<{

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -19,6 +19,7 @@ import { MarketStatusStrip } from '@/components/dashboard/MarketStatusStrip';
 import { DashZone } from '@/components/dashboard/DashZone';
 import { getDisplayName } from '@/lib/getDisplayName';
 import { type DataSource, EMPTY, wrapReal } from '@/lib/dataSource';
+import { DEMO_HOLDINGS, DEMO_CASH, DEMO_TOTAL_VALUE, DEMO_FACTORS } from '@/lib/demoFixtures';
 
 // Types
 interface Position {
@@ -259,32 +260,21 @@ function generateInsight(factors: FactorExposure[]): string {
   return insights.slice(0, 3).join(' ');
 }
 
-// Demo data for unauthenticated users
+// Demo data for unauthenticated users — sourced from the shared golden-state
+// fixtures so the Dashboard preview matches the Portfolio page exactly.
 function getDemoPortfolio(): Portfolio {
   return {
     id: 'demo',
     name: 'Demo Portfolio',
-    positions: [
-      { symbol: 'NVDA', shares: 50, weight: 0.22, costBasis: 450, currentPrice: 520, unrealizedPnL: 3500 },
-      { symbol: 'MSFT', shares: 30, weight: 0.18, costBasis: 380, currentPrice: 415, unrealizedPnL: 1050 },
-      { symbol: 'AAPL', shares: 100, weight: 0.15, costBasis: 175, currentPrice: 195, unrealizedPnL: 2000 },
-      { symbol: 'GOOGL', shares: 25, weight: 0.14, costBasis: 140, currentPrice: 165, unrealizedPnL: 625 },
-      { symbol: 'AMZN', shares: 40, weight: 0.12, costBasis: 180, currentPrice: 205, unrealizedPnL: 1000 },
-    ],
-    cash: 15000,
-    totalValue: 125000,
+    positions: DEMO_HOLDINGS.map((h) => ({ ...h })),
+    cash: DEMO_CASH,
+    totalValue: DEMO_TOTAL_VALUE,
     currency: 'USD',
   };
 }
 
 function getDemoFactors(): FactorExposure[] {
-  return [
-    { factor: 'momentum_12m', exposure: 0.85, tStat: 2.31, confidence: 0.92, contribution: 0.04 },
-    { factor: 'roe', exposure: 0.62, tStat: 1.89, confidence: 0.85, contribution: 0.02 },
-    { factor: 'low_vol', exposure: -0.42, tStat: -1.45, confidence: 0.78, contribution: 0.01 },
-    { factor: 'value', exposure: -0.28, tStat: -0.92, confidence: 0.65, contribution: -0.01 },
-    { factor: 'sector_tech', exposure: 0.85, tStat: 8.5, confidence: 0.99, contribution: 0.05 },
-  ];
+  return DEMO_FACTORS.map((f) => ({ ...f }));
 }
 
 // Quick action pill component

--- a/client/src/pages/Earnings.tsx
+++ b/client/src/pages/Earnings.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Calendar, AlertCircle } from 'lucide-react';
 import { portfolioApi } from '@/api/portfolio';
+import { useAuthStore } from '@/stores/authStore';
 import { EarningsCalendar } from '@/components/earnings/EarningsCalendar';
 import { EarningsForecast } from '@/components/earnings/EarningsForecast';
 import { EarningsHeatmap } from '@/components/earnings/EarningsHeatmap';
@@ -20,11 +21,20 @@ export function Earnings() {
   const [selectedSymbol, setSelectedSymbol] = useState<string | null>(null);
   const [daysAhead, setDaysAhead] = useState(30);
 
+  // US-003 auth gate — /portfolio is Bearer-gated. An anonymous visitor (open
+  // front door, no session) must not fire it or it 401s and spams the public
+  // console. With no session the query is disabled, `symbols` stays empty, and
+  // the page settles into its "No positions to track" empty state.
+  const isReady = useAuthStore((state) => state.isReady);
+  const session = useAuthStore((state) => state.session);
+  const authReady = isReady && !!session?.access_token;
+
   // Get portfolio to extract symbols
   const { data: portfolio, isLoading: portfolioLoading } = useQuery({
     queryKey: ['portfolio'],
     queryFn: portfolioApi.getPortfolio,
     retry: false,
+    enabled: authReady,
   });
 
   // Use portfolio symbols only — empty array surfaces the empty-state

--- a/client/src/pages/Factors.tsx
+++ b/client/src/pages/Factors.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/shared/Button';
 import { DataQualityBadge } from '@/components/shared/DataQualityBadge';
 import { SkeletonFactorsPage } from '@/components/shared/LoadingSkeleton';
 import { portfolioApi } from '@/api/portfolio';
+import { useAuthStore } from '@/stores/authStore';
 import { useFactorsByCategory, useRefreshFactors, FACTOR_CATEGORY_LABELS, FACTOR_CATEGORY_DESCRIPTIONS } from '@/hooks/useFactors';
 import { DataLoadError, NoFactorData, EmptyState } from '@/components/shared/EmptyState';
 import type { FactorExposureWithCategory } from '@/api/factors';
@@ -75,11 +76,21 @@ const DEMO_SYMBOLS = ['NVDA', 'AAPL', 'MSFT', 'GOOGL', 'AMZN'];
 export function Factors() {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
 
+  // US-003 auth gate — /portfolio is Bearer-gated. An anonymous visitor (open
+  // front door, no session) must not fire it or it 401s and spams the public
+  // console. With no session the query is disabled and `symbols` falls back to
+  // the demo set; the factor hook (also session-gated) stays idle so the page
+  // settles into its no-factor-data empty state instead of erroring.
+  const isReady = useAuthStore((state) => state.isReady);
+  const session = useAuthStore((state) => state.session);
+  const authReady = isReady && !!session?.access_token;
+
   // Get portfolio to extract symbols
   const { data: portfolio, isLoading: portfolioLoading } = useQuery({
     queryKey: ['portfolio'],
     queryFn: portfolioApi.getPortfolio,
     retry: false,
+    enabled: authReady,
   });
 
   // Use portfolio symbols if available, otherwise use demo symbols

--- a/client/src/pages/InsightHistory.tsx
+++ b/client/src/pages/InsightHistory.tsx
@@ -27,6 +27,7 @@ import {
 import { SectionErrorBoundary } from '@/components/shared/ErrorBoundary';
 import { LineageExplorer } from '@/components/provenance/LineageExplorer';
 import { insightsApi, type InsightLedgerEntry } from '@/api/insights';
+import { useAuthStore } from '@/stores/authStore';
 
 const PAGE_SIZE = 25;
 
@@ -209,11 +210,24 @@ function EmptyHistory() {
 function HistoryBody() {
   const [page, setPage] = useState(0);
 
+  // US-003 auth gate — the insight-ledger history is Bearer-gated. An anonymous
+  // visitor (open front door, no session) must not fire it or it 401s and spams
+  // the public console. With no session we skip the fetch and render the same
+  // "No insights logged yet" empty state a fresh account sees.
+  const isReady = useAuthStore((s) => s.isReady);
+  const session = useAuthStore((s) => s.session);
+  const authReady = isReady && !!session?.access_token;
+
   const { data, isLoading, isError } = useQuery({
     queryKey: ['insights', 'history', page],
     queryFn: () => insightsApi.getHistory({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
     retry: false,
+    enabled: authReady,
   });
+
+  if (!authReady) {
+    return <EmptyHistory />;
+  }
 
   if (isLoading) {
     return (

--- a/client/src/pages/Optimize.tsx
+++ b/client/src/pages/Optimize.tsx
@@ -11,6 +11,7 @@ import { useMutation, useQuery } from '@tanstack/react-query';
 import { Sparkles, TrendingUp, Shield, Target, Info } from 'lucide-react';
 import { api, getErrorMessage } from '@/api/client';
 import { useToast } from '@/hooks/useToast';
+import { useAuthStore } from '@/stores/authStore';
 import { Spinner } from '@/components/shared/Spinner';
 import { UpgradeGate } from '@/components/shared/UpgradeGate';
 import { SectionErrorBoundary } from '@/components/shared/ErrorBoundary';
@@ -56,9 +57,19 @@ function OptimizeContent() {
   const [maxWeight, setMaxWeight] = useState('0.25');
   const { toastSuccess, toastError } = useToast();
 
+  // US-003 auth gate — /portfolio is Bearer-gated. The UpgradeGate renders this
+  // content as a blurred preview for non-pro (incl. anonymous) visitors, so the
+  // query would otherwise fire and 401 in demo mode. Hold it until a real
+  // session exists; with none, `symbols` stays empty and the holdings panel
+  // shows its "No positions in portfolio." state.
+  const isReady = useAuthStore((state) => state.isReady);
+  const session = useAuthStore((state) => state.session);
+  const authReady = isReady && !!session?.access_token;
+
   const { data: portfolio } = useQuery({
     queryKey: ['portfolio'],
     queryFn: () => api.get('/portfolio'),
+    enabled: authReady,
   });
 
   const optimizeMutation = useMutation<{ data: OptimizationResult }, Error, { symbols: string[]; config: OptimizationConfig }>({

--- a/client/src/pages/Options.tsx
+++ b/client/src/pages/Options.tsx
@@ -25,6 +25,7 @@ import { Button } from '@/components/shared/Button';
 import { MockDataBanner } from '@/components/shared/MockDataBanner';
 import { EmptyState } from '@/components/shared/EmptyState';
 import { portfolioApi } from '@/api/portfolio';
+import { useAuthStore } from '@/stores/authStore';
 import { useNavigate } from 'react-router-dom';
 import {
   UNDERLYING_PRICE,
@@ -89,6 +90,14 @@ export function Options() {
   const [activeTab, setActiveTab] = useState<TabId>('chain');
   const [isLoading, setIsLoading] = useState(true);
 
+  // US-003 auth gate — /portfolio is Bearer-gated. An anonymous visitor (open
+  // front door, no session) must not fire it or it 401s and spams the public
+  // console. With no session the query is disabled, `hasPositions` stays false,
+  // and the page renders the "Awaiting Position" empty state below.
+  const isReady = useAuthStore((state) => state.isReady);
+  const session = useAuthStore((state) => state.session);
+  const authReady = isReady && !!session?.access_token;
+
   // US-002: detect whether the user has any positions wired. Without one,
   // we render an explicit empty state instead of a chain of mock 1.00/1.00
   // strikes for AAPL — those numbers read as live to a brand new account.
@@ -96,6 +105,7 @@ export function Options() {
     queryKey: ['portfolio'],
     queryFn: portfolioApi.getPortfolio,
     retry: false,
+    enabled: authReady,
   });
   const hasPositions = (portfolio?.positions?.length ?? 0) > 0;
 

--- a/client/src/pages/Portfolio.tsx
+++ b/client/src/pages/Portfolio.tsx
@@ -10,6 +10,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Plus, Trash2, Edit2, X, Check, Share2, DollarSign, TrendingUp, TrendingDown, BarChart3, Wallet } from 'lucide-react';
 import { api, isNetworkError, getErrorMessage } from '@/api/client';
 import { useAuthStore } from '@/stores/authStore';
+import { DEMO_HOLDINGS, DEMO_CASH, DEMO_TOTAL_VALUE } from '@/lib/demoFixtures';
 import { useCountUp } from '@/components/portfolio/PortfolioOverview';
 import { Spinner } from '@/components/shared/Spinner';
 import { SkeletonPortfolioPage } from '@/components/shared/Skeleton';
@@ -205,9 +206,15 @@ export function Portfolio() {
   // Pulled out BEFORE any conditional returns so the hook count stays
   // constant across renders (loading → loaded transition triggered React
   // error #310 because useMemo/useCountUp lived below an early return).
-  const positions = portfolio?.data?.positions || [];
-  const cashBalance = portfolio?.data?.cash || 0;
-  const totalValue = portfolio?.data?.totalValue || 0;
+  // Demo-mode (open front door, no session): show the shared golden-state
+  // holdings so the public Portfolio page mirrors the Dashboard preview
+  // instead of an empty state. Authed users always see their real data.
+  const isDemoView = isReady && !session;
+  const positions: Position[] = isDemoView
+    ? DEMO_HOLDINGS.map((h, i) => ({ id: `demo-${i}`, ...h }))
+    : portfolio?.data?.positions || [];
+  const cashBalance = isDemoView ? DEMO_CASH : portfolio?.data?.cash || 0;
+  const totalValue = isDemoView ? DEMO_TOTAL_VALUE : portfolio?.data?.totalValue || 0;
 
   const mobileVisible = useMemo(() => {
     const q = mobileQuery.trim();

--- a/client/src/pages/Portfolio.tsx
+++ b/client/src/pages/Portfolio.tsx
@@ -9,6 +9,7 @@ import { useState, useMemo, useEffect } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Plus, Trash2, Edit2, X, Check, Share2, DollarSign, TrendingUp, TrendingDown, BarChart3, Wallet } from 'lucide-react';
 import { api, isNetworkError, getErrorMessage } from '@/api/client';
+import { useAuthStore } from '@/stores/authStore';
 import { useCountUp } from '@/components/portfolio/PortfolioOverview';
 import { Spinner } from '@/components/shared/Spinner';
 import { SkeletonPortfolioPage } from '@/components/shared/Skeleton';
@@ -67,9 +68,18 @@ export function Portfolio() {
   const [mobileFilter, setMobileFilter] = useState<FilterKey>('all');
   const [mobileQuery, setMobileQuery] = useState('');
 
+  // US-003 auth gate — /portfolio is Bearer-gated. An anonymous visitor (open
+  // front door, no session) must not fire it or it 401s and spams the public
+  // console. With no session the query is disabled (no loading, no error) and
+  // `positions` stays empty so the page renders <EmptyPortfolio>.
+  const isReady = useAuthStore((state) => state.isReady);
+  const session = useAuthStore((state) => state.session);
+  const authReady = isReady && !!session?.access_token;
+
   const { data: portfolio, isLoading, error, refetch } = useQuery<{ data: PortfolioData }>({
     queryKey: ['portfolio'],
     queryFn: () => api.get('/portfolio'),
+    enabled: authReady,
   });
 
   const addPositionMutation = useMutation({

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -115,10 +115,22 @@ export function Settings() {
   const { toastSuccess, toastError } = useToast();
   const [hasChanges, setHasChanges] = useState(false);
 
-  const { data: settingsData, isLoading } = useQuery<{ data: UserSettings }>({
+  // US-003 auth gate — /settings is Bearer-gated. An anonymous visitor (open
+  // front door, no session) must not fire it or it 401s and spams the public
+  // console. With no session we skip the fetch and render the page against the
+  // local default form state (the Profile email shows empty; nothing leaks).
+  const isReady = useAuthStore((state) => state.isReady);
+  const session = useAuthStore((state) => state.session);
+  const authReady = isReady && !!session?.access_token;
+
+  const { data: settingsData, isLoading: settingsLoading } = useQuery<{ data: UserSettings }>({
     queryKey: ['settings'],
     queryFn: () => api.get('/settings'),
+    enabled: authReady,
   });
+  // Only hold for the skeleton while a real fetch is in flight. Without a
+  // session the query is disabled (never loads), so we render immediately.
+  const isLoading = authReady && settingsLoading;
 
   const [settings, setSettings] = useState<UserSettings>({
     display_name: '',

--- a/client/src/pages/Tax.tsx
+++ b/client/src/pages/Tax.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/api/tax';
 import { detectDemoMode } from '@/lib/demoMode';
 import { type DataSource, EMPTY, wrapReal, wrapDemo } from '@/lib/dataSource';
+import { useAuthStore } from '@/stores/authStore';
 
 // ── Types ──────────────────────────────────────────────────────
 
@@ -884,6 +885,15 @@ export function Tax() {
   const [activeTab, setActiveTab] = useState<TaxTab>('summary');
   const isDemo = detectDemoMode();
 
+  // US-003 auth gate — the /api/v1/tax/* + /portfolio reads are Bearer-gated.
+  // An anonymous visitor (open front door, no ?demo latch) must NOT fire them
+  // or they 401 and spam the public console. Live data only flows when a real
+  // session exists; otherwise the page falls to its empty / demo states below.
+  const isReady = useAuthStore((state) => state.isReady);
+  const session = useAuthStore((state) => state.session);
+  const authReady = isReady && !!session?.access_token;
+  const fetchEnabled = authReady && !isDemo;
+
   // Demo mode (?demo=true shareable link, FF-6): render banner-marked
   // fixtures. Real accounts: live data from the /api/v1/tax/* routes, which
   // reconstruct the tax tracker from the user's persisted lots + events.
@@ -891,7 +901,7 @@ export function Tax() {
     queryKey: ['portfolio'],
     queryFn: portfolioApi.getPortfolio,
     retry: false,
-    enabled: !isDemo,
+    enabled: fetchEnabled,
   });
 
   const portfolioSymbols = useMemo(
@@ -903,19 +913,19 @@ export function Tax() {
     queryKey: ['tax', 'report'],
     queryFn: () => taxApi.getReport(),
     retry: false,
-    enabled: !isDemo,
+    enabled: fetchEnabled,
   });
   const harvestQuery = useQuery({
     queryKey: ['tax', 'harvest', portfolioSymbols],
     queryFn: () => taxApi.getHarvest(portfolioSymbols),
     retry: false,
-    enabled: !isDemo,
+    enabled: fetchEnabled,
   });
   const washSalesQuery = useQuery({
     queryKey: ['tax', 'wash-sales'],
     queryFn: () => taxApi.getWashSales(),
     retry: false,
-    enabled: !isDemo,
+    enabled: fetchEnabled,
   });
 
   const report = reportQuery.data;

--- a/src/data/MarketDataProvider.ts
+++ b/src/data/MarketDataProvider.ts
@@ -769,7 +769,13 @@ export class MarketDataProvider {
   // ============================================================================
 
   private async fetchPolygonQuote(symbol: string): Promise<Quote | null> {
-    const url = `https://api.polygon.io/v2/last/trade/${symbol}?apiKey=${this.config.polygonApiKey}`;
+    // Polygon Stocks Starter is 15-min delayed and is NOT entitled to the
+    // real-time `/v2/last/trade` endpoint (it 403s). The snapshot endpoint is
+    // entitled on Starter and returns the delayed last price plus today's
+    // change/changePercent in a single call.
+    const url =
+      `https://api.polygon.io/v2/snapshot/locale/us/markets/stocks/tickers/` +
+      `${encodeURIComponent(symbol)}?apiKey=${this.config.polygonApiKey}`;
 
     const response = await fetch(url);
     if (!response.ok) {
@@ -777,19 +783,44 @@ export class MarketDataProvider {
       return null;
     }
 
-    const data = await response.json() as { results?: { t: number; p: number } };
-    const trade = data.results;
+    const data = (await response.json()) as {
+      status?: string;
+      ticker?: {
+        todaysChange?: number;
+        todaysChangePerc?: number;
+        updated?: number; // unix nanoseconds
+        day?: { c?: number };
+        min?: { c?: number };
+        prevDay?: { c?: number };
+      };
+    };
 
-    if (!trade) return null;
+    const t = data.ticker;
+    if (!t) return null;
+
+    // Prefer the freshest delayed price available: intraday minute close, then
+    // the current day close, then the previous day close as a floor. (The
+    // real-time lastTrade field is absent on the delayed Starter plan.)
+    const last =
+      t.min?.c && t.min.c > 0
+        ? t.min.c
+        : t.day?.c && t.day.c > 0
+          ? t.day.c
+          : (t.prevDay?.c ?? 0);
+
+    if (!last) return null;
+
+    // `updated` is unix nanoseconds; convert to ms. Fall back to now if absent.
+    const timestamp = t.updated ? new Date(Math.floor(t.updated / 1e6)) : new Date();
 
     return {
       symbol,
-      timestamp: new Date(trade.t),
-      bid: trade.p * 0.9999,  // Approximate
-      ask: trade.p * 1.0001,
-      last: trade.p,
-      change: 0,
-      changePercent: 0,
+      timestamp,
+      bid: last * 0.9999, // Approximate (no real-time bid/ask on delayed plan)
+      ask: last * 1.0001,
+      last,
+      change: t.todaysChange ?? 0,
+      changePercent: t.todaysChangePerc ?? 0,
     };
   }
 

--- a/src/data/cache/SupabaseCache.ts
+++ b/src/data/cache/SupabaseCache.ts
@@ -10,12 +10,18 @@
  *
  * Counter telemetry (`hitCount`, `missCount`, `staleCount`) follows the
  * same contract as `MemoryCache<T>`:
- *   - `hitCount` — successful read with sufficient row coverage
- *   - `missCount` — no row OR insufficient coverage
- *   - `staleCount` — reserved; this layer has no TTL today (rows are
- *     persisted indefinitely; staleness is enforced by the upper Memory
- *     layer in CompositeCache). Kept on the interface so US-008 telemetry
- *     can roll it up uniformly.
+ *   - `hitCount` — successful read with sufficient row coverage AND a newest
+ *     bar inside the staleness window
+ *   - `missCount` — no row OR insufficient coverage OR stale
+ *   - `staleCount` — newest cached bar older than `maxStalenessMs`. This
+ *     layer persists rows indefinitely (no row-level TTL), so without a
+ *     freshness gate it serves stale prices forever once poisoned — the
+ *     Memory layer that was meant to enforce freshness is per-instance and
+ *     cold on serverless, so it never gates production reads. The gate here
+ *     forces a miss → upstream refetch → write-through, self-healing the
+ *     cache. (Root-caused 2026-06-23: production froze at 15-month-old
+ *     prices because ascending+limit returned the OLDEST rows and nothing
+ *     ever expired them.)
  *
  * Failure mode:
  *   - All Supabase errors are swallowed and logged. The caller receives a
@@ -38,14 +44,24 @@ export interface SupabaseCacheOptions {
   client?: typeof supabaseAdmin;
   /** Disable cache entirely (used when service key isn't wired). */
   enabled?: boolean;
+  /**
+   * Freshness window in milliseconds. A read whose newest bar is older than
+   * this is treated as a miss so the caller refetches from upstream. Set to
+   * 0 to disable the gate (e.g. in tests with fixed historical fixtures).
+   * Default 5 days — wide enough to cover normal Fri→Mon/holiday weekends
+   * for daily bars, tight enough to catch real staleness.
+   */
+  maxStalenessMs?: number;
 }
 
 const DEFAULT_COVERAGE = 0.9;
+const DEFAULT_MAX_STALENESS_MS = 5 * 24 * 60 * 60 * 1000; // 5 days
 
 export class SupabaseCache {
   private client: typeof supabaseAdmin | null;
   private coverage: number;
   private enabled: boolean;
+  private maxStalenessMs: number;
 
   hitCount = 0;
   missCount = 0;
@@ -57,6 +73,7 @@ export class SupabaseCache {
     this.enabled = opts.enabled ?? Boolean(process.env.SUPABASE_SERVICE_KEY);
     this.client = opts.client ?? (this.enabled ? supabaseAdmin : null);
     this.coverage = opts.coverage ?? DEFAULT_COVERAGE;
+    this.maxStalenessMs = opts.maxStalenessMs ?? DEFAULT_MAX_STALENESS_MS;
   }
 
   /**
@@ -71,11 +88,15 @@ export class SupabaseCache {
     }
 
     try {
+      // Fetch the MOST RECENT `days` rows (descending), then reverse below to
+      // the oldest-first order downstream consumers expect. Ascending+limit
+      // returns the OLDEST rows in the table — the bug that froze production
+      // at the dawn of the cached window once the table held > `days` rows.
       const { data, error } = await this.client
         .from('frontier_historical_prices')
         .select('*')
         .eq('symbol', symbol)
-        .order('date', { ascending: true })
+        .order('date', { ascending: false })
         .limit(days);
 
       if (error) {
@@ -99,7 +120,21 @@ export class SupabaseCache {
         return null;
       }
 
+      // Freshness gate: rows are newest-first, so rows[0] is the latest bar.
+      // If it predates the staleness window, treat as a miss so the caller
+      // refetches from upstream and write-through replaces the stale window.
+      if (this.maxStalenessMs > 0) {
+        const newest = new Date(rows[0].date).getTime();
+        if (Number.isFinite(newest) && Date.now() - newest > this.maxStalenessMs) {
+          this.staleCount += 1;
+          this.missCount += 1;
+          return null;
+        }
+      }
+
       this.hitCount += 1;
+      // Reverse to oldest-first (chronological) for factor math + charting.
+      rows.reverse();
       return rows.map((r) => ({
         symbol,
         timestamp: new Date(r.date),

--- a/src/earnings/EarningsOracle.ts
+++ b/src/earnings/EarningsOracle.ts
@@ -143,9 +143,16 @@ export class EarningsOracle {
   }
 
   /**
-   * Fetch historical daily prices from Polygon.io
+   * Fetch historical daily prices from Polygon.io.
+   *
+   * Defaults to 5 years — the full window the Polygon Stocks Starter plan is
+   * entitled to (the free tier was ~2yr). A wider window strictly improves the
+   * earnings-reaction stats: more historical earnings dates get matched price
+   * data, so beat-rate / expected-move / volatility-trend are computed off more
+   * samples. `buildEarningsPattern` folds prices against earnings dates, so
+   * extra history only adds coverage, never skews a fixed-size window.
    */
-  async fetchHistoricalPrices(symbol: string, years: number = 2): Promise<DailyPrice[]> {
+  async fetchHistoricalPrices(symbol: string, years: number = 5): Promise<DailyPrice[]> {
     // Check cache first
     const cached = this.priceCache.get(symbol);
     if (cached && cached.length > 0) {

--- a/src/middleware/publicRateLimit.ts
+++ b/src/middleware/publicRateLimit.ts
@@ -1,0 +1,138 @@
+/**
+ * FRONTIER ALPHA - Public Route Rate Limiter (in-memory)
+ *
+ * A deliberately lightweight, in-process fixed-window limiter for the PUBLIC
+ * quote REST endpoints (`/api/v1/quotes/:symbol` and `/:symbol/history`).
+ * These routes have no auth preHandler and, now that the app is public, are
+ * reachable by anonymous internet traffic that proxies Polygon.
+ *
+ * Why not reuse `rateLimiterMiddleware` here: that limiter is Supabase-backed
+ * in production (an RPC round-trip per request) which is too heavy for these
+ * hot, unauthenticated read paths. This limiter adds zero latency and makes
+ * no external calls — a plain Map keyed by client IP with a periodic sweep.
+ *
+ * The limit is intentionally generous so a normal dashboard load never trips
+ * it: one load fires quotes + history for ~5-8 symbols, sometimes twice, so
+ * ~16-32 requests per load. 120 req/min/IP leaves several loads of headroom.
+ */
+
+import { FastifyRequest, FastifyReply } from 'fastify';
+
+// ============================================================================
+// CONFIG
+// ============================================================================
+
+/** Max requests per window, per client IP. */
+const PUBLIC_LIMIT = 120;
+/** Fixed-window size in milliseconds. */
+const WINDOW_MS = 60 * 1000;
+/** How often to sweep expired buckets to keep the Map bounded. */
+const CLEANUP_INTERVAL_MS = 60 * 1000;
+
+// ============================================================================
+// STORE
+// ============================================================================
+
+interface Bucket {
+  count: number;
+  resetAt: number; // Unix timestamp in ms
+}
+
+const buckets = new Map<string, Bucket>();
+
+const cleanupTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [key, bucket] of buckets) {
+    if (now >= bucket.resetAt) {
+      buckets.delete(key);
+    }
+  }
+}, CLEANUP_INTERVAL_MS);
+
+// Don't keep the Node process alive just for the sweep.
+if (typeof cleanupTimer === 'object' && 'unref' in cleanupTimer) {
+  cleanupTimer.unref();
+}
+
+// ============================================================================
+// CLIENT IP RESOLUTION
+// ============================================================================
+
+/**
+ * Resolve the originating client IP behind Vercel / Railway / direct Fastify.
+ * Mirrors the header preference used by the Supabase-backed limiter so the two
+ * paths key the same anonymous client to the same identifier: prefer Vercel's
+ * stable `x-vercel-forwarded-for` and Cloudflare's `cf-connecting-ip`, then
+ * `x-real-ip`, then the first hop of XFF, and finally Fastify's `request.ip`.
+ */
+function pickHeader(value: string | string[] | undefined): string | null {
+  if (!value) return null;
+  const v = Array.isArray(value) ? value[0] : value;
+  return v.split(',')[0].trim() || null;
+}
+
+function getClientIp(request: FastifyRequest): string {
+  return (
+    pickHeader(request.headers['x-vercel-forwarded-for']) ||
+    pickHeader(request.headers['cf-connecting-ip']) ||
+    pickHeader(request.headers['x-real-ip']) ||
+    pickHeader(request.headers['x-forwarded-for']) ||
+    request.ip
+  );
+}
+
+// ============================================================================
+// MIDDLEWARE
+// ============================================================================
+
+/**
+ * Fastify preHandler for the public quote REST routes. Pure in-memory, no
+ * external calls. On exceed, returns 429 with the repo's standard error
+ * envelope and a `Retry-After` header; otherwise sets standard RateLimit-*
+ * headers and lets the request through unchanged.
+ */
+export async function publicRateLimit(
+  request: FastifyRequest,
+  reply: FastifyReply
+): Promise<void> {
+  const now = Date.now();
+  const key = getClientIp(request);
+  const bucket = buckets.get(key);
+
+  let count: number;
+  let resetAt: number;
+
+  if (!bucket || now >= bucket.resetAt) {
+    // No bucket or window expired — start a fresh window.
+    resetAt = now + WINDOW_MS;
+    count = 1;
+    buckets.set(key, { count, resetAt });
+  } else {
+    bucket.count += 1;
+    count = bucket.count;
+    resetAt = bucket.resetAt;
+  }
+
+  reply.header('RateLimit-Limit', PUBLIC_LIMIT);
+  reply.header('RateLimit-Remaining', Math.max(0, PUBLIC_LIMIT - count));
+  reply.header('RateLimit-Reset', Math.ceil(resetAt / 1000));
+
+  if (count > PUBLIC_LIMIT) {
+    const retryAfterSeconds = Math.max(1, Math.ceil((resetAt - now) / 1000));
+    reply.header('Retry-After', retryAfterSeconds);
+
+    return reply.status(429).send({
+      success: false,
+      error: {
+        code: 'RATE_LIMITED',
+        message: 'Too many requests. Please try again later.',
+        retryAfter: retryAfterSeconds,
+      },
+    });
+  }
+}
+
+/** Reset the in-memory store (for tests). */
+export function resetPublicRateLimit(): void {
+  buckets.clear();
+}

--- a/src/routes/quotes.ts
+++ b/src/routes/quotes.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import { logger } from '../observability/logger.js';
+import { publicRateLimit } from '../middleware/publicRateLimit.js';
 import type { APIResponse, Price, Quote } from '../types/index.js';
 
 interface RouteContext {
@@ -60,6 +61,7 @@ export async function quotesRoutes(fastify: FastifyInstance, opts: RouteContext)
     Reply: APIResponse<{ symbol: string; closes: number[]; timestamps: string[] }>;
   }>(
     '/api/v1/quotes/:symbol/history',
+    { preHandler: publicRateLimit },
     async (request, reply) => {
       const start = Date.now();
       const { symbol } = request.params;
@@ -109,6 +111,7 @@ export async function quotesRoutes(fastify: FastifyInstance, opts: RouteContext)
     Reply: APIResponse<Quote>;
   }>(
     '/api/v1/quotes/:symbol',
+    { preHandler: publicRateLimit },
     async (request, reply) => {
       const start = Date.now();
       const { symbol } = request.params;

--- a/tests/unit/cache.test.ts
+++ b/tests/unit/cache.test.ts
@@ -8,7 +8,7 @@
  *     telemetry roll-up
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.hoisted(() => {
   process.env.SUPABASE_URL ??= 'http://localhost:54321';
@@ -33,6 +33,12 @@ describe('MemoryCache<T> — in-process key/value with TTL', () => {
 
   beforeEach(() => {
     cache = new MemoryCache<string>({ defaultTtlMs: 1000, maxEntries: 3 });
+  });
+
+  // The TTL tests below `vi.spyOn(Date, 'now')`; restore it after each so the
+  // mocked clock doesn't leak into the SupabaseCache freshness-gate tests.
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it('returns null on miss and increments missCount', () => {
@@ -175,17 +181,72 @@ describe('SupabaseCache — durable price cache', () => {
     expect(cache.missCount).toBe(1);
   });
 
-  it('returns rows and bumps hitCount on coverage hit', async () => {
+  it('returns rows oldest-first and bumps hitCount on coverage hit', async () => {
     const days = 5;
-    const rows = Array.from({ length: days }, (_, i) => ({
-      date: `2026-01-0${i + 1}`,
-      open: 100 + i,
-      high: 101 + i,
-      low: 99 + i,
-      close: 100 + i,
-      adjusted_close: 100 + i,
-      volume: 1_000_000,
-    }));
+    // The real query orders DESCENDING, so the stub returns newest-first.
+    const rows = Array.from({ length: days }, (_, i) => {
+      const dayNum = days - i; // 5,4,3,2,1 → dates descending
+      return {
+        date: `2026-01-0${dayNum}`,
+        open: 100 + dayNum,
+        high: 101 + dayNum,
+        low: 99 + dayNum,
+        close: 100 + dayNum,
+        adjusted_close: 100 + dayNum,
+        volume: 1_000_000,
+      };
+    });
+    const stub = makeStubClient(rows);
+    const cache = new SupabaseCache({
+      enabled: true,
+      client: stub as unknown as any,
+      coverage: 0.9,
+      maxStalenessMs: 0, // disable freshness gate to assert ordering on fixed dates
+    });
+    const result = await cache.getPrices('AAPL', days);
+    expect(result).toHaveLength(days);
+    expect(cache.hitCount).toBe(1);
+    // Reversed to oldest-first: 2026-01-01 .. 2026-01-05
+    expect(result?.[0].timestamp.toISOString().slice(0, 10)).toBe('2026-01-01');
+    expect(result?.[days - 1].timestamp.toISOString().slice(0, 10)).toBe('2026-01-05');
+    expect(result?.[0].close).toBe(101); // adjusted_close for 2026-01-01 (100+1)
+  });
+
+  it('returns null and bumps staleCount when newest bar is older than maxStalenessMs', async () => {
+    const days = 5;
+    const rows = Array.from({ length: days }, (_, i) => {
+      const dayNum = days - i;
+      return {
+        date: `2020-01-0${dayNum}`,
+        open: 1, high: 1, low: 1, close: 1, adjusted_close: 1, volume: 100,
+      };
+    });
+    const stub = makeStubClient(rows);
+    const cache = new SupabaseCache({
+      enabled: true,
+      client: stub as unknown as any,
+      coverage: 0.9,
+      maxStalenessMs: 5 * 24 * 60 * 60 * 1000,
+    });
+    const result = await cache.getPrices('AAPL', days);
+    expect(result).toBeNull();
+    expect(cache.staleCount).toBe(1);
+    expect(cache.missCount).toBe(1);
+    expect(cache.hitCount).toBe(0);
+  });
+
+  it('returns rows when newest bar is within maxStalenessMs', async () => {
+    const days = 3;
+    const today = new Date();
+    // newest-first, dated today, yesterday, day-before
+    const rows = Array.from({ length: days }, (_, i) => {
+      const d = new Date(today);
+      d.setUTCDate(d.getUTCDate() - i);
+      return {
+        date: d.toISOString().slice(0, 10),
+        open: 1, high: 1, low: 1, close: 1, adjusted_close: 1, volume: 100,
+      };
+    });
     const stub = makeStubClient(rows);
     const cache = new SupabaseCache({
       enabled: true,
@@ -195,7 +256,7 @@ describe('SupabaseCache — durable price cache', () => {
     const result = await cache.getPrices('AAPL', days);
     expect(result).toHaveLength(days);
     expect(cache.hitCount).toBe(1);
-    expect(result?.[0].close).toBe(100); // adjusted_close routed to close
+    expect(cache.staleCount).toBe(0);
   });
 
   it('setPrices upserts in batches', async () => {


### PR DESCRIPTION
## Summary

Polygon Stocks Starter is entitled to **5 years** of historical data; `EarningsOracle.fetchHistoricalPrices` still defaulted to `years = 2` (a leftover from the free tier). So beat-rate, expected-move, and volatility-trend stats trained on a 2-year window and silently ignored the extra 3 years we now pay for.

Widening the default to 5 improves those stats monotonically: `buildEarningsPattern` folds the price series against earnings report dates via `calculatePriceReaction`, so more history means more historical earnings get matched price data — it never skews a fixed-size window, only adds coverage.

## Changes

- `src/earnings/EarningsOracle.ts` — `fetchHistoricalPrices` default `years: 2 → 5` (+ explanatory comment).

## Testing

- `EarningsOracle` 31 tests pass
- `typecheck` clean

Independent of the other Polygon PRs (touches only `EarningsOracle.ts`). Part of the Polygon Starter harden+unlock plan (Workstream B1).