### PR TITLE
feat(observability): Polygon health alerting + quota digest + health-path reconcile (E)

### DIFF
--- a/schemas/arch.json
+++ b/schemas/arch.json
@@ -1,16 +1,16 @@
 {
-  "generatedAt": "2026-06-17T00:38:42.907Z",
-  "headSha": "2a6c7f668d611496d9d36ae6ff531571c8cb68f4",
+  "generatedAt": "2026-07-02T06:03:22.371Z",
+  "headSha": "327e594ed2df4158485bce352e8508bbe32cf189",
   "version": "1.13.0",
   "server": {
-    "tsFiles": 145,
-    "tsNonTestFiles": 139,
+    "tsFiles": 148,
+    "tsNonTestFiles": 142,
     "inSourceTestFiles": 6,
     "routeModules": 33,
     "endpoints": 124,
     "migrations": 17,
     "vercelApiFiles": 4,
-    "testFiles": 53
+    "testFiles": 56
   },
   "client": {
     "pages": 25,

--- a/src/notifications/email-templates/weekly-health-digest.ts
+++ b/src/notifications/email-templates/weekly-health-digest.ts
@@ -45,6 +45,28 @@ export interface IntegrationStatusEntry {
   reason?: string | null;
 }
 
+/** Per-provider quota + operational error-kind counts (IDEA-CIN-5). Shape
+ * mirrors one provider entry of `getQuotaStats().providers`. */
+export interface ProviderQuotaSummary {
+  quota_burned: number;
+  quota_free: number;
+  provider_fault: number;
+  guidance: string | null;
+  errorKinds: {
+    rate_limit: number;
+    auth: number;
+    plan_tier: number;
+    client_error: number;
+    server_fault: number;
+  };
+}
+
+/** Full quota snapshot passed from `getQuotaStats()`. */
+export interface QuotaDigestSection {
+  since: string;
+  providers: Record<string, ProviderQuotaSummary>;
+}
+
 export interface WeeklyHealthDigestData {
   dateRange: string; // "May 4 – May 10, 2026"
   /** Total errors counted in the rolling 1-hour window. */
@@ -58,8 +80,12 @@ export interface WeeklyHealthDigestData {
     offline: number;
     badEntries: IntegrationStatusEntry[];
   };
-  /** Placeholder until US-006 wires real cache stats. `null` ⇒ N/A. */
+  /** Real cache hit ratio from CompositeCache telemetry (US-006). `null` ⇒
+   * nothing read yet this window (renders "n/a"). */
   cacheHitRatio: number | null;
+  /** Per-provider upstream quota + error-kind counts. Optional; omitted ⇒
+   * the quota card is not rendered (back-compat with older callers/tests). */
+  quota?: QuotaDigestSection | null;
   /** Most-recent deploy id (Vercel commit SHA, Railway revision, or null). */
   deployId: string | null;
   /** Whether Sentry is configured. False ⇒ counter is sole source. */
@@ -121,6 +147,32 @@ function integrationListRow(entry: IntegrationStatusEntry): string {
         </td>
         <td align="right" valign="top" style="padding:6px 0;white-space:nowrap;">
           <span style="font-family:${FONT_MONO};color:${color};font-size:11px;letter-spacing:0.18em;text-transform:uppercase;font-weight:600;">${escapeHtml(entry.status)}</span>
+        </td>
+      </tr>
+    </table>`;
+}
+
+/** One provider row in the quota card: rate-limit / auth / plan-tier counts. */
+function quotaProviderRow(name: string, p: ProviderQuotaSummary): string {
+  const k = p.errorKinds;
+  // Alertable kinds (auth/plan-tier) go red when non-zero; rate-limit is amber.
+  const authColor = k.auth > 0 ? NEG : COLORS.textMuted;
+  const planColor = k.plan_tier > 0 ? NEG : COLORS.textMuted;
+  const rateColor = k.rate_limit > 0 ? WARN : COLORS.textMuted;
+  const guidance = p.guidance
+    ? `<div style="font-family:${FONT_SANS};color:${COLORS.textDim};font-size:11px;line-height:1.4;">${escapeHtml(p.guidance)}</div>`
+    : '';
+  return `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td style="padding:6px 0;border-bottom:1px solid ${COLORS.border};">
+          <div style="font-family:${FONT_MONO};color:${COLORS.text};font-size:12px;">${escapeHtml(name)}</div>
+          ${guidance}
+        </td>
+        <td align="right" valign="top" style="padding:6px 0;border-bottom:1px solid ${COLORS.border};white-space:nowrap;">
+          <span style="font-family:${FONT_MONO};font-size:11px;font-variant-numeric:tabular-nums;color:${rateColor};">rate ${k.rate_limit}</span>
+          <span style="font-family:${FONT_MONO};font-size:11px;font-variant-numeric:tabular-nums;color:${authColor};margin-left:10px;">auth ${k.auth}</span>
+          <span style="font-family:${FONT_MONO};font-size:11px;font-variant-numeric:tabular-nums;color:${planColor};margin-left:10px;">plan ${k.plan_tier}</span>
         </td>
       </tr>
     </table>`;
@@ -192,6 +244,20 @@ export function renderWeeklyHealthDigest(
     ${summaryRow('Cache hit ratio', cacheValue, COLORS.white)}
     ${summaryRow('Latest deploy', deployValue, COLORS.white)}`;
 
+  // --- Provider quota card (optional) -------------------------------------
+  const quotaProviders = data.quota
+    ? Object.entries(data.quota.providers)
+    : [];
+  const quotaBlock =
+    quotaProviders.length === 0
+      ? null
+      : `
+    ${monoKicker('Upstream Quota · Error Kinds', COLORS.textMuted)}
+    ${spacer(6)}
+    <div style="font-family:${FONT_SANS};color:${COLORS.textMuted};font-size:12px;line-height:1.5;">Per-provider request outcomes since ${escapeHtml(data.quota!.since)}. rate = 429 rate-limits · auth = 401 revoked/invalid key · plan = 403 plan-tier block.</div>
+    ${spacer(10)}
+    ${quotaProviders.map(([name, p]) => quotaProviderRow(name, p)).join('')}`;
+
   // --- Caveat -------------------------------------------------------------
   const caveatText = data.sentryConfigured
     ? 'Sentry is configured. The error counter and Sentry are dual sources; cross-reference via X-Request-Id tag for any specific incident.'
@@ -214,6 +280,7 @@ export function renderWeeklyHealthDigest(
         ${spacer(16)}
         ${card({ body: infraBlock })}
         ${spacer(16)}
+        ${quotaBlock ? `${card({ body: quotaBlock })}${spacer(16)}` : ''}
         ${card({ body: caveatBlock, padding: '16px 20px' })}
         ${spacer(24)}
         ${cta({ href: data.errorsEndpointUrl, label: 'Open /health/errors', accent: 'halo' })}
@@ -243,6 +310,16 @@ export function renderWeeklyHealthDigest(
         .join('\n')
     : '  (all live)';
 
+  const textQuota =
+    quotaProviders.length === 0
+      ? null
+      : quotaProviders
+          .map(
+            ([name, p]) =>
+              `  ${name.padEnd(13)} rate ${p.errorKinds.rate_limit} · auth ${p.errorKinds.auth} · plan ${p.errorKinds.plan_tier}${p.guidance ? ` — ${p.guidance}` : ''}`
+          )
+          .join('\n');
+
   const text = [
     `FRONTIER ALPHA · WEEKLY HEALTH DIGEST · ${data.dateRange}`,
     '',
@@ -255,6 +332,9 @@ export function renderWeeklyHealthDigest(
     '',
     `Cache hit ratio: ${cacheValue}`,
     `Latest deploy: ${deployValue}`,
+    ...(textQuota
+      ? ['', `Upstream quota (since ${data.quota!.since}):`, textQuota]
+      : []),
     '',
     caveatText,
     '',

--- a/src/observability/PolygonHealthAlerter.ts
+++ b/src/observability/PolygonHealthAlerter.ts
@@ -1,0 +1,205 @@
+/**
+ * Polygon health alerting (Workstream E1).
+ *
+ * Before this, a Polygon outage only surfaced when a human read the dashboard,
+ * curled `/health/integrations`, or opened the weekly digest. This module turns
+ * the synthetic monitor into an active alarm:
+ *
+ *   1. DEBOUNCED alert — after N consecutive failing synthetic-monitor polls
+ *      (default 3), send one operator notification. Only fires on the
+ *      TRANSITION into the failing state (not every poll), and resets when a
+ *      poll comes back clean. This absorbs transient blips (a single failed
+ *      15-minute poll) while still catching a sustained outage within ~45 min.
+ *
+ *   2. IMMEDIATE escalation — if Polygon has logged an ALERTABLE error kind
+ *      (401 auth = revoked/invalid key, or 403 plan_tier = entitlement block),
+ *      alert now with no debounce. Those need a human immediately; waiting 3
+ *      polls to tell the operator their key was revoked is a bug, not caution.
+ *      Alertable-kind counts come from `QuotaClassifier` (recorded at the
+ *      Polygon fetch sites via `recordProviderError`).
+ *
+ * State is in-process module-level (same posture as ErrorCounter / QuotaClassifier)
+ * and resets on process restart. The send is BEST-EFFORT — every failure path is
+ * swallowed so an alerting hiccup never throws into the cron path.
+ */
+
+import {
+  getErrorKindCount,
+  isAlertableErrorKind,
+  type ProviderErrorKind,
+} from '../data/QuotaClassifier.js';
+import { getAlertDelivery } from '../notifications/AlertDelivery.js';
+import { logger } from './logger.js';
+
+/** Consecutive failing polls before the debounced alert fires. */
+const DEFAULT_THRESHOLD = 3;
+
+/** Operator recipient — the sole operator for v1.3.x (matches health-summary). */
+const DEFAULT_RECIPIENT = 'dicoangelo@metaventionsai.com';
+
+// ── In-process state (resets on restart) ───────────────────────────────────
+let consecutiveFailures = 0;
+/** Guard: only one debounced alert per failing streak (no per-poll spam). */
+let alertedForCurrentStreak = false;
+/** Alertable-kind counts we've already alerted on, so a persistent 401 doesn't
+ * re-alert every 15-minute poll. */
+let lastAlertedAuthCount = 0;
+let lastAlertedPlanTierCount = 0;
+
+export interface MonitorRunSummary {
+  /** Number of failing probes in this poll. */
+  failed: number;
+  /** Number of passing probes in this poll. */
+  passed: number;
+  /** Failing routes (route key + error) for the alert body. */
+  failingRoutes: Array<{ route: string; error: string | null }>;
+}
+
+export interface PolygonAlertOutcome {
+  alerted: boolean;
+  reason: 'debounce-threshold' | 'alertable-kind' | null;
+  consecutiveFailures: number;
+}
+
+function threshold(): number {
+  const raw = Number(process.env.POLYGON_ALERT_THRESHOLD);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_THRESHOLD;
+}
+
+function recipient(): string {
+  return process.env.HEALTH_ALERT_RECIPIENT?.trim() || DEFAULT_RECIPIENT;
+}
+
+interface AlertContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+/** Best-effort operator email. Never throws — logs and returns on any failure. */
+async function sendOperatorEmail(content: AlertContent): Promise<void> {
+  try {
+    const to = recipient();
+    const result = await getAlertDelivery().sendEmail({
+      to,
+      subject: content.subject,
+      html: content.html,
+      text: content.text,
+    });
+    if (!result.success) {
+      logger.warn(
+        { error: result.error, to },
+        'PolygonHealthAlerter: operator alert email failed',
+      );
+    } else {
+      logger.info({ to, subject: content.subject }, 'PolygonHealthAlerter: alert sent');
+    }
+  } catch (err) {
+    logger.warn({ err }, 'PolygonHealthAlerter: alert send threw (swallowed)');
+  }
+}
+
+function buildAlertContent(
+  reason: 'debounce-threshold' | 'alertable-kind',
+  summary: MonitorRunSummary,
+  detail: string,
+): AlertContent {
+  const headline =
+    reason === 'alertable-kind'
+      ? 'Polygon needs a human NOW'
+      : `Polygon health failing (${consecutiveFailures} consecutive polls)`;
+  const failing = summary.failingRoutes.length
+    ? summary.failingRoutes.map((r) => `  - ${r.route}: ${r.error ?? 'unknown'}`).join('\n')
+    : '  (no per-route detail)';
+  const text = [
+    `FRONTIER ALPHA · HEALTH ALERT`,
+    '',
+    headline,
+    detail,
+    '',
+    `Passed: ${summary.passed} · Failed: ${summary.failed}`,
+    'Failing routes:',
+    failing,
+    '',
+    'Source: synthetic-monitor (GET /api/v1/cron/synthetic-monitor).',
+    'Runbook: CLAUDE.md → Incident playbook (/health/integrations degraded).',
+  ].join('\n');
+  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const html = `<!DOCTYPE html><html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111;max-width:600px;margin:0 auto;padding:20px;">
+  <h2 style="margin:0 0 8px;color:#b91c1c;">${esc(headline)}</h2>
+  <p style="margin:0 0 12px;color:#374151;">${esc(detail)}</p>
+  <p style="margin:0 0 4px;color:#374151;"><strong>Passed:</strong> ${summary.passed} · <strong>Failed:</strong> ${summary.failed}</p>
+  <pre style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:8px;padding:12px;font-size:12px;overflow:auto;">${esc(failing)}</pre>
+  <p style="margin:12px 0 0;color:#6b7280;font-size:12px;">Source: synthetic-monitor · Runbook: CLAUDE.md incident playbook.</p>
+</body></html>`;
+  const subject =
+    reason === 'alertable-kind'
+      ? 'Frontier Alpha · Polygon ALERT · key/plan action required'
+      : `Frontier Alpha · Polygon health failing (${consecutiveFailures}× polls)`;
+  return { subject, html, text };
+}
+
+/**
+ * Evaluate one synthetic-monitor poll and, if warranted, fire a best-effort
+ * operator alert. Returns the decision so the caller (and tests) can assert
+ * behavior. Never throws.
+ */
+export async function evaluatePolygonHealth(
+  summary: MonitorRunSummary,
+): Promise<PolygonAlertOutcome> {
+  // Update the debounce counter first so the alert body reports the right count.
+  if (summary.failed > 0) {
+    consecutiveFailures += 1;
+  } else {
+    consecutiveFailures = 0;
+    alertedForCurrentStreak = false;
+  }
+
+  // ── 1) Immediate alertable-kind escalation (no debounce) ─────────────────
+  const authCount = getErrorKindCount('polygon', 'auth');
+  const planTierCount = getErrorKindCount('polygon', 'plan_tier');
+  const newAuth = authCount > lastAlertedAuthCount;
+  const newPlanTier = planTierCount > lastAlertedPlanTierCount;
+  if (newAuth || newPlanTier) {
+    const kind: ProviderErrorKind = newAuth ? 'auth' : 'plan_tier';
+    // isAlertableErrorKind is true by construction here, but keep the guard
+    // explicit so the intent (auth/plan-tier only) is legible.
+    if (isAlertableErrorKind(kind)) {
+      // Advance both watermarks so we don't re-alert on the same counts.
+      lastAlertedAuthCount = authCount;
+      lastAlertedPlanTierCount = planTierCount;
+      const detail =
+        kind === 'auth'
+          ? `Polygon returned HTTP 401 (auth). The API key is likely revoked, invalid, or truncated. Rotate it (CLAUDE.md rotation runbook, printf-not-echo).`
+          : `Polygon returned HTTP 403 (plan_tier). The requested data is not entitled on the current plan. Check the Polygon plan / endpoint entitlement.`;
+      await sendOperatorEmail(buildAlertContent('alertable-kind', summary, detail));
+      return { alerted: true, reason: 'alertable-kind', consecutiveFailures };
+    }
+  }
+
+  // ── 2) Debounced threshold alert (transition into failing state only) ────
+  if (summary.failed > 0 && consecutiveFailures >= threshold() && !alertedForCurrentStreak) {
+    alertedForCurrentStreak = true;
+    const detail = `The synthetic monitor has failed ${consecutiveFailures} consecutive polls (threshold ${threshold()}). This is a sustained Polygon-path / production health failure, not a transient blip.`;
+    await sendOperatorEmail(buildAlertContent('debounce-threshold', summary, detail));
+    return { alerted: true, reason: 'debounce-threshold', consecutiveFailures };
+  }
+
+  return { alerted: false, reason: null, consecutiveFailures };
+}
+
+/** Reset all in-process state (test seam). */
+export function resetPolygonHealthAlerter(): void {
+  consecutiveFailures = 0;
+  alertedForCurrentStreak = false;
+  lastAlertedAuthCount = 0;
+  lastAlertedPlanTierCount = 0;
+}
+
+/** Read-only snapshot (test seam / diagnostics). */
+export function getPolygonHealthAlerterState(): {
+  consecutiveFailures: number;
+  alertedForCurrentStreak: boolean;
+} {
+  return { consecutiveFailures, alertedForCurrentStreak };
+}

--- a/src/routes/health-summary.ts
+++ b/src/routes/health-summary.ts
@@ -24,6 +24,8 @@ import type {
 } from 'fastify';
 import { errorCounter } from '../observability/ErrorCounter.js';
 import { logger } from '../observability/logger.js';
+import { getQuotaStats } from '../data/QuotaClassifier.js';
+import { getCacheTelemetry } from '../data/cache/index.js';
 import type {
   APIResponse,
   IntegrationHealthEntry,
@@ -182,8 +184,17 @@ export async function healthSummaryRoutes(
       }
     }
 
-    // ── Cache hit ratio (placeholder until US-006) ────────────────────────
-    const cacheHitRatio: number | null = null;
+    // ── Cache hit ratio (US-006 — real telemetry) ────────────────────────
+    // CompositeCache rolls up memory + supabase hits/misses. Ratio is
+    // hits / (hits + misses); null when nothing has been read yet so the
+    // template renders "n/a" rather than a misleading 0%.
+    const cacheTelemetry = getCacheTelemetry();
+    const cacheReads = cacheTelemetry.total.hits + cacheTelemetry.total.misses;
+    const cacheHitRatio: number | null =
+      cacheReads > 0 ? cacheTelemetry.total.hits / cacheReads : null;
+
+    // ── Provider quota + error-kind stats (IDEA-CIN-5) ────────────────────
+    const quota = getQuotaStats();
 
     // ── Deploy id ─────────────────────────────────────────────────────────
     const deployId = resolveDeployId();
@@ -218,6 +229,7 @@ export async function healthSummaryRoutes(
         badEntries,
       },
       cacheHitRatio,
+      quota,
       deployId,
       sentryConfigured,
       errorsEndpointUrl,

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -731,27 +731,21 @@ async function checkDatabase(): Promise<{ status: 'ok' | 'error'; message?: stri
 }
 
 async function checkExternalApis(): Promise<{ status: 'ok' | 'error'; message?: string }> {
-  const polygonKey = process.env.POLYGON_API_KEY;
-
-  if (!polygonKey) {
-    return { status: 'error', message: 'Polygon API not configured' };
+  // E4: delegate to probePolygon() so the 429 semantics stay CONSISTENT with
+  // the /api/v1/health/integrations path. Previously this treated HTTP 429 as
+  // `{ status: 'ok', message: 'Rate limited (normal)' }` while probePolygon
+  // reported 429 as `degraded`. Now that Polygon Starter is unlimited, a 429 is
+  // a real signal (something is wrong), so it must NOT read as healthy here.
+  // probePolygon maps: live → ok; degraded/offline (incl. 429, missing key,
+  // 5xx, non-OK body) → error, preserving the reason for the deep health check.
+  const result = await probePolygon();
+  if (result.status === 'live') {
+    return { status: 'ok' };
   }
-
-  try {
-    const response = await fetch(
-      `https://api.polygon.io/v2/aggs/ticker/AAPL/prev?adjusted=true&apiKey=${polygonKey}`
-    );
-
-    if (response.ok) {
-      return { status: 'ok' };
-    }
-    if (response.status === 429) {
-      return { status: 'ok', message: 'Rate limited (normal)' };
-    }
-    return { status: 'error', message: `HTTP ${response.status}` };
-  } catch {
-    return { status: 'error', message: 'Connection failed' };
-  }
+  return {
+    status: 'error',
+    message: result.reason ?? result.lastError ?? `polygon ${result.status}`,
+  };
 }
 
 export async function healthRoutes(fastify: FastifyInstance, opts: RouteContext) {

--- a/src/routes/synthetic-monitor.ts
+++ b/src/routes/synthetic-monitor.ts
@@ -427,6 +427,24 @@ export async function syntheticMonitorRoutes(
       }
     }
 
+    // E1: debounced Polygon/synthetic health alerting. Best-effort — the whole
+    // evaluation is wrapped so an alerting fault never throws into the cron
+    // path (which must always return a 200 status report).
+    try {
+      const { evaluatePolygonHealth } = await import(
+        '../observability/PolygonHealthAlerter.js'
+      );
+      await evaluatePolygonHealth({
+        passed,
+        failed,
+        failingRoutes: results
+          .filter((r) => r.error !== null || !r.schemaValid)
+          .map((r) => ({ route: r.route, error: r.error })),
+      });
+    } catch (err) {
+      logger.warn({ err }, 'synthetic-monitor: health-alert evaluation failed');
+    }
+
     if (failed > 0) {
       logger.warn(
         {

--- a/tests/unit/observability-alerting.test.ts
+++ b/tests/unit/observability-alerting.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Unit tests: Workstream E — observability + alerting.
+ *
+ *   E4  reconcile the two Polygon health-check paths — HTTP 429 must read as
+ *       `degraded` in BOTH probePolygon (/health/integrations) and
+ *       checkExternalApis (/api/v1/health), never as "ok / rate limited (normal)".
+ *   E2  weekly digest surfaces per-provider quota + error-kind stats and a REAL
+ *       (non-null) cache hit ratio computed from CompositeCache telemetry.
+ *   E1  debounced Polygon health alerting off the synthetic monitor — no alert
+ *       before the threshold, one alert AT the threshold, no duplicate spam,
+ *       reset on a clean poll, and immediate escalation on an alertable error
+ *       kind (401 auth / 403 plan-tier).
+ *
+ * MSW intercepts outbound HTTP. Resend/PushService are never hit — AlertDelivery
+ * is mocked at the module level so no real mail/push is sent.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { http, HttpResponse } from 'msw';
+import { server } from '../setup.js';
+import { _probeCacheForTests } from '../../src/routes/health.js';
+import { renderWeeklyHealthDigest } from '../../src/notifications/email-templates/weekly-health-digest.js';
+import {
+  recordProviderError,
+  resetQuotaStats,
+} from '../../src/data/QuotaClassifier.js';
+import { marketDataCache } from '../../src/data/cache/index.js';
+
+// supabase.ts throws on import without these — set before any import resolves.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+// Capture-only email spy so no real Resend/PushService call is made.
+const { sendEmailSpy } = vi.hoisted(() => ({ sendEmailSpy: vi.fn() }));
+
+vi.mock('../../src/notifications/AlertDelivery.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/notifications/AlertDelivery.js')>();
+  return {
+    ...actual,
+    getAlertDelivery: vi.fn(() => ({ sendEmail: sendEmailSpy })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const { buildApp } = await import('../../src/app.js');
+  const { app } = await buildApp({ websockets: false, enableLogger: false });
+  await app.ready();
+  return app;
+}
+
+const savedEnv: Record<string, string | undefined> = {};
+function saveEnv(...keys: string[]) {
+  for (const k of keys) savedEnv[k] = process.env[k];
+}
+function restoreEnv(...keys: string[]) {
+  for (const k of keys) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+}
+
+const POLYGON_PREV = 'https://api.polygon.io/v2/aggs/ticker/AAPL/prev';
+const SUPABASE_REST = 'http://localhost:54321/rest/v1/';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  _probeCacheForTests.clear();
+  sendEmailSpy.mockReset();
+  sendEmailSpy.mockResolvedValue({ success: true, messageId: 'test' });
+});
+
+// ===========================================================================
+// E4 — 429 → degraded consistency across BOTH health-check paths
+// ===========================================================================
+
+describe('E4: Polygon 429 is degraded in both health-check paths', () => {
+  beforeEach(() => {
+    saveEnv('POLYGON_API_KEY');
+    process.env.POLYGON_API_KEY = 'test-polygon-key';
+    _probeCacheForTests.clear();
+  });
+  afterEach(() => {
+    restoreEnv('POLYGON_API_KEY');
+    _probeCacheForTests.clear();
+  });
+
+  it('probePolygon path (/health/integrations): 429 → degraded', async () => {
+    server.use(
+      http.get(POLYGON_PREV, () => new HttpResponse(null, { status: 429 })),
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/v1/health/integrations' });
+    const body = res.json() as {
+      integrations: Record<string, { status: string; reason?: string }>;
+    };
+    expect(body.integrations.polygon.status).toBe('degraded');
+    expect(body.integrations.polygon.reason).toContain('429');
+  });
+
+  it('checkExternalApis path (/api/v1/health): 429 → error (not "ok / normal") → overall degraded', async () => {
+    server.use(
+      http.get(POLYGON_PREV, () => new HttpResponse(null, { status: 429 })),
+      // Keep the DB check green so the ONLY error is the external Polygon 429,
+      // which must drop overall health to `degraded` (one error), proving the
+      // 429 is no longer swallowed as "ok".
+      http.get(SUPABASE_REST, () => HttpResponse.json({}, { status: 200 })),
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/v1/health' });
+    const body = res.json() as {
+      status: string;
+      checks: {
+        database?: { status: string };
+        external?: { status: string; message?: string };
+      };
+    };
+    expect(body.checks.external?.status).toBe('error');
+    // The message must reflect the rate-limit signal, not "normal".
+    expect(body.checks.external?.message ?? '').toMatch(/429/);
+    expect(body.checks.external?.message ?? '').not.toMatch(/normal/i);
+    expect(body.checks.database?.status).toBe('ok');
+    expect(body.status).toBe('degraded');
+  });
+
+  it('checkExternalApis path: healthy Polygon → external ok', async () => {
+    server.use(
+      http.get(POLYGON_PREV, () =>
+        HttpResponse.json({ status: 'OK', resultsCount: 1, results: [] }),
+      ),
+      http.get(SUPABASE_REST, () => HttpResponse.json({}, { status: 200 })),
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/v1/health' });
+    const body = res.json() as { status: string; checks: { external?: { status: string } } };
+    expect(body.checks.external?.status).toBe('ok');
+    expect(body.status).toBe('healthy');
+  });
+});
+
+// ===========================================================================
+// E2 — digest quota stats + real cache hit ratio
+// ===========================================================================
+
+describe('E2: weekly digest renders quota + cache ratio', () => {
+  const baseDigest = {
+    dateRange: 'May 4 – May 10, 2026',
+    totalErrors: 0,
+    topRoutes: [],
+    integrations: { live: 5, degraded: 1, offline: 0, badEntries: [] },
+    deployId: 'abc123',
+    sentryConfigured: false,
+    errorsEndpointUrl: 'https://example.com/api/v1/health/errors',
+  };
+
+  it('template: renders per-provider rate/auth/plan counts + computed cache %', () => {
+    const payload = renderWeeklyHealthDigest({
+      ...baseDigest,
+      cacheHitRatio: 0.75,
+      quota: {
+        since: '2026-05-04T00:00:00.000Z',
+        providers: {
+          polygon: {
+            quota_burned: 3,
+            quota_free: 2,
+            provider_fault: 0,
+            guidance: 'back off the full rate window before retrying',
+            errorKinds: {
+              rate_limit: 3,
+              auth: 2,
+              plan_tier: 1,
+              client_error: 2,
+              server_fault: 0,
+            },
+          },
+        },
+      },
+    });
+    // Cache ratio is computed, not "pending".
+    expect(payload.html).toContain('75.0%');
+    expect(payload.html).not.toContain('pending US-006');
+    // Quota card present with the three headline error-kind counts.
+    expect(payload.html).toContain('Upstream Quota');
+    expect(payload.html).toContain('rate 3');
+    expect(payload.html).toContain('auth 2');
+    expect(payload.html).toContain('plan 1');
+    // Text mirror carries it too.
+    expect(payload.text).toContain('Cache hit ratio: 75.0%');
+    expect(payload.text).toMatch(/polygon\s+rate 3 · auth 2 · plan 1/);
+  });
+
+  it('template: null quota omits the card; null ratio renders n/a', () => {
+    const payload = renderWeeklyHealthDigest({ ...baseDigest, cacheHitRatio: null });
+    expect(payload.html).not.toContain('Upstream Quota');
+    expect(payload.html).toContain('n/a');
+  });
+
+  it('route: /digest/health-summary computes a NON-null cache ratio and includes quota', async () => {
+    saveEnv('CRON_SECRET', 'EMAIL_PROVIDER');
+    process.env.CRON_SECRET = 'test-cron-secret';
+    process.env.EMAIL_PROVIDER = 'resend';
+
+    // Seed real quota state (alertable auth kind on polygon).
+    resetQuotaStats();
+    recordProviderError('polygon', 401);
+    recordProviderError('polygon', 429);
+
+    // Seed real CompositeCache telemetry so hits+misses > 0 → ratio is non-null.
+    marketDataCache.resetCounters();
+    marketDataCache.memory.set('AAPL:7', []);
+    marketDataCache.memory.get('AAPL:7'); // hit
+    marketDataCache.memory.get('MISS:7'); // miss
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/digest/health-summary?key=test-cron-secret',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+    const payload = sendEmailSpy.mock.calls[0][0] as { html: string; text: string };
+    // Non-null ratio: 1 hit / 2 reads = 50.0%.
+    expect(payload.html).toContain('50.0%');
+    expect(payload.html).not.toContain('pending US-006');
+    // Quota card carries the seeded polygon counts.
+    expect(payload.html).toContain('Upstream Quota');
+    expect(payload.text).toMatch(/polygon\s+rate 1 · auth 1 · plan 0/);
+
+    resetQuotaStats();
+    marketDataCache.resetCounters();
+    restoreEnv('CRON_SECRET', 'EMAIL_PROVIDER');
+  });
+});
+
+// ===========================================================================
+// E1 — debounced Polygon health alerting
+// ===========================================================================
+
+describe('E1: debounced Polygon health alerter', () => {
+  let evaluatePolygonHealth: typeof import('../../src/observability/PolygonHealthAlerter.js')['evaluatePolygonHealth'];
+  let resetPolygonHealthAlerter: typeof import('../../src/observability/PolygonHealthAlerter.js')['resetPolygonHealthAlerter'];
+
+  beforeAll(async () => {
+    const mod = await import('../../src/observability/PolygonHealthAlerter.js');
+    evaluatePolygonHealth = mod.evaluatePolygonHealth;
+    resetPolygonHealthAlerter = mod.resetPolygonHealthAlerter;
+  });
+
+  const failingPoll = { failed: 1, passed: 9, failingRoutes: [{ route: 'quotesHistory', error: 'non-200 (500)' }] };
+  const cleanPoll = { failed: 0, passed: 10, failingRoutes: [] };
+
+  beforeEach(() => {
+    resetPolygonHealthAlerter();
+    resetQuotaStats();
+    sendEmailSpy.mockReset();
+    sendEmailSpy.mockResolvedValue({ success: true, messageId: 'test' });
+  });
+
+  it('does NOT alert before the threshold (default 3)', async () => {
+    const r1 = await evaluatePolygonHealth(failingPoll);
+    const r2 = await evaluatePolygonHealth(failingPoll);
+    expect(r1.alerted).toBe(false);
+    expect(r2.alerted).toBe(false);
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+  });
+
+  it('alerts exactly AT the threshold with reason=debounce-threshold', async () => {
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll);
+    const r3 = await evaluatePolygonHealth(failingPoll);
+    expect(r3.alerted).toBe(true);
+    expect(r3.reason).toBe('debounce-threshold');
+    expect(r3.consecutiveFailures).toBe(3);
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT re-alert on subsequent failing polls (no spam)', async () => {
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll); // alert #1
+    const r4 = await evaluatePolygonHealth(failingPoll);
+    const r5 = await evaluatePolygonHealth(failingPoll);
+    expect(r4.alerted).toBe(false);
+    expect(r5.alerted).toBe(false);
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the counter (and re-arms) on a clean poll', async () => {
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll);
+    const clean = await evaluatePolygonHealth(cleanPoll);
+    expect(clean.consecutiveFailures).toBe(0);
+
+    // Must take a fresh full run of 3 to alert again.
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll);
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+    const third = await evaluatePolygonHealth(failingPoll);
+    expect(third.alerted).toBe(true);
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('escalates IMMEDIATELY (no debounce) on an alertable auth kind', async () => {
+    recordProviderError('polygon', 401); // revoked/invalid key
+    const r1 = await evaluatePolygonHealth(failingPoll);
+    expect(r1.alerted).toBe(true);
+    expect(r1.reason).toBe('alertable-kind');
+    expect(r1.consecutiveFailures).toBe(1); // fired well before threshold
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+    const subject = (sendEmailSpy.mock.calls[0][0] as { subject: string }).subject;
+    expect(subject).toMatch(/action required/i);
+  });
+
+  it('escalates immediately on a plan-tier (403) block', async () => {
+    recordProviderError('polygon', 403);
+    const r1 = await evaluatePolygonHealth(failingPoll);
+    expect(r1.alerted).toBe(true);
+    expect(r1.reason).toBe('alertable-kind');
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-escalate on the same alertable count across polls', async () => {
+    recordProviderError('polygon', 401);
+    await evaluatePolygonHealth(failingPoll); // alertable alert #1
+    const r2 = await evaluatePolygonHealth(failingPoll); // same 401 count, no new alert
+    expect(r2.reason).not.toBe('alertable-kind');
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Workstream E (observability + alerting) for the Polygon Starter hardening. Builds on the error-kind tracking added in `harden/data-provider-cdf`.

## E4 — reconcile the two health-check paths
`checkExternalApis()` (used by `GET /api/v1/health`) treated Polygon HTTP 429 as `{ status: 'ok', message: 'Rate limited (normal)' }` while `probePolygon()` (used by `/health/integrations`) treated it as `degraded`. Now that Starter is unlimited a 429 is a real signal, so `checkExternalApis()` delegates to `probePolygon()`: `live` maps to `ok`, everything else (incl. 429, missing key, 5xx, non-OK body) maps to `error`. Both paths now agree that a 429 is degraded.

## E2 — quota stats + real cache ratio in the weekly digest
- `health-summary` now calls `getQuotaStats()` and passes it to the digest.
- The `null` "pending US-006" cache placeholder is replaced with a real ratio computed from `getCacheTelemetry()` (`total.hits / (total.hits + total.misses)`), `null` only when nothing has been read.
- `weekly-health-digest.ts` renders a per-provider Upstream Quota card (rate-limit / auth / plan-tier counts + guidance) and a plaintext mirror.

## E1 — debounced Polygon health alerting
New `src/observability/PolygonHealthAlerter.ts`, wired into the synthetic monitor:
- After N consecutive failing polls (default 3, `POLYGON_ALERT_THRESHOLD`) it sends ONE operator alert on the transition into the failing state; resets on a clean poll; no per-poll spam.
- Immediate escalation (no debounce) when Polygon has logged an alertable error kind (401 auth / 403 plan-tier), detected via `getErrorKindCount` + `isAlertableErrorKind`.
- Sends via the existing `AlertDelivery` Resend path, fully best-effort (try/catch, never throws into the cron path).

## Tests
`tests/unit/observability-alerting.test.ts` (13 tests): E4 429 consistency in both paths; E2 template + route render quota and a non-null cache ratio; E1 debounce (no alert before threshold, alert at threshold, no spam, reset on success, immediate auth/plan-tier escalation, no re-escalation on same count). Resend/PushService mocked, no real sends.

## Verification
- `npm run typecheck` clean
- `npx vitest run` 1014 pass (was 1001; +13 new)
- `npm run lint` clean
- `npm run arch:check` clean (arch.json regenerated)

## Not done
- E3 (adding the `VERCEL_TOKEN` repo secret) is a USER action and was NOT performed here.
- No `src/data/CacheWarmer.ts` or `src/data/MarketDataProvider.ts` changes (owned by a parallel agent).