### PR TITLE
feat(data): Polygon grouped-daily freshness sync (B2)

### DIFF
--- a/schemas/arch.json
+++ b/schemas/arch.json
@@ -1,16 +1,16 @@
 {
-  "generatedAt": "2026-06-17T00:38:42.907Z",
-  "headSha": "2a6c7f668d611496d9d36ae6ff531571c8cb68f4",
+  "generatedAt": "2026-07-02T06:00:16.613Z",
+  "headSha": "327e594ed2df4158485bce352e8508bbe32cf189",
   "version": "1.13.0",
   "server": {
-    "tsFiles": 145,
-    "tsNonTestFiles": 139,
+    "tsFiles": 147,
+    "tsNonTestFiles": 141,
     "inSourceTestFiles": 6,
     "routeModules": 33,
     "endpoints": 124,
     "migrations": 17,
     "vercelApiFiles": 4,
-    "testFiles": 53
+    "testFiles": 56
   },
   "client": {
     "pages": 25,

--- a/src/data/CacheWarmer.ts
+++ b/src/data/CacheWarmer.ts
@@ -1,18 +1,33 @@
 /**
  * CacheWarmer — proactive prefetch for top-held symbols (US-006, P5).
  *
- * Hits `frontier_positions` joined through `frontier_portfolios.user_id` to
- * find the most-held symbols across all users, then pre-fetches their
- * historical prices into `marketDataCache`. The warmer is called:
+ * Two-tier warming strategy (B2, Polygon Starter):
+ *
+ *   TIER 1 — per-symbol backfill (`warmTopHeldSymbols`):
+ *     One historical fetch per warmed symbol via
+ *     `MarketDataProvider.getHistoricalPrices` (~20 symbols → ~20 calls). This
+ *     is the ONLY way to build deep 300-day history: grouped-daily is
+ *     one-day-all-tickers, so a 300-day backfill would cost 300 grouped calls.
+ *     Backfill therefore stays per-symbol.
+ *
+ *   TIER 2 — grouped-daily freshness sync (`warmLatestDayAllSymbols`):
+ *     Once history is built, refreshing the LATEST bar for ALL warmed symbols
+ *     takes ONE `fetchGroupedDaily` call (every US ticker's OHLCV for one day)
+ *     instead of N per-symbol calls. Additive: it write-throughs only the
+ *     newest bar into the cache (upsert on symbol,date) and leaves the
+ *     backfilled history untouched. Complements Tier 1; never replaces it.
+ *
+ * The warmer is called:
  *   - On server boot (non-blocking) from `src/index.ts`
  *   - On hourly Vercel cron via `/api/v1/cron/warm-cache`
  *   - On boot for the dev account's portfolio symbols (solo-user mode)
  *
  * Per-process bottleneck:
  *   - We hand-roll a small p-queue-style limiter (no `p-queue` dep) capped
- *     at 4 concurrent Polygon calls. The same limiter wraps every
- *     warmTopHeldSymbols() call so background warming doesn't starve
- *     synchronous user requests.
+ *     at MAX_CONCURRENT_UPSTREAM concurrent Polygon calls. The same limiter
+ *     wraps every warmTopHeldSymbols() call so background warming doesn't
+ *     starve synchronous user requests. (The grouped-daily freshness sync is
+ *     a single call, so it doesn't need the limiter.)
  *
  * Failure mode:
  *   - Per-symbol errors are caught and logged; the run continues.
@@ -255,6 +270,107 @@ export async function warmTopHeldSymbols(
     'CacheWarmer: complete',
   );
   return result;
+}
+
+/**
+ * Result of a grouped-daily freshness sync (Tier 2).
+ */
+export interface FreshnessResult {
+  /** The trading day (YYYY-MM-DD) the grouped-daily call targeted. */
+  date: string;
+  /** How many tickers the single grouped-daily call returned. */
+  tickersInGroup: number;
+  /** How many of the warmed symbols were found and write-through refreshed. */
+  updated: number;
+  /** The warmed symbols that were refreshed. */
+  symbols: string[];
+}
+
+/**
+ * Resolve the most recent trading day, walking weekends back to Friday.
+ *
+ * Uses UTC to match `fetchGroupedDaily`, which formats the date via
+ * `toISOString().slice(0, 10)` (also UTC). Holidays are NOT special-cased: a
+ * grouped-daily call for a holiday returns empty results, which the caller
+ * treats as "nothing to refresh" — so we never need a holiday calendar here.
+ */
+export function mostRecentTradingDay(from: Date = new Date()): Date {
+  const d = new Date(from.getTime());
+  const dow = d.getUTCDay(); // 0 = Sun ... 6 = Sat
+  if (dow === 0) {
+    d.setUTCDate(d.getUTCDate() - 2); // Sunday -> Friday
+  } else if (dow === 6) {
+    d.setUTCDate(d.getUTCDate() - 1); // Saturday -> Friday
+  }
+  return d;
+}
+
+/**
+ * Tier 2 — grouped-daily freshness sync. Fetches every US ticker's OHLCV for
+ * the most recent trading day in ONE `fetchGroupedDaily` call, then
+ * write-throughs the latest bar for each warmed symbol found in the group.
+ *
+ * This is ADDITIVE to `warmTopHeldSymbols` (Tier 1 backfill): it refreshes only
+ * the newest bar (upsert on symbol,date via `CompositeCache.setPrices`) and
+ * leaves the backfilled history intact. On the next read, the SupabaseCache
+ * freshness gate sees the fresh newest bar and serves the cached window instead
+ * of forcing a per-symbol upstream refetch.
+ *
+ * A single grouped call replaces N per-symbol freshness fetches — the core B2
+ * win once Polygon Starter lifts the per-call ceiling.
+ */
+export async function warmLatestDayAllSymbols(
+  provider: MarketDataProvider,
+  symbols: string[],
+  refDate: Date = new Date(),
+): Promise<FreshnessResult> {
+  const tradingDay = mostRecentTradingDay(refDate);
+  const dateStr = tradingDay.toISOString().slice(0, 10);
+
+  if (symbols.length === 0) {
+    return { date: dateStr, tickersInGroup: 0, updated: 0, symbols: [] };
+  }
+
+  logger.info({ date: dateStr, symbolCount: symbols.length }, 'CacheWarmer: grouped-daily freshness sync starting');
+
+  const group = await provider.fetchGroupedDaily(tradingDay);
+  if (group.size === 0) {
+    logger.info(
+      { date: dateStr },
+      'CacheWarmer: grouped-daily returned no rows (holiday, provider error, or breaker open)',
+    );
+    return { date: dateStr, tickersInGroup: 0, updated: 0, symbols: [] };
+  }
+
+  const cache = provider.getHistoricalCache();
+  const updatedSymbols: string[] = [];
+
+  for (const raw of symbols) {
+    const symbol = raw.toUpperCase();
+    const bar = group.get(symbol);
+    if (!bar || bar.length === 0) continue;
+    try {
+      // Upsert the single latest bar. SupabaseCache.setPrices upserts on
+      // (symbol,date) so this refreshes the newest bar without rewriting the
+      // backfilled history.
+      await cache.setPrices(symbol, bar);
+      updatedSymbols.push(symbol);
+    } catch (err) {
+      logger.warn({ err, symbol }, 'CacheWarmer: freshness write-through failed');
+    }
+  }
+
+  logger.info(
+    { date: dateStr, tickersInGroup: group.size, updated: updatedSymbols.length },
+    'CacheWarmer: grouped-daily freshness sync complete',
+  );
+
+  return {
+    date: dateStr,
+    tickersInGroup: group.size,
+    updated: updatedSymbols.length,
+    symbols: updatedSymbols,
+  };
 }
 
 /**

--- a/src/data/MarketDataProvider.ts
+++ b/src/data/MarketDataProvider.ts
@@ -435,6 +435,17 @@ export class MarketDataProvider {
     }
   }
 
+  /**
+   * The composite historical-price cache (Memory + Supabase). Exposed so the
+   * grouped-daily freshness sync (`CacheWarmer.warmLatestDayAllSymbols`) can
+   * write-through the latest bar for warmed symbols WITHOUT re-reading through
+   * the provider chain. Kept an accessor (not a public field) so tests can
+   * still override the private `historicalPriceCache` slot.
+   */
+  getHistoricalCache(): CompositeCache {
+    return this.historicalPriceCache;
+  }
+
   private async doFetchHistoricalPrices(
     upperSymbol: string,
     days: number,
@@ -1157,6 +1168,104 @@ export class MarketDataProvider {
     }));
 
     return prices;
+  }
+
+  /**
+   * Polygon grouped-daily aggregates (B2 freshness sync).
+   *
+   * The grouped-daily endpoint returns EVERY US ticker's OHLCV for ONE trading
+   * day in a SINGLE HTTP call. That makes it a big win for DAILY FRESHNESS
+   * (refresh the latest bar for all warmed symbols in one request instead of N
+   * per-symbol calls) but NOT for deep backfill — a 300-day history would need
+   * 300 grouped calls. So this COMPLEMENTS the per-symbol `fetchPolygonPrices`
+   * backfill; it does not replace it. See `CacheWarmer.warmLatestDayAllSymbols`.
+   *
+   * Response shape: `{ status, results: [{ T, o, h, l, c, v, t }, ...] }` where
+   * `T` is the ticker symbol and `t` is the bar's ms timestamp.
+   *
+   * Returns a map of `symbol -> single-day Price[]`. On any non-OK HTTP status,
+   * an `ERROR` body, or empty results (e.g. a market holiday), returns an EMPTY
+   * map so the caller treats it as "no freshness data this run" and leaves the
+   * backfilled history untouched. Guarded by the shared `polygon` breaker; note
+   * we accept both `OK` and the delayed Starter plan's `DELAYED` status (we key
+   * off the presence of `results`, not a strict `status === 'OK'`).
+   */
+  async fetchGroupedDaily(date: Date): Promise<Map<string, Price[]>> {
+    const empty = new Map<string, Price[]>();
+    if (!this.config.polygonApiKey) return empty;
+
+    const breaker = getBreaker('polygon');
+    if (!breaker.canAttempt()) {
+      logger.warn('Polygon breaker open — skipping grouped-daily freshness sync');
+      return empty;
+    }
+
+    const day = date.toISOString().slice(0, 10);
+    const url =
+      `https://api.polygon.io/v2/aggs/grouped/locale/us/market/stocks/${day}` +
+      `?adjusted=true&apiKey=${this.config.polygonApiKey}`;
+
+    try {
+      const response = await fetchWithRetry(url, undefined);
+      if (!response.ok) {
+        const { impact, kind } = recordProviderError('polygon', response.status);
+        logger.warn(
+          { day, status: response.status, quotaImpact: impact, kind, guidance: BACKOFF_GUIDANCE[impact] },
+          'Polygon HTTP non-200 for grouped-daily'
+        );
+        breaker.recordFailure();
+        return empty;
+      }
+
+      const data = (await response.json()) as {
+        status?: string;
+        error?: string;
+        results?: Array<{ T: string; o: number; h: number; l: number; c: number; v: number; t: number }>;
+      };
+
+      if (data.status === 'ERROR' || data.error) {
+        const reason = String(data.error ?? data.status).slice(0, 240);
+        const impact = recordUpstreamError('polygon', classifyErrorBody(reason));
+        logger.warn(
+          { day, reason, quotaImpact: impact, guidance: BACKOFF_GUIDANCE[impact] },
+          'Polygon refused grouped-daily (key invalid or rate-limited)'
+        );
+        breaker.recordFailure();
+        return empty;
+      }
+
+      const results = data.results ?? [];
+      // A valid response with no rows (market holiday / weekend) is NOT a
+      // provider failure — record success so the breaker doesn't trip on quiet
+      // days, and return an empty map.
+      if (results.length === 0) {
+        breaker.recordSuccess();
+        return empty;
+      }
+
+      const map = new Map<string, Price[]>();
+      for (const r of results) {
+        if (!r.T) continue;
+        const symbol = r.T.toUpperCase();
+        map.set(symbol, [
+          {
+            symbol,
+            timestamp: new Date(r.t),
+            open: r.o,
+            high: r.h,
+            low: r.l,
+            close: r.c,
+            volume: r.v,
+          },
+        ]);
+      }
+      breaker.recordSuccess();
+      return map;
+    } catch (e) {
+      breaker.recordFailure();
+      logger.warn({ err: e, day }, 'Polygon grouped-daily fetch error');
+      return empty;
+    }
   }
 
   private async fetchAlphaVantagePrices(

--- a/tests/data/CacheWarmer.groupedDaily.test.ts
+++ b/tests/data/CacheWarmer.groupedDaily.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the B2 grouped-daily freshness sync (Tier 2 cache warming).
+ *
+ * The grouped-daily endpoint returns EVERY US ticker's OHLCV for ONE trading
+ * day in a SINGLE call — a big win for DAILY FRESHNESS (one call refreshes the
+ * latest bar for all warmed symbols instead of N per-symbol calls). It
+ * COMPLEMENTS the per-symbol backfill; it does not replace it.
+ *
+ * MSW intercepts the grouped endpoint. Coverage:
+ *   - grouped-daily returns a multi-ticker map from ONE call
+ *   - a `status:'ERROR'` / empty body yields an empty map
+ *   - the freshness sync write-throughs the latest bar for warmed symbols
+ *   - weekend ref dates walk back to Friday (mostRecentTradingDay)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../setup.js';
+
+// supabase.ts throws on import without these — set before importing the SUT.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+import { MarketDataProvider } from '../../src/data/MarketDataProvider.js';
+import {
+  warmLatestDayAllSymbols,
+  mostRecentTradingDay,
+} from '../../src/data/CacheWarmer.js';
+import type { CompositeCache } from '../../src/data/cache/index.js';
+import type { Price } from '../../src/types/index.js';
+import { resetBreakers, getBreaker } from '../../src/data/resilience.js';
+import { resetQuotaStats } from '../../src/data/QuotaClassifier.js';
+
+const POLY_KEY = 'x'.repeat(32);
+const POLY_GROUPED =
+  'https://api.polygon.io/v2/aggs/grouped/locale/us/market/stocks/:date';
+
+/** Grouped-daily OK body with one row per ticker (T = ticker, t = ms ts). */
+function groupedOK(tickers: Record<string, number>) {
+  const ts = Date.parse('2026-06-19T20:00:00Z');
+  return HttpResponse.json({
+    status: 'OK',
+    results: Object.entries(tickers).map(([T, c]) => ({
+      T,
+      o: c - 1,
+      h: c + 1,
+      l: c - 2,
+      c,
+      v: 1_000_000,
+      t: ts,
+    })),
+  });
+}
+
+/** A cache stub that records setPrices calls. */
+function stubCache(): CompositeCache {
+  return {
+    getPrices: vi.fn().mockResolvedValue(null),
+    setPrices: vi.fn().mockResolvedValue(undefined),
+    getStalePrices: vi.fn().mockResolvedValue(null),
+    setMemoryOnly: vi.fn(),
+    telemetry: vi.fn(),
+    resetCounters: vi.fn(),
+  } as unknown as CompositeCache;
+}
+
+function makeProvider(): MarketDataProvider {
+  const p = new MarketDataProvider({
+    polygonApiKey: POLY_KEY,
+    allowMockFallback: false,
+  });
+  (p as unknown as { useSupabaseCache: boolean }).useSupabaseCache = false;
+  return p;
+}
+
+beforeEach(() => {
+  resetBreakers();
+  resetQuotaStats();
+});
+
+describe('MarketDataProvider.fetchGroupedDaily', () => {
+  it('returns a multi-ticker map from ONE grouped-daily call', async () => {
+    let hits = 0;
+    server.use(
+      http.get(POLY_GROUPED, () => {
+        hits += 1;
+        return groupedOK({ AAPL: 200, MSFT: 400, NVDA: 120 });
+      }),
+    );
+
+    const provider = makeProvider();
+    const map = await provider.fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+
+    expect(hits).toBe(1); // one call for the whole market
+    expect(map.size).toBe(3);
+    expect(map.get('AAPL')?.[0].close).toBe(200);
+    expect(map.get('MSFT')?.[0].close).toBe(400);
+    expect(map.get('NVDA')?.[0].close).toBe(120);
+    // Each entry is a single-day Price[].
+    expect(map.get('AAPL')).toHaveLength(1);
+    const bar = map.get('AAPL')![0];
+    expect(bar.symbol).toBe('AAPL');
+    expect(bar.open).toBe(199);
+    expect(bar.high).toBe(201);
+    expect(bar.low).toBe(198);
+    expect(bar.volume).toBe(1_000_000);
+    expect(bar.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('yields an empty map on a status:ERROR body', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () =>
+        HttpResponse.json({ status: 'ERROR', error: 'unknown api key' }),
+      ),
+    );
+
+    const map = await makeProvider().fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+    expect(map.size).toBe(0);
+  });
+
+  it('yields an empty map on an OK body with no results (holiday)', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () => HttpResponse.json({ status: 'OK', results: [] })),
+    );
+
+    const map = await makeProvider().fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+    expect(map.size).toBe(0);
+    // A valid empty response is NOT a provider failure — breaker stays closed.
+    expect(getBreaker('polygon').getState()).toBe('closed');
+  });
+
+  it('yields an empty map (no throw) on a non-200 HTTP status', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () => new HttpResponse('rate limited', { status: 429 })),
+    );
+
+    const map = await makeProvider().fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+    expect(map.size).toBe(0);
+  });
+
+  it('skips the call entirely when the polygon breaker is open', async () => {
+    let hits = 0;
+    server.use(
+      http.get(POLY_GROUPED, () => {
+        hits += 1;
+        return groupedOK({ AAPL: 200 });
+      }),
+    );
+
+    const breaker = getBreaker('polygon');
+    for (let i = 0; i < 5; i++) breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+
+    const map = await makeProvider().fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+    expect(map.size).toBe(0);
+    expect(hits).toBe(0); // never called — breaker open
+  });
+});
+
+describe('warmLatestDayAllSymbols — freshness sync', () => {
+  it('write-throughs the latest bar for each warmed symbol found in the group', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () => groupedOK({ AAPL: 200, MSFT: 400, NVDA: 120, TSLA: 250 })),
+    );
+
+    const provider = makeProvider();
+    const cache = stubCache();
+    (provider as unknown as { historicalPriceCache: CompositeCache }).historicalPriceCache = cache;
+
+    // Ask for 3 warmed symbols; only those present in the group are refreshed.
+    const result = await warmLatestDayAllSymbols(
+      provider,
+      ['aapl', 'msft', 'GOOGL'], // GOOGL is NOT in the group
+      new Date('2026-06-19T12:00:00Z'),
+    );
+
+    expect(result.tickersInGroup).toBe(4);
+    expect(result.updated).toBe(2);
+    expect(result.symbols).toEqual(['AAPL', 'MSFT']);
+
+    expect(cache.setPrices).toHaveBeenCalledTimes(2);
+    const [aaplSym, aaplBars] = (cache.setPrices as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(aaplSym).toBe('AAPL');
+    expect(aaplBars).toHaveLength(1);
+    expect((aaplBars as Price[])[0].close).toBe(200);
+  });
+
+  it('is a no-op (no cache writes) when grouped-daily returns nothing', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () => HttpResponse.json({ status: 'OK', results: [] })),
+    );
+
+    const provider = makeProvider();
+    const cache = stubCache();
+    (provider as unknown as { historicalPriceCache: CompositeCache }).historicalPriceCache = cache;
+
+    const result = await warmLatestDayAllSymbols(provider, ['AAPL', 'MSFT'], new Date('2026-06-19T12:00:00Z'));
+
+    expect(result.updated).toBe(0);
+    expect(cache.setPrices).not.toHaveBeenCalled();
+  });
+
+  it('returns early without an upstream call when no symbols are warmed', async () => {
+    let hits = 0;
+    server.use(
+      http.get(POLY_GROUPED, () => {
+        hits += 1;
+        return groupedOK({ AAPL: 200 });
+      }),
+    );
+
+    const result = await warmLatestDayAllSymbols(makeProvider(), [], new Date('2026-06-19T12:00:00Z'));
+    expect(result.updated).toBe(0);
+    expect(hits).toBe(0);
+  });
+});
+
+describe('mostRecentTradingDay', () => {
+  it('returns the same day for a weekday', () => {
+    // 2026-06-19 is a Friday.
+    const d = mostRecentTradingDay(new Date('2026-06-19T12:00:00Z'));
+    expect(d.toISOString().slice(0, 10)).toBe('2026-06-19');
+  });
+
+  it('walks Saturday back to Friday', () => {
+    // 2026-06-20 is a Saturday.
+    const d = mostRecentTradingDay(new Date('2026-06-20T12:00:00Z'));
+    expect(d.toISOString().slice(0, 10)).toBe('2026-06-19');
+  });
+
+  it('walks Sunday back to Friday', () => {
+    // 2026-06-21 is a Sunday.
+    const d = mostRecentTradingDay(new Date('2026-06-21T12:00:00Z'));
+    expect(d.toISOString().slice(0, 10)).toBe('2026-06-19');
+  });
+});


### PR DESCRIPTION
## What

Adds a **Tier 2 grouped-daily freshness sync** that complements the existing per-symbol backfill.

## The one-day-all-tickers nuance (why this is NOT a backfill replacement)

Polygon's grouped-daily endpoint (`/v2/aggs/grouped/locale/us/market/stocks/{YYYY-MM-DD}`) returns **every US ticker's OHLCV for ONE trading day in a single call**.

- That is a big win for **daily freshness**: once history is built, refreshing the latest bar for ALL warmed symbols costs **one** call instead of N per-symbol calls.
- It is **not** a win for deep backfill: a 300-day history would need 300 grouped calls (one per day).

So this is **additive**. Deep 300-day backfill stays on the per-symbol path (`warmTopHeldSymbols` -> `getHistoricalPrices`); only the newest-bar freshness refresh moves to grouped-daily. The existing backfill path is untouched.

## Changes

- **`MarketDataProvider.fetchGroupedDaily(date)`** - one grouped-daily call, returns `Map<symbol, Price[]>` (single-day bar per ticker). Reuses `fetchWithRetry` + `recordProviderError` + the shared `polygon` circuit breaker, mirroring `fetchPolygonPrices`. Non-OK HTTP, an `ERROR` body, or empty results (market holiday) all return an empty map. Accepts both `OK` and the delayed Starter plan's `DELAYED` status by keying off `results` presence rather than a strict `status === 'OK'`.
- **`MarketDataProvider.getHistoricalCache()`** - accessor so the warmer can write-through without re-reading through the provider chain.
- **`CacheWarmer.warmLatestDayAllSymbols(provider, symbols)`** - resolves the most recent trading day (weekends walk back to Friday via `mostRecentTradingDay`), fetches grouped-daily once, then upserts the latest bar for each warmed symbol via `CompositeCache.setPrices` (upsert on `symbol,date`, so backfilled history is preserved). On the next read the `SupabaseCache` freshness gate sees the fresh newest bar and serves the cached window instead of forcing a per-symbol refetch.
- **CacheWarmer header comment** now documents the two-tier strategy.

## Tests

New `tests/data/CacheWarmer.groupedDaily.test.ts` (11 tests, MSW):
- grouped-daily returns a multi-ticker map from ONE call
- `status:'ERROR'` body / empty-results body / non-200 HTTP each yield an empty map
- breaker-open skips the call entirely
- freshness sync write-throughs the latest bar for warmed symbols found in the group (and no-ops when the group is empty / no symbols warmed)
- `mostRecentTradingDay` weekend walk-back

## Verification

- `npm run typecheck` - clean
- `npx vitest run tests/data` - 54 passed (43 baseline + 11 new)
- `npm run lint` - clean
- `npm run arch:check` - passes (regenerated `schemas/arch.json`; the only delta is test/non-test file counts, no route/page/integration drift)