### PR TITLE
feat(data): Polygon hardening + entitlement unlock + observability (C+D+F+B2+E)

### DIFF
--- a/schemas/arch.json
+++ b/schemas/arch.json
@@ -1,16 +1,16 @@
 {
-  "generatedAt": "2026-06-17T00:38:42.907Z",
-  "headSha": "2a6c7f668d611496d9d36ae6ff531571c8cb68f4",
+  "generatedAt": "2026-07-02T06:00:16.613Z",
+  "headSha": "327e594ed2df4158485bce352e8508bbe32cf189",
   "version": "1.13.0",
   "server": {
-    "tsFiles": 145,
-    "tsNonTestFiles": 139,
+    "tsFiles": 147,
+    "tsNonTestFiles": 141,
     "inSourceTestFiles": 6,
     "routeModules": 33,
     "endpoints": 124,
     "migrations": 17,
     "vercelApiFiles": 4,
-    "testFiles": 53
+    "testFiles": 56
   },
   "client": {
     "pages": 25,

--- a/schemas/arch.json
+++ b/schemas/arch.json
@@ -1,16 +1,16 @@
 {
-  "generatedAt": "2026-06-17T00:38:42.907Z",
-  "headSha": "2a6c7f668d611496d9d36ae6ff531571c8cb68f4",
+  "generatedAt": "2026-07-02T06:03:22.371Z",
+  "headSha": "327e594ed2df4158485bce352e8508bbe32cf189",
   "version": "1.13.0",
   "server": {
-    "tsFiles": 145,
-    "tsNonTestFiles": 139,
+    "tsFiles": 148,
+    "tsNonTestFiles": 142,
     "inSourceTestFiles": 6,
     "routeModules": 33,
     "endpoints": 124,
     "migrations": 17,
     "vercelApiFiles": 4,
-    "testFiles": 53
+    "testFiles": 56
   },
   "client": {
     "pages": 25,

--- a/schemas/env-schema.json
+++ b/schemas/env-schema.json
@@ -40,6 +40,14 @@
       "description": "Polygon REST + WebSocket API key. EXACTLY 32 chars — v1.2.6 incident: echo|vercel env add truncated to 30 chars and silently 401'd for weeks. Always rotate via printf, not echo."
     },
     {
+      "name": "POLYGON_WS_URL",
+      "required": false,
+      "regex": "^wss://.+",
+      "sourceUrl": "https://polygon.io/docs/websocket/getting-started",
+      "lastVerified": "2026-07-02",
+      "description": "Optional Polygon WebSocket cluster override. Defaults in code to wss://delayed.polygon.io/stocks (Stocks Starter is a 15-min-delayed plan, NOT entitled to the real-time cluster wss://socket.polygon.io). Set to the real-time cluster only on a real-time plan."
+    },
+    {
       "name": "ALPHA_VANTAGE_API_KEY",
       "required": true,
       "regex": "^[A-Z0-9]{8,32}$",

--- a/schemas/env-schema.json
+++ b/schemas/env-schema.json
@@ -48,6 +48,19 @@
       "description": "Optional Polygon WebSocket cluster override. Defaults in code to wss://delayed.polygon.io/stocks (Stocks Starter is a 15-min-delayed plan, NOT entitled to the real-time cluster wss://socket.polygon.io). Set to the real-time cluster only on a real-time plan."
     },
     {
+      "name": "POLYGON_ALERT_THRESHOLD",
+      "required": false,
+      "regex": "^[0-9]+$",
+      "lastVerified": "2026-07-02",
+      "description": "Consecutive failed synthetic-monitor polls before PolygonHealthAlerter fires a debounced alert (E1). Defaults to 3 in code. Auth/plan-tier (401/403) errors escalate immediately regardless."
+    },
+    {
+      "name": "HEALTH_ALERT_RECIPIENT",
+      "required": false,
+      "lastVerified": "2026-07-02",
+      "description": "Optional override for the email address PolygonHealthAlerter sends health-flip alerts to (E1). Defaults to the operator address used by the weekly digest."
+    },
+    {
       "name": "ALPHA_VANTAGE_API_KEY",
       "required": true,
       "regex": "^[A-Z0-9]{8,32}$",

--- a/src/data/CacheWarmer.ts
+++ b/src/data/CacheWarmer.ts
@@ -32,11 +32,14 @@ import { MarketDataProvider } from './MarketDataProvider.js';
 export const DEV_USER_ID = '3ea07211-a7a6-43cd-ae10-0dc112d03ce5';
 
 /**
- * Max concurrent upstream Polygon calls in flight. Polygon free tier is
- * 5 req/min — 4 leaves a 1-req cushion for synchronous user traffic. Any
- * higher and a burst from the warmer can starve a paying user.
+ * Max concurrent upstream calls in flight from the warmer. This is now a
+ * FAIRNESS bound, not a rate cap: Polygon Stocks Starter has no per-minute
+ * call ceiling (the old value of 4 dated from the free tier's 5-req/min
+ * limit). We keep a bound so a warmer burst doesn't monopolize the event
+ * loop / socket pool ahead of synchronous user traffic, but it can be higher
+ * now. (B2 will further reduce fan-out via Polygon grouped-daily.)
  */
-const MAX_CONCURRENT_UPSTREAM = 4;
+const MAX_CONCURRENT_UPSTREAM = 8;
 
 /**
  * Hand-rolled FIFO concurrency limiter. We avoid the `p-queue` dependency

--- a/src/data/CacheWarmer.ts
+++ b/src/data/CacheWarmer.ts
@@ -1,18 +1,33 @@
 /**
  * CacheWarmer — proactive prefetch for top-held symbols (US-006, P5).
  *
- * Hits `frontier_positions` joined through `frontier_portfolios.user_id` to
- * find the most-held symbols across all users, then pre-fetches their
- * historical prices into `marketDataCache`. The warmer is called:
+ * Two-tier warming strategy (B2, Polygon Starter):
+ *
+ *   TIER 1 — per-symbol backfill (`warmTopHeldSymbols`):
+ *     One historical fetch per warmed symbol via
+ *     `MarketDataProvider.getHistoricalPrices` (~20 symbols → ~20 calls). This
+ *     is the ONLY way to build deep 300-day history: grouped-daily is
+ *     one-day-all-tickers, so a 300-day backfill would cost 300 grouped calls.
+ *     Backfill therefore stays per-symbol.
+ *
+ *   TIER 2 — grouped-daily freshness sync (`warmLatestDayAllSymbols`):
+ *     Once history is built, refreshing the LATEST bar for ALL warmed symbols
+ *     takes ONE `fetchGroupedDaily` call (every US ticker's OHLCV for one day)
+ *     instead of N per-symbol calls. Additive: it write-throughs only the
+ *     newest bar into the cache (upsert on symbol,date) and leaves the
+ *     backfilled history untouched. Complements Tier 1; never replaces it.
+ *
+ * The warmer is called:
  *   - On server boot (non-blocking) from `src/index.ts`
  *   - On hourly Vercel cron via `/api/v1/cron/warm-cache`
  *   - On boot for the dev account's portfolio symbols (solo-user mode)
  *
  * Per-process bottleneck:
  *   - We hand-roll a small p-queue-style limiter (no `p-queue` dep) capped
- *     at 4 concurrent Polygon calls. The same limiter wraps every
- *     warmTopHeldSymbols() call so background warming doesn't starve
- *     synchronous user requests.
+ *     at MAX_CONCURRENT_UPSTREAM concurrent Polygon calls. The same limiter
+ *     wraps every warmTopHeldSymbols() call so background warming doesn't
+ *     starve synchronous user requests. (The grouped-daily freshness sync is
+ *     a single call, so it doesn't need the limiter.)
  *
  * Failure mode:
  *   - Per-symbol errors are caught and logged; the run continues.
@@ -255,6 +270,107 @@ export async function warmTopHeldSymbols(
     'CacheWarmer: complete',
   );
   return result;
+}
+
+/**
+ * Result of a grouped-daily freshness sync (Tier 2).
+ */
+export interface FreshnessResult {
+  /** The trading day (YYYY-MM-DD) the grouped-daily call targeted. */
+  date: string;
+  /** How many tickers the single grouped-daily call returned. */
+  tickersInGroup: number;
+  /** How many of the warmed symbols were found and write-through refreshed. */
+  updated: number;
+  /** The warmed symbols that were refreshed. */
+  symbols: string[];
+}
+
+/**
+ * Resolve the most recent trading day, walking weekends back to Friday.
+ *
+ * Uses UTC to match `fetchGroupedDaily`, which formats the date via
+ * `toISOString().slice(0, 10)` (also UTC). Holidays are NOT special-cased: a
+ * grouped-daily call for a holiday returns empty results, which the caller
+ * treats as "nothing to refresh" — so we never need a holiday calendar here.
+ */
+export function mostRecentTradingDay(from: Date = new Date()): Date {
+  const d = new Date(from.getTime());
+  const dow = d.getUTCDay(); // 0 = Sun ... 6 = Sat
+  if (dow === 0) {
+    d.setUTCDate(d.getUTCDate() - 2); // Sunday -> Friday
+  } else if (dow === 6) {
+    d.setUTCDate(d.getUTCDate() - 1); // Saturday -> Friday
+  }
+  return d;
+}
+
+/**
+ * Tier 2 — grouped-daily freshness sync. Fetches every US ticker's OHLCV for
+ * the most recent trading day in ONE `fetchGroupedDaily` call, then
+ * write-throughs the latest bar for each warmed symbol found in the group.
+ *
+ * This is ADDITIVE to `warmTopHeldSymbols` (Tier 1 backfill): it refreshes only
+ * the newest bar (upsert on symbol,date via `CompositeCache.setPrices`) and
+ * leaves the backfilled history intact. On the next read, the SupabaseCache
+ * freshness gate sees the fresh newest bar and serves the cached window instead
+ * of forcing a per-symbol upstream refetch.
+ *
+ * A single grouped call replaces N per-symbol freshness fetches — the core B2
+ * win once Polygon Starter lifts the per-call ceiling.
+ */
+export async function warmLatestDayAllSymbols(
+  provider: MarketDataProvider,
+  symbols: string[],
+  refDate: Date = new Date(),
+): Promise<FreshnessResult> {
+  const tradingDay = mostRecentTradingDay(refDate);
+  const dateStr = tradingDay.toISOString().slice(0, 10);
+
+  if (symbols.length === 0) {
+    return { date: dateStr, tickersInGroup: 0, updated: 0, symbols: [] };
+  }
+
+  logger.info({ date: dateStr, symbolCount: symbols.length }, 'CacheWarmer: grouped-daily freshness sync starting');
+
+  const group = await provider.fetchGroupedDaily(tradingDay);
+  if (group.size === 0) {
+    logger.info(
+      { date: dateStr },
+      'CacheWarmer: grouped-daily returned no rows (holiday, provider error, or breaker open)',
+    );
+    return { date: dateStr, tickersInGroup: 0, updated: 0, symbols: [] };
+  }
+
+  const cache = provider.getHistoricalCache();
+  const updatedSymbols: string[] = [];
+
+  for (const raw of symbols) {
+    const symbol = raw.toUpperCase();
+    const bar = group.get(symbol);
+    if (!bar || bar.length === 0) continue;
+    try {
+      // Upsert the single latest bar. SupabaseCache.setPrices upserts on
+      // (symbol,date) so this refreshes the newest bar without rewriting the
+      // backfilled history.
+      await cache.setPrices(symbol, bar);
+      updatedSymbols.push(symbol);
+    } catch (err) {
+      logger.warn({ err, symbol }, 'CacheWarmer: freshness write-through failed');
+    }
+  }
+
+  logger.info(
+    { date: dateStr, tickersInGroup: group.size, updated: updatedSymbols.length },
+    'CacheWarmer: grouped-daily freshness sync complete',
+  );
+
+  return {
+    date: dateStr,
+    tickersInGroup: group.size,
+    updated: updatedSymbols.length,
+    symbols: updatedSymbols,
+  };
 }
 
 /**

--- a/src/data/MarketDataProvider.ts
+++ b/src/data/MarketDataProvider.ts
@@ -2,12 +2,21 @@
  * FRONTIER ALPHA - Market Data Provider
  *
  * Production-grade market data integration:
- * - Polygon.io: Real-time quotes via WebSocket streaming (<20ms latency)
+ * - Polygon.io: streaming (15-minute delayed) quotes via WebSocket + REST
+ * - Alpaca: provider-independent failover (free IEX delayed feed)
  * - Alpha Vantage: Historical prices (5yr), fundamentals, earnings
  * - Ken French Data Library: Factor returns (30+ years)
  * - Redis: 5-minute quote cache layer
  *
- * NO MOCK DATA IN PRODUCTION - All data from real APIs or throws errors
+ * Reliability posture (harden/data-provider-cdf):
+ * - fetchWithRetry: bounded retry + jittered backoff on transient upstream
+ *   failures (429/5xx/network) before failing over to the next provider.
+ * - CircuitBreaker: per-provider fast-fail so a down/rate-limited provider is
+ *   skipped for a cooldown instead of hammered on every request.
+ * - Graceful degradation: when every provider fails, serve last-resort stale
+ *   cache rows instead of throwing (historical path).
+ *
+ * NO MOCK DATA IN PRODUCTION - All data from real APIs, stale cache, or throws.
  */
 
 import type { Price, Quote, Asset } from '../types/index.js';
@@ -15,11 +24,13 @@ import { supabaseAdmin } from '../lib/supabase.js';
 import { logger } from '../lib/logger.js';
 import { marketDataCache, type CompositeCache } from './cache/index.js';
 import {
-  classifyHttpStatus,
   classifyErrorBody,
   recordUpstreamError,
+  recordProviderError,
+  isAlertableErrorKind,
   BACKOFF_GUIDANCE,
 } from './QuotaClassifier.js';
+import { fetchWithRetry, getBreaker } from './resilience.js';
 import WebSocket from 'ws';
 import Redis, { type Redis as RedisClient } from 'ioredis';
 
@@ -29,6 +40,13 @@ import Redis, { type Redis as RedisClient } from 'ioredis';
 
 export interface DataProviderConfig {
   polygonApiKey?: string;
+  /**
+   * Polygon WebSocket cluster URL. Defaults to the DELAYED cluster
+   * (wss://delayed.polygon.io/stocks), which is what the Stocks Starter plan
+   * is entitled to. Override to wss://socket.polygon.io/stocks only on a
+   * real-time plan.
+   */
+  polygonWsUrl?: string;
   alphaVantageApiKey?: string;
   // Alpaca Market Data API — provider-independent failover for quotes + daily
   // bars. Polygon.io was acquired by Massive (2026-06); if a Massive plan
@@ -87,7 +105,7 @@ export class MarketDataProvider {
   /**
    * In-flight promise dedup — when N parallel callers (e.g. dashboard
    * sparklines) ask for the same symbol's history simultaneously, only one
-   * upstream Polygon/AV call goes out. Saves the free-tier rate limit and
+   * upstream Polygon/AV call goes out. Cuts redundant upstream load and
    * eliminates "5 of 5 symbols 502'd in parallel" UX on first paint.
    *
    * NOTE: kept separate from the cache layer because request coalescing is
@@ -95,6 +113,13 @@ export class MarketDataProvider {
    * need to wait on the SAME upstream fetch; that's not what a cache does.
    */
   private inflightHistoricalPrices: Map<string, Promise<Price[]>> = new Map();
+  /**
+   * In-flight quote dedup (D3). Mirrors `inflightHistoricalPrices` for the
+   * quote path — parallel callers asking for the same symbol on a cache miss
+   * (e.g. the dashboard header + a widget) coalesce onto one upstream fetch
+   * instead of each hitting Polygon independently.
+   */
+  private inflightQuotes: Map<string, Promise<Quote | null>> = new Map();
   private quoteCache: Map<string, { quote: Quote; timestamp: number }> = new Map();
   private useSupabaseCache: boolean = !!process.env.SUPABASE_SERVICE_KEY;
 
@@ -205,59 +230,94 @@ export class MarketDataProvider {
       }
     }
 
-    // 4. Fetch from Polygon.io (primary real-time source)
+    // 4. Cache miss — fetch upstream, coalescing concurrent callers (D3) so a
+    //    dashboard-wide miss fires one upstream request per symbol, not N.
+    const existing = this.inflightQuotes.get(upperSymbol);
+    if (existing) return existing;
+
+    const fetcher = this.doFetchQuoteUpstream(upperSymbol, now);
+    this.inflightQuotes.set(upperSymbol, fetcher);
+    try {
+      return await fetcher;
+    } finally {
+      this.inflightQuotes.delete(upperSymbol);
+    }
+  }
+
+  /**
+   * Upstream quote chain: Polygon -> Alpaca -> Alpha Vantage, each guarded by
+   * a per-provider circuit breaker (skip a provider whose breaker is open
+   * instead of hammering it). Throws DataNotAvailableError in production when
+   * every provider is exhausted; falls back to a mock quote only in dev.
+   */
+  private async doFetchQuoteUpstream(upperSymbol: string, now: number): Promise<Quote | null> {
+    const persist = async (quote: Quote): Promise<Quote> => {
+      this.quoteCache.set(upperSymbol, { quote, timestamp: now });
+      await Promise.all([
+        this.cacheQuoteToRedis(quote),
+        this.cacheQuoteToSupabase(quote),
+      ]);
+      return quote;
+    };
+
+    // 4a. Polygon.io (primary delayed source)
     if (this.config.polygonApiKey) {
-      try {
-        const quote = await this.fetchPolygonQuote(upperSymbol);
-        if (quote) {
-          this.quoteCache.set(upperSymbol, { quote, timestamp: now });
-          await Promise.all([
-            this.cacheQuoteToRedis(quote),
-            this.cacheQuoteToSupabase(quote),
-          ]);
-          return quote;
+      const breaker = getBreaker('polygon');
+      if (breaker.canAttempt()) {
+        try {
+          const quote = await this.fetchPolygonQuote(upperSymbol);
+          if (quote) {
+            breaker.recordSuccess();
+            return await persist(quote);
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.error({ err: e, symbol: upperSymbol }, 'Polygon quote error');
         }
-      } catch (e) {
-        logger.error({ err: e, symbol: upperSymbol }, 'Polygon quote error');
+      } else {
+        logger.warn({ symbol: upperSymbol }, 'Polygon breaker open — skipping to failover');
       }
     }
 
-    // 5. Fetch from Alpaca (provider-independent failover — survives a Massive
-    //    cutoff of the Polygon key). Free IEX feed, real delayed quotes.
+    // 4b. Alpaca (provider-independent failover — survives a Massive cutoff of
+    //     the Polygon key). Free IEX feed, real delayed quotes.
     if (this.config.alpacaApiKey && this.config.alpacaApiSecret) {
-      try {
-        const quote = await this.fetchAlpacaQuote(upperSymbol);
-        if (quote) {
-          this.quoteCache.set(upperSymbol, { quote, timestamp: now });
-          await Promise.all([
-            this.cacheQuoteToRedis(quote),
-            this.cacheQuoteToSupabase(quote),
-          ]);
-          return quote;
+      const breaker = getBreaker('alpaca');
+      if (breaker.canAttempt()) {
+        try {
+          const quote = await this.fetchAlpacaQuote(upperSymbol);
+          if (quote) {
+            breaker.recordSuccess();
+            return await persist(quote);
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.error({ err: e, symbol: upperSymbol }, 'Alpaca quote error');
         }
-      } catch (e) {
-        logger.error({ err: e, symbol: upperSymbol }, 'Alpaca quote error');
       }
     }
 
-    // 6. Fetch from Alpha Vantage (backup for real quotes)
+    // 4c. Alpha Vantage (backup)
     if (this.config.alphaVantageApiKey) {
-      try {
-        const quote = await this.fetchAlphaVantageQuote(upperSymbol);
-        if (quote) {
-          this.quoteCache.set(upperSymbol, { quote, timestamp: now });
-          await Promise.all([
-            this.cacheQuoteToRedis(quote),
-            this.cacheQuoteToSupabase(quote),
-          ]);
-          return quote;
+      const breaker = getBreaker('alphaVantage');
+      if (breaker.canAttempt()) {
+        try {
+          const quote = await this.fetchAlphaVantageQuote(upperSymbol);
+          if (quote) {
+            breaker.recordSuccess();
+            return await persist(quote);
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.error({ err: e, symbol: upperSymbol }, 'Alpha Vantage quote error');
         }
-      } catch (e) {
-        logger.error({ err: e, symbol: upperSymbol }, 'Alpha Vantage quote error');
       }
     }
 
-    // 7. PRODUCTION: Throw error, no mock fallback
+    // 5. PRODUCTION: Throw error, no mock fallback
     if (!this.config.allowMockFallback) {
       throw new DataNotAvailableError(
         `Unable to fetch quote for ${upperSymbol}: No data providers available or all failed. ` +
@@ -265,7 +325,7 @@ export class MarketDataProvider {
       );
     }
 
-    // 8. DEVELOPMENT ONLY: Generate mock quote
+    // 6. DEVELOPMENT ONLY: Generate mock quote
     logger.warn({ symbol: upperSymbol }, 'Using mock quote (dev fallback)');
     return this.generateMockQuote(upperSymbol);
   }
@@ -315,8 +375,11 @@ export class MarketDataProvider {
   private async fetchAlphaVantageQuote(symbol: string): Promise<Quote | null> {
     const url = `https://www.alphavantage.co/query?function=GLOBAL_QUOTE&symbol=${symbol}&apikey=${this.config.alphaVantageApiKey}`;
 
-    const response = await fetch(url);
-    if (!response.ok) return null;
+    const response = await fetchWithRetry(url, undefined);
+    if (!response.ok) {
+      recordProviderError('alphaVantage', response.status);
+      return null;
+    }
 
     const data = await response.json();
     const globalQuote = data['Global Quote'];
@@ -382,14 +445,22 @@ export class MarketDataProvider {
     // hammer Polygon first to preserve the AV quota. Successful upstream
     // fetches write through both cache layers via `setPrices()`.
     if (this.config.polygonApiKey) {
-      try {
-        const prices = await this.fetchPolygonPrices(upperSymbol, days);
-        if (prices.length > 0) {
-          await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
-          return prices;
+      const breaker = getBreaker('polygon');
+      if (breaker.canAttempt()) {
+        try {
+          const prices = await this.fetchPolygonPrices(upperSymbol, days);
+          if (prices.length > 0) {
+            breaker.recordSuccess();
+            await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
+            return prices;
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.warn({ err: e, symbol: upperSymbol }, 'Polygon historical price error');
         }
-      } catch (e) {
-        logger.warn({ err: e, symbol: upperSymbol }, 'Polygon historical price error');
+      } else {
+        logger.warn({ symbol: upperSymbol }, 'Polygon breaker open — skipping to failover');
       }
     }
 
@@ -397,34 +468,63 @@ export class MarketDataProvider {
     // Free IEX feed has no daily request cap, so it absorbs a Polygon/Massive
     // outage far better than Alpha Vantage's 25 req/day.
     if (this.config.alpacaApiKey && this.config.alpacaApiSecret) {
-      try {
-        const prices = await this.fetchAlpacaPrices(upperSymbol, days);
-        if (prices.length > 0) {
-          await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
-          return prices;
+      const breaker = getBreaker('alpaca');
+      if (breaker.canAttempt()) {
+        try {
+          const prices = await this.fetchAlpacaPrices(upperSymbol, days);
+          if (prices.length > 0) {
+            breaker.recordSuccess();
+            await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
+            return prices;
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.warn({ err: e, symbol: upperSymbol }, 'Alpaca historical price error');
         }
-      } catch (e) {
-        logger.warn({ err: e, symbol: upperSymbol }, 'Alpaca historical price error');
       }
     }
 
     if (this.config.alphaVantageApiKey) {
-      try {
-        const prices = await this.fetchAlphaVantagePrices(upperSymbol, days);
-        if (prices.length > 0) {
-          await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
-          return prices;
+      const breaker = getBreaker('alphaVantage');
+      if (breaker.canAttempt()) {
+        try {
+          const prices = await this.fetchAlphaVantagePrices(upperSymbol, days);
+          if (prices.length > 0) {
+            breaker.recordSuccess();
+            await this.historicalPriceCache.setPrices(upperSymbol, prices, days);
+            return prices;
+          }
+          breaker.recordFailure();
+        } catch (e) {
+          breaker.recordFailure();
+          logger.error({ err: e, symbol: upperSymbol }, 'Alpha Vantage price error');
         }
-      } catch (e) {
-        logger.error({ err: e, symbol: upperSymbol }, 'Alpha Vantage price error');
       }
+    }
+
+    // Graceful degradation (C2): every provider failed (or every breaker is
+    // open). Before hard-failing, serve last-resort stale cache rows — a
+    // month-old price series with a loud warning beats a blank dashboard.
+    const stale = await this.historicalPriceCache.getStalePrices(upperSymbol, days);
+    if (stale && stale.length > 0) {
+      const newest = stale[stale.length - 1]?.timestamp;
+      logger.warn(
+        {
+          symbol: upperSymbol,
+          rows: stale.length,
+          newestBar: newest instanceof Date ? newest.toISOString() : null,
+        },
+        'All upstream providers failed — serving STALE cached prices (graceful degradation)'
+      );
+      return stale;
     }
 
     // PRODUCTION: Throw error, no mock fallback
     if (!this.config.allowMockFallback) {
       throw new DataNotAvailableError(
-        `Unable to fetch historical prices for ${upperSymbol}: Alpha Vantage API key required. ` +
-        `Ensure ALPHA_VANTAGE_API_KEY is set.`
+        `Unable to fetch historical prices for ${upperSymbol}: all providers failed and no ` +
+        `cached data is available. Ensure POLYGON_API_KEY / ALPACA_API_KEY / ALPHA_VANTAGE_API_KEY are set.`
       );
     }
 
@@ -577,8 +677,14 @@ export class MarketDataProvider {
     }
 
     return new Promise((resolve, reject) => {
-      const wsUrl = 'wss://socket.polygon.io/stocks';
-      logger.info('Connecting to Polygon.io WebSocket');
+      // Polygon Stocks Starter is a 15-minute-DELAYED plan and is NOT entitled
+      // to the real-time cluster (wss://socket.polygon.io) — auth there
+      // succeeds but no trade/quote messages ever arrive, so the feed looked
+      // "connected" while silently delivering nothing. The delayed cluster
+      // (wss://delayed.polygon.io) is the entitled endpoint on Starter and
+      // streams the same delayed bars the REST snapshot returns.
+      const wsUrl = this.config.polygonWsUrl || 'wss://delayed.polygon.io/stocks';
+      logger.info({ wsUrl }, 'Connecting to Polygon.io WebSocket (delayed cluster)');
 
       this.polygonWs = new WebSocket(wsUrl);
 
@@ -818,9 +924,12 @@ export class MarketDataProvider {
       `https://api.polygon.io/v2/snapshot/locale/us/markets/stocks/tickers/` +
       `${encodeURIComponent(symbol)}?apiKey=${this.config.polygonApiKey}`;
 
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url, undefined);
     if (!response.ok) {
-      recordUpstreamError('polygon', classifyHttpStatus(response.status));
+      const { kind } = recordProviderError('polygon', response.status);
+      if (isAlertableErrorKind(kind)) {
+        logger.error({ symbol, status: response.status, kind }, 'Polygon quote auth/plan-tier failure');
+      }
       return null;
     }
 
@@ -892,9 +1001,12 @@ export class MarketDataProvider {
     const url =
       `${dataUrl}/v2/stocks/${encodeURIComponent(symbol)}/snapshot?feed=iex`;
 
-    const response = await fetch(url, { headers: this.alpacaHeaders() });
+    const response = await fetchWithRetry(url, { headers: this.alpacaHeaders() });
     if (!response.ok) {
-      recordUpstreamError('alpaca', classifyHttpStatus(response.status));
+      const { kind } = recordProviderError('alpaca', response.status);
+      if (isAlertableErrorKind(kind)) {
+        logger.error({ symbol, status: response.status, kind }, 'Alpaca quote auth/plan-tier failure');
+      }
       return null;
     }
 
@@ -949,11 +1061,11 @@ export class MarketDataProvider {
       `?timeframe=1Day&start=${fmt(start)}&end=${fmt(end)}` +
       `&adjustment=all&feed=iex&sort=asc&limit=10000`;
 
-    const response = await fetch(url, { headers: this.alpacaHeaders() });
+    const response = await fetchWithRetry(url, { headers: this.alpacaHeaders() });
     if (!response.ok) {
-      const impact = recordUpstreamError('alpaca', classifyHttpStatus(response.status));
+      const { impact, kind } = recordProviderError('alpaca', response.status);
       logger.warn(
-        { symbol, status: response.status, quotaImpact: impact, guidance: BACKOFF_GUIDANCE[impact] },
+        { symbol, status: response.status, quotaImpact: impact, kind, guidance: BACKOFF_GUIDANCE[impact] },
         'Alpaca HTTP non-200 for daily bars'
       );
       return [];
@@ -984,11 +1096,12 @@ export class MarketDataProvider {
   // ============================================================================
 
   /**
-   * Polygon REST historical aggregates — preferred path because the free tier
-   * is 5 req/min (vs Alpha Vantage's 25 req/day). The Polygon `aggs` endpoint
-   * returns daily OHLCV with one HTTP call per symbol.
+   * Polygon REST historical aggregates — preferred path. On the Stocks Starter
+   * plan Polygon has no per-minute call ceiling (unlike Alpha Vantage's
+   * 25 req/day free cap), so it's the primary and highest-volume source. The
+   * `aggs` endpoint returns daily OHLCV with one HTTP call per symbol.
    *
-   * Returns [] on any error so the caller falls through to Alpha Vantage.
+   * Returns [] on any error so the caller falls through to Alpaca / Alpha Vantage.
    */
   private async fetchPolygonPrices(symbol: string, days: number): Promise<Price[]> {
     const end = new Date();
@@ -1004,11 +1117,11 @@ export class MarketDataProvider {
       `/range/1/day/${fmt(start)}/${fmt(end)}` +
       `?adjusted=true&sort=asc&limit=5000&apiKey=${this.config.polygonApiKey}`;
 
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url, undefined);
     if (!response.ok) {
-      const impact = recordUpstreamError('polygon', classifyHttpStatus(response.status));
+      const { impact, kind } = recordProviderError('polygon', response.status);
       logger.warn(
-        { symbol, status: response.status, quotaImpact: impact, guidance: BACKOFF_GUIDANCE[impact] },
+        { symbol, status: response.status, quotaImpact: impact, kind, guidance: BACKOFF_GUIDANCE[impact] },
         'Polygon HTTP non-200 for historical aggregates'
       );
       return [];
@@ -1058,11 +1171,11 @@ export class MarketDataProvider {
     const outputsize = days > 100 ? 'full' : 'compact';
     const url = `https://www.alphavantage.co/query?function=TIME_SERIES_DAILY&symbol=${symbol}&outputsize=${outputsize}&apikey=${this.config.alphaVantageApiKey}`;
 
-    const response = await fetch(url);
+    const response = await fetchWithRetry(url, undefined);
     if (!response.ok) {
-      const impact = recordUpstreamError('alphaVantage', classifyHttpStatus(response.status));
+      const { impact, kind } = recordProviderError('alphaVantage', response.status);
       logger.warn(
-        { symbol, status: response.status, quotaImpact: impact, guidance: BACKOFF_GUIDANCE[impact] },
+        { symbol, status: response.status, quotaImpact: impact, kind, guidance: BACKOFF_GUIDANCE[impact] },
         'Alpha Vantage HTTP non-200'
       );
       return [];
@@ -1236,6 +1349,9 @@ export class MarketDataProvider {
 // Default export with environment configuration
 export const marketDataProvider = new MarketDataProvider({
   polygonApiKey: process.env.POLYGON_API_KEY,
+  // Delayed cluster by default (Starter entitlement); override via env only on
+  // a real-time Polygon plan.
+  polygonWsUrl: process.env.POLYGON_WS_URL,
   alphaVantageApiKey: process.env.ALPHA_VANTAGE_API_KEY,
   // Alpaca market-data failover — reuses the app-level Alpaca data credentials
   // when present. No-op until both are set (the chain skips the provider).

--- a/src/data/MarketDataProvider.ts
+++ b/src/data/MarketDataProvider.ts
@@ -677,12 +677,15 @@ export class MarketDataProvider {
     }
 
     return new Promise((resolve, reject) => {
-      // Polygon Stocks Starter is a 15-minute-DELAYED plan and is NOT entitled
-      // to the real-time cluster (wss://socket.polygon.io) — auth there
-      // succeeds but no trade/quote messages ever arrive, so the feed looked
-      // "connected" while silently delivering nothing. The delayed cluster
-      // (wss://delayed.polygon.io) is the entitled endpoint on Starter and
-      // streams the same delayed bars the REST snapshot returns.
+      // Polygon Stocks Starter is a 15-minute-DELAYED plan. Point the stream at
+      // the DELAYED cluster (wss://delayed.polygon.io/stocks) — Polygon's
+      // documented endpoint for delayed plans. NB (verified live 2026-07-02):
+      // auth SUCCEEDS on BOTH the delayed and the realtime cluster
+      // (wss://socket.polygon.io) with a Starter key, so a green auth is not
+      // proof of a working feed. The realtime cluster requires a realtime
+      // subscription to actually deliver data; a delayed plan must use the
+      // delayed cluster to receive the (15-min-delayed) trade/quote messages.
+      // Override via POLYGON_WS_URL only on a real-time plan.
       const wsUrl = this.config.polygonWsUrl || 'wss://delayed.polygon.io/stocks';
       logger.info({ wsUrl }, 'Connecting to Polygon.io WebSocket (delayed cluster)');
 

--- a/src/data/MarketDataProvider.ts
+++ b/src/data/MarketDataProvider.ts
@@ -435,6 +435,17 @@ export class MarketDataProvider {
     }
   }
 
+  /**
+   * The composite historical-price cache (Memory + Supabase). Exposed so the
+   * grouped-daily freshness sync (`CacheWarmer.warmLatestDayAllSymbols`) can
+   * write-through the latest bar for warmed symbols WITHOUT re-reading through
+   * the provider chain. Kept an accessor (not a public field) so tests can
+   * still override the private `historicalPriceCache` slot.
+   */
+  getHistoricalCache(): CompositeCache {
+    return this.historicalPriceCache;
+  }
+
   private async doFetchHistoricalPrices(
     upperSymbol: string,
     days: number,
@@ -1157,6 +1168,104 @@ export class MarketDataProvider {
     }));
 
     return prices;
+  }
+
+  /**
+   * Polygon grouped-daily aggregates (B2 freshness sync).
+   *
+   * The grouped-daily endpoint returns EVERY US ticker's OHLCV for ONE trading
+   * day in a SINGLE HTTP call. That makes it a big win for DAILY FRESHNESS
+   * (refresh the latest bar for all warmed symbols in one request instead of N
+   * per-symbol calls) but NOT for deep backfill — a 300-day history would need
+   * 300 grouped calls. So this COMPLEMENTS the per-symbol `fetchPolygonPrices`
+   * backfill; it does not replace it. See `CacheWarmer.warmLatestDayAllSymbols`.
+   *
+   * Response shape: `{ status, results: [{ T, o, h, l, c, v, t }, ...] }` where
+   * `T` is the ticker symbol and `t` is the bar's ms timestamp.
+   *
+   * Returns a map of `symbol -> single-day Price[]`. On any non-OK HTTP status,
+   * an `ERROR` body, or empty results (e.g. a market holiday), returns an EMPTY
+   * map so the caller treats it as "no freshness data this run" and leaves the
+   * backfilled history untouched. Guarded by the shared `polygon` breaker; note
+   * we accept both `OK` and the delayed Starter plan's `DELAYED` status (we key
+   * off the presence of `results`, not a strict `status === 'OK'`).
+   */
+  async fetchGroupedDaily(date: Date): Promise<Map<string, Price[]>> {
+    const empty = new Map<string, Price[]>();
+    if (!this.config.polygonApiKey) return empty;
+
+    const breaker = getBreaker('polygon');
+    if (!breaker.canAttempt()) {
+      logger.warn('Polygon breaker open — skipping grouped-daily freshness sync');
+      return empty;
+    }
+
+    const day = date.toISOString().slice(0, 10);
+    const url =
+      `https://api.polygon.io/v2/aggs/grouped/locale/us/market/stocks/${day}` +
+      `?adjusted=true&apiKey=${this.config.polygonApiKey}`;
+
+    try {
+      const response = await fetchWithRetry(url, undefined);
+      if (!response.ok) {
+        const { impact, kind } = recordProviderError('polygon', response.status);
+        logger.warn(
+          { day, status: response.status, quotaImpact: impact, kind, guidance: BACKOFF_GUIDANCE[impact] },
+          'Polygon HTTP non-200 for grouped-daily'
+        );
+        breaker.recordFailure();
+        return empty;
+      }
+
+      const data = (await response.json()) as {
+        status?: string;
+        error?: string;
+        results?: Array<{ T: string; o: number; h: number; l: number; c: number; v: number; t: number }>;
+      };
+
+      if (data.status === 'ERROR' || data.error) {
+        const reason = String(data.error ?? data.status).slice(0, 240);
+        const impact = recordUpstreamError('polygon', classifyErrorBody(reason));
+        logger.warn(
+          { day, reason, quotaImpact: impact, guidance: BACKOFF_GUIDANCE[impact] },
+          'Polygon refused grouped-daily (key invalid or rate-limited)'
+        );
+        breaker.recordFailure();
+        return empty;
+      }
+
+      const results = data.results ?? [];
+      // A valid response with no rows (market holiday / weekend) is NOT a
+      // provider failure — record success so the breaker doesn't trip on quiet
+      // days, and return an empty map.
+      if (results.length === 0) {
+        breaker.recordSuccess();
+        return empty;
+      }
+
+      const map = new Map<string, Price[]>();
+      for (const r of results) {
+        if (!r.T) continue;
+        const symbol = r.T.toUpperCase();
+        map.set(symbol, [
+          {
+            symbol,
+            timestamp: new Date(r.t),
+            open: r.o,
+            high: r.h,
+            low: r.l,
+            close: r.c,
+            volume: r.v,
+          },
+        ]);
+      }
+      breaker.recordSuccess();
+      return map;
+    } catch (e) {
+      breaker.recordFailure();
+      logger.warn({ err: e, day }, 'Polygon grouped-daily fetch error');
+      return empty;
+    }
   }
 
   private async fetchAlphaVantagePrices(

--- a/src/data/QuotaClassifier.ts
+++ b/src/data/QuotaClassifier.ts
@@ -2,9 +2,11 @@
  * Upstream Error Quota Classification (IDEA-CIN-5)
  *
  * Classifies every upstream data-provider failure by whether it consumed
- * quota. A rate-limited Polygon call DID burn a request against the 5/min
- * ceiling; a malformed query or auth rejection did not; a 5xx is the
- * provider's fault and says nothing about our budget. Different backoff
+ * quota. A rate-limited call (HTTP 429) DID burn a metered request; a
+ * malformed query or auth rejection did not; a 5xx is the provider's fault
+ * and says nothing about our budget. (Polygon Stocks Starter has no per-minute
+ * call ceiling, but Alpha Vantage's free tier does — 25 req/day — so the
+ * quota signal still matters for the failover providers.) Different backoff
  * strategies follow from each class — and the v1.3.7 cache-thrashing
  * investigation would have been faster with this signal in the logs.
  *
@@ -45,6 +47,39 @@ export function classifyHttpStatus(status: number): QuotaImpact {
 }
 
 /**
+ * Orthogonal to QuotaImpact (which is about *budget* accounting), this is the
+ * *operational* class of the failure — what a human should DO about it.
+ * `classifyHttpStatus` collapses 400/401/403/404/422 into a single
+ * `quota_free` bucket, which is right for quota math but hides the two cases
+ * that need a human: a revoked/invalid key (401) and a plan-tier block (403).
+ */
+export type ProviderErrorKind =
+  /** 429 — rate limited. Back off; transient. */
+  | 'rate_limit'
+  /** 401 — key invalid, revoked, or truncated. ALERT: needs key rotation. */
+  | 'auth'
+  /** 403 — entitlement/plan-tier block. Surface the plan limit, not an outage. */
+  | 'plan_tier'
+  /** 400/404/422 — malformed query or bad symbol. Benign; fix the request. */
+  | 'client_error'
+  /** 5xx / network — the provider's fault. Retry with jitter, then failover. */
+  | 'server_fault';
+
+/** Map an HTTP status to its operational error kind. */
+export function classifyErrorKind(status: number): ProviderErrorKind {
+  if (status === 429) return 'rate_limit';
+  if (status === 401) return 'auth';
+  if (status === 403) return 'plan_tier';
+  if (status >= 500) return 'server_fault';
+  return 'client_error';
+}
+
+/** Kinds that warrant an operator alert rather than silent failover. */
+export function isAlertableErrorKind(kind: ProviderErrorKind): boolean {
+  return kind === 'auth' || kind === 'plan_tier';
+}
+
+/**
  * Classify a 200-with-error-body response (both Polygon and Alpha Vantage
  * signal rate limits inside successful HTTP responses). Rate-limit language
  * means the request was metered; anything else is a free rejection.
@@ -69,11 +104,32 @@ interface QuotaStats {
   provider_fault: number;
 }
 
+type ErrorKindStats = Record<ProviderErrorKind, number>;
+
+const emptyKindStats = (): ErrorKindStats => ({
+  rate_limit: 0,
+  auth: 0,
+  plan_tier: 0,
+  client_error: 0,
+  server_fault: 0,
+});
+
 const stats: Record<UpstreamProvider, QuotaStats> = {
   polygon: { quota_burned: 0, quota_free: 0, provider_fault: 0 },
   alpaca: { quota_burned: 0, quota_free: 0, provider_fault: 0 },
   alphaVantage: { quota_burned: 0, quota_free: 0, provider_fault: 0 },
 };
+
+const kindStats: Record<UpstreamProvider, ErrorKindStats> = {
+  polygon: emptyKindStats(),
+  alpaca: emptyKindStats(),
+  alphaVantage: emptyKindStats(),
+};
+
+metrics.registerCounter(
+  'upstream_error_kinds_total',
+  'Upstream data-provider errors classified by operational kind',
+);
 
 let trackingSince = new Date();
 
@@ -84,23 +140,57 @@ export function recordUpstreamError(provider: UpstreamProvider, impact: QuotaImp
   return impact;
 }
 
+/**
+ * Record an HTTP error from a provider on BOTH axes at once — quota impact
+ * (for budget math) and operational kind (for alerting). Prefer this over
+ * calling `recordUpstreamError(provider, classifyHttpStatus(status))` at fetch
+ * sites so the auth/plan-tier signal is captured for E1 alerting.
+ */
+export function recordProviderError(
+  provider: UpstreamProvider,
+  status: number,
+): { impact: QuotaImpact; kind: ProviderErrorKind } {
+  const impact = classifyHttpStatus(status);
+  const kind = classifyErrorKind(status);
+  stats[provider][impact]++;
+  kindStats[provider][kind]++;
+  metrics.incCounter('upstream_errors_total', { provider, impact });
+  metrics.incCounter('upstream_error_kinds_total', { provider, kind });
+  return { impact, kind };
+}
+
+/** Per-provider count of a given operational error kind since tracking began. */
+export function getErrorKindCount(provider: UpstreamProvider, kind: ProviderErrorKind): number {
+  return kindStats[provider][kind];
+}
+
 /** Snapshot for the health surface. */
 export function getQuotaStats(): {
   since: string;
-  providers: Record<UpstreamProvider, QuotaStats & { guidance: string | null }>;
+  providers: Record<
+    UpstreamProvider,
+    QuotaStats & { guidance: string | null; errorKinds: ErrorKindStats }
+  >;
 } {
-  const withGuidance = (s: QuotaStats): QuotaStats & { guidance: string | null } => {
+  const withGuidance = (
+    provider: UpstreamProvider,
+  ): QuotaStats & { guidance: string | null; errorKinds: ErrorKindStats } => {
+    const s = stats[provider];
     // Surface the guidance for the dominant error class so the operator's
     // first glance at /health/quota says what to do next.
     const dominant = (Object.entries(s) as Array<[QuotaImpact, number]>).sort((a, b) => b[1] - a[1])[0];
-    return { ...s, guidance: dominant[1] > 0 ? BACKOFF_GUIDANCE[dominant[0]] : null };
+    return {
+      ...s,
+      guidance: dominant[1] > 0 ? BACKOFF_GUIDANCE[dominant[0]] : null,
+      errorKinds: { ...kindStats[provider] },
+    };
   };
   return {
     since: trackingSince.toISOString(),
     providers: {
-      polygon: withGuidance(stats.polygon),
-      alpaca: withGuidance(stats.alpaca),
-      alphaVantage: withGuidance(stats.alphaVantage),
+      polygon: withGuidance('polygon'),
+      alpaca: withGuidance('alpaca'),
+      alphaVantage: withGuidance('alphaVantage'),
     },
   };
 }
@@ -109,6 +199,7 @@ export function getQuotaStats(): {
 export function resetQuotaStats(): void {
   for (const provider of Object.keys(stats) as UpstreamProvider[]) {
     stats[provider] = { quota_burned: 0, quota_free: 0, provider_fault: 0 };
+    kindStats[provider] = emptyKindStats();
   }
   trackingSince = new Date();
 }

--- a/src/data/cache/CompositeCache.ts
+++ b/src/data/cache/CompositeCache.ts
@@ -71,6 +71,17 @@ export class CompositeCache {
   }
 
   /**
+   * Last-resort stale read (graceful degradation). Goes straight to the
+   * durable Supabase layer — the Memory layer is per-instance and cold on
+   * serverless, so it's usually empty exactly when we need this. Ignores
+   * coverage + freshness gates; returns whatever exists. Returns null only
+   * when the durable table has no rows for the symbol.
+   */
+  async getStalePrices(symbol: string, days: number): Promise<Price[] | null> {
+    return this.supabase.getStalePrices(symbol.toUpperCase(), days);
+  }
+
+  /**
    * Persist prices to BOTH layers. Memory write is synchronous; Supabase
    * write is awaited so callers can rely on durability before returning to
    * end users (matters for the cache warmer cron).

--- a/src/data/cache/SupabaseCache.ts
+++ b/src/data/cache/SupabaseCache.ts
@@ -154,6 +154,57 @@ export class SupabaseCache {
   }
 
   /**
+   * Last-resort read: return whatever rows exist for `symbol`, oldest-first,
+   * WITHOUT the coverage or freshness gates. Used only when every upstream
+   * provider has failed — serving month-old prices with a loud "stale" signal
+   * beats a hard `DataNotAvailableError` that blanks the whole dashboard.
+   * Returns null only when the table genuinely has no rows for the symbol.
+   */
+  async getStalePrices(symbol: string, days: number): Promise<Price[] | null> {
+    if (!this.enabled || !this.client) return null;
+
+    try {
+      const { data, error } = await this.client
+        .from('frontier_historical_prices')
+        .select('*')
+        .eq('symbol', symbol)
+        .order('date', { ascending: false })
+        .limit(days);
+
+      if (error) {
+        logger.warn({ err: error, symbol }, 'SupabaseCache.getStalePrices error');
+        return null;
+      }
+
+      const rows = (data ?? []) as Array<{
+        date: string;
+        open: number;
+        high: number;
+        low: number;
+        close: number;
+        adjusted_close: number;
+        volume: number;
+      }>;
+
+      if (rows.length === 0) return null;
+
+      rows.reverse();
+      return rows.map((r) => ({
+        symbol,
+        timestamp: new Date(r.date),
+        open: r.open,
+        high: r.high,
+        low: r.low,
+        close: r.adjusted_close,
+        volume: r.volume,
+      }));
+    } catch (err) {
+      logger.warn({ err, symbol }, 'SupabaseCache.getStalePrices threw');
+      return null;
+    }
+  }
+
+  /**
    * Upsert price rows for `symbol`. Batches at 100 rows per call to keep
    * upsert payloads small. Errors are logged and swallowed.
    */

--- a/src/data/resilience.ts
+++ b/src/data/resilience.ts
@@ -1,0 +1,203 @@
+/**
+ * Upstream resilience primitives (harden/data-provider-cdf).
+ *
+ * Two small, dependency-free building blocks the MarketDataProvider layers
+ * over its per-provider fetch calls:
+ *
+ *   1. `fetchWithRetry` — wraps a single HTTP call with bounded retry +
+ *      exponential backoff and full jitter. Retries only *transient* failures
+ *      (network throw, HTTP 429, HTTP 5xx). A 4xx that isn't 429 is returned
+ *      as-is: retrying a 401/403/404 burns time and never succeeds (mirrors
+ *      the `quota_free` guidance in QuotaClassifier — "fix the request").
+ *
+ *   2. `CircuitBreaker` — per-provider fast-fail. After `failureThreshold`
+ *      consecutive failures the breaker OPENS and `canAttempt()` returns false
+ *      for `cooldownMs`, so a hot 429 storm or a down provider stops getting
+ *      hammered on every request and the orchestrator skips straight to the
+ *      next provider. After the cooldown it goes HALF_OPEN and allows a single
+ *      probe; success closes it, failure re-opens it for another cooldown.
+ *
+ * Both are intentionally synchronous-state / in-memory (same posture as
+ * QuotaClassifier's counters): reset on process restart, no external store.
+ */
+
+export interface RetryOptions {
+  /** Max attempts total (including the first). Default 3 (1 try + 2 retries). */
+  retries?: number;
+  /** Base backoff in ms before the first retry. Default 200ms. */
+  baseDelayMs?: number;
+  /** Cap on any single backoff wait. Default 3000ms. */
+  maxDelayMs?: number;
+  /** Injectable sleeper (tests pass a no-op / fake timer). */
+  sleep?: (ms: number) => Promise<void>;
+  /** Injectable jitter source in [0,1). Default Math.random. */
+  random?: () => number;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((r) => setTimeout(r, ms));
+
+/** True for statuses worth retrying against the SAME provider. */
+export function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+/**
+ * Fetch with bounded retry + exponential backoff + full jitter.
+ *
+ * Retries on a thrown network error or a retryable status (429 / 5xx). Returns
+ * the final `Response` (which may still be non-OK if retries are exhausted) so
+ * the caller keeps its existing `response.ok` / status-classification logic.
+ * Re-throws the last network error only if every attempt threw.
+ */
+export async function fetchWithRetry(
+  url: string,
+  init: RequestInit | undefined,
+  opts: RetryOptions = {},
+): Promise<Response> {
+  const retries = Math.max(1, opts.retries ?? 3);
+  const baseDelayMs = opts.baseDelayMs ?? 200;
+  const maxDelayMs = opts.maxDelayMs ?? 3000;
+  const sleep = opts.sleep ?? defaultSleep;
+  const random = opts.random ?? Math.random;
+
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const response = await fetch(url, init);
+      if (attempt < retries && isRetryableStatus(response.status)) {
+        await sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs, random));
+        continue;
+      }
+      return response;
+    } catch (err) {
+      lastError = err;
+      if (attempt < retries) {
+        await sleep(backoffDelay(attempt, baseDelayMs, maxDelayMs, random));
+        continue;
+      }
+    }
+  }
+
+  // Every attempt threw a network error — surface the last one.
+  throw lastError;
+}
+
+/**
+ * Exponential backoff with full jitter: random in [0, min(cap, base*2^(n-1))].
+ * Full jitter (vs equal jitter) is the AWS-recommended default for spreading
+ * retry storms; it minimizes contention when many callers back off together.
+ */
+export function backoffDelay(
+  attempt: number,
+  baseDelayMs: number,
+  maxDelayMs: number,
+  random: () => number = Math.random,
+): number {
+  const exp = Math.min(maxDelayMs, baseDelayMs * 2 ** (attempt - 1));
+  return Math.floor(random() * exp);
+}
+
+export type BreakerState = 'closed' | 'open' | 'half_open';
+
+export interface CircuitBreakerOptions {
+  /** Consecutive failures before the breaker opens. Default 5. */
+  failureThreshold?: number;
+  /** How long the breaker stays open before a half-open probe. Default 30s. */
+  cooldownMs?: number;
+  /** Injectable clock (tests). Default Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Per-provider circuit breaker. Not generic over keys — construct one per
+ * provider and hold them in a registry (see `getBreaker`).
+ */
+export class CircuitBreaker {
+  private failures = 0;
+  private state: BreakerState = 'closed';
+  private openedAt = 0;
+  private readonly failureThreshold: number;
+  private readonly cooldownMs: number;
+  private readonly now: () => number;
+
+  constructor(opts: CircuitBreakerOptions = {}) {
+    this.failureThreshold = opts.failureThreshold ?? 5;
+    this.cooldownMs = opts.cooldownMs ?? 30_000;
+    this.now = opts.now ?? Date.now;
+  }
+
+  /**
+   * Whether the caller should attempt the provider. Transitions open→half_open
+   * once the cooldown elapses (allowing exactly one probe through).
+   */
+  canAttempt(): boolean {
+    if (this.state === 'open') {
+      if (this.now() - this.openedAt >= this.cooldownMs) {
+        this.state = 'half_open';
+        return true;
+      }
+      return false;
+    }
+    // closed or half_open both allow an attempt (half_open = single probe).
+    return true;
+  }
+
+  recordSuccess(): void {
+    this.failures = 0;
+    this.state = 'closed';
+  }
+
+  recordFailure(): void {
+    // A failure while probing (half_open) re-opens immediately.
+    if (this.state === 'half_open') {
+      this.trip();
+      return;
+    }
+    this.failures += 1;
+    if (this.failures >= this.failureThreshold) {
+      this.trip();
+    }
+  }
+
+  private trip(): void {
+    this.state = 'open';
+    this.openedAt = this.now();
+    this.failures = this.failureThreshold;
+  }
+
+  getState(): BreakerState {
+    return this.state;
+  }
+
+  reset(): void {
+    this.failures = 0;
+    this.state = 'closed';
+    this.openedAt = 0;
+  }
+}
+
+/**
+ * Process-wide breaker registry keyed by provider name. Kept module-level so
+ * every MarketDataProvider instance shares breaker state for a given provider
+ * (the rate limit / outage is upstream, not per-instance). Tests can reset via
+ * `resetBreakers()`.
+ */
+const breakers = new Map<string, CircuitBreaker>();
+
+export function getBreaker(
+  provider: string,
+  opts?: CircuitBreakerOptions,
+): CircuitBreaker {
+  let b = breakers.get(provider);
+  if (!b) {
+    b = new CircuitBreaker(opts);
+    breakers.set(provider, b);
+  }
+  return b;
+}
+
+export function resetBreakers(): void {
+  breakers.clear();
+}

--- a/src/notifications/email-templates/weekly-health-digest.ts
+++ b/src/notifications/email-templates/weekly-health-digest.ts
@@ -45,6 +45,28 @@ export interface IntegrationStatusEntry {
   reason?: string | null;
 }
 
+/** Per-provider quota + operational error-kind counts (IDEA-CIN-5). Shape
+ * mirrors one provider entry of `getQuotaStats().providers`. */
+export interface ProviderQuotaSummary {
+  quota_burned: number;
+  quota_free: number;
+  provider_fault: number;
+  guidance: string | null;
+  errorKinds: {
+    rate_limit: number;
+    auth: number;
+    plan_tier: number;
+    client_error: number;
+    server_fault: number;
+  };
+}
+
+/** Full quota snapshot passed from `getQuotaStats()`. */
+export interface QuotaDigestSection {
+  since: string;
+  providers: Record<string, ProviderQuotaSummary>;
+}
+
 export interface WeeklyHealthDigestData {
   dateRange: string; // "May 4 – May 10, 2026"
   /** Total errors counted in the rolling 1-hour window. */
@@ -58,8 +80,12 @@ export interface WeeklyHealthDigestData {
     offline: number;
     badEntries: IntegrationStatusEntry[];
   };
-  /** Placeholder until US-006 wires real cache stats. `null` ⇒ N/A. */
+  /** Real cache hit ratio from CompositeCache telemetry (US-006). `null` ⇒
+   * nothing read yet this window (renders "n/a"). */
   cacheHitRatio: number | null;
+  /** Per-provider upstream quota + error-kind counts. Optional; omitted ⇒
+   * the quota card is not rendered (back-compat with older callers/tests). */
+  quota?: QuotaDigestSection | null;
   /** Most-recent deploy id (Vercel commit SHA, Railway revision, or null). */
   deployId: string | null;
   /** Whether Sentry is configured. False ⇒ counter is sole source. */
@@ -121,6 +147,32 @@ function integrationListRow(entry: IntegrationStatusEntry): string {
         </td>
         <td align="right" valign="top" style="padding:6px 0;white-space:nowrap;">
           <span style="font-family:${FONT_MONO};color:${color};font-size:11px;letter-spacing:0.18em;text-transform:uppercase;font-weight:600;">${escapeHtml(entry.status)}</span>
+        </td>
+      </tr>
+    </table>`;
+}
+
+/** One provider row in the quota card: rate-limit / auth / plan-tier counts. */
+function quotaProviderRow(name: string, p: ProviderQuotaSummary): string {
+  const k = p.errorKinds;
+  // Alertable kinds (auth/plan-tier) go red when non-zero; rate-limit is amber.
+  const authColor = k.auth > 0 ? NEG : COLORS.textMuted;
+  const planColor = k.plan_tier > 0 ? NEG : COLORS.textMuted;
+  const rateColor = k.rate_limit > 0 ? WARN : COLORS.textMuted;
+  const guidance = p.guidance
+    ? `<div style="font-family:${FONT_SANS};color:${COLORS.textDim};font-size:11px;line-height:1.4;">${escapeHtml(p.guidance)}</div>`
+    : '';
+  return `
+    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+      <tr>
+        <td style="padding:6px 0;border-bottom:1px solid ${COLORS.border};">
+          <div style="font-family:${FONT_MONO};color:${COLORS.text};font-size:12px;">${escapeHtml(name)}</div>
+          ${guidance}
+        </td>
+        <td align="right" valign="top" style="padding:6px 0;border-bottom:1px solid ${COLORS.border};white-space:nowrap;">
+          <span style="font-family:${FONT_MONO};font-size:11px;font-variant-numeric:tabular-nums;color:${rateColor};">rate ${k.rate_limit}</span>
+          <span style="font-family:${FONT_MONO};font-size:11px;font-variant-numeric:tabular-nums;color:${authColor};margin-left:10px;">auth ${k.auth}</span>
+          <span style="font-family:${FONT_MONO};font-size:11px;font-variant-numeric:tabular-nums;color:${planColor};margin-left:10px;">plan ${k.plan_tier}</span>
         </td>
       </tr>
     </table>`;
@@ -192,6 +244,20 @@ export function renderWeeklyHealthDigest(
     ${summaryRow('Cache hit ratio', cacheValue, COLORS.white)}
     ${summaryRow('Latest deploy', deployValue, COLORS.white)}`;
 
+  // --- Provider quota card (optional) -------------------------------------
+  const quotaProviders = data.quota
+    ? Object.entries(data.quota.providers)
+    : [];
+  const quotaBlock =
+    quotaProviders.length === 0
+      ? null
+      : `
+    ${monoKicker('Upstream Quota · Error Kinds', COLORS.textMuted)}
+    ${spacer(6)}
+    <div style="font-family:${FONT_SANS};color:${COLORS.textMuted};font-size:12px;line-height:1.5;">Per-provider request outcomes since ${escapeHtml(data.quota!.since)}. rate = 429 rate-limits · auth = 401 revoked/invalid key · plan = 403 plan-tier block.</div>
+    ${spacer(10)}
+    ${quotaProviders.map(([name, p]) => quotaProviderRow(name, p)).join('')}`;
+
   // --- Caveat -------------------------------------------------------------
   const caveatText = data.sentryConfigured
     ? 'Sentry is configured. The error counter and Sentry are dual sources; cross-reference via X-Request-Id tag for any specific incident.'
@@ -214,6 +280,7 @@ export function renderWeeklyHealthDigest(
         ${spacer(16)}
         ${card({ body: infraBlock })}
         ${spacer(16)}
+        ${quotaBlock ? `${card({ body: quotaBlock })}${spacer(16)}` : ''}
         ${card({ body: caveatBlock, padding: '16px 20px' })}
         ${spacer(24)}
         ${cta({ href: data.errorsEndpointUrl, label: 'Open /health/errors', accent: 'halo' })}
@@ -243,6 +310,16 @@ export function renderWeeklyHealthDigest(
         .join('\n')
     : '  (all live)';
 
+  const textQuota =
+    quotaProviders.length === 0
+      ? null
+      : quotaProviders
+          .map(
+            ([name, p]) =>
+              `  ${name.padEnd(13)} rate ${p.errorKinds.rate_limit} · auth ${p.errorKinds.auth} · plan ${p.errorKinds.plan_tier}${p.guidance ? ` — ${p.guidance}` : ''}`
+          )
+          .join('\n');
+
   const text = [
     `FRONTIER ALPHA · WEEKLY HEALTH DIGEST · ${data.dateRange}`,
     '',
@@ -255,6 +332,9 @@ export function renderWeeklyHealthDigest(
     '',
     `Cache hit ratio: ${cacheValue}`,
     `Latest deploy: ${deployValue}`,
+    ...(textQuota
+      ? ['', `Upstream quota (since ${data.quota!.since}):`, textQuota]
+      : []),
     '',
     caveatText,
     '',

--- a/src/observability/PolygonHealthAlerter.ts
+++ b/src/observability/PolygonHealthAlerter.ts
@@ -1,0 +1,205 @@
+/**
+ * Polygon health alerting (Workstream E1).
+ *
+ * Before this, a Polygon outage only surfaced when a human read the dashboard,
+ * curled `/health/integrations`, or opened the weekly digest. This module turns
+ * the synthetic monitor into an active alarm:
+ *
+ *   1. DEBOUNCED alert — after N consecutive failing synthetic-monitor polls
+ *      (default 3), send one operator notification. Only fires on the
+ *      TRANSITION into the failing state (not every poll), and resets when a
+ *      poll comes back clean. This absorbs transient blips (a single failed
+ *      15-minute poll) while still catching a sustained outage within ~45 min.
+ *
+ *   2. IMMEDIATE escalation — if Polygon has logged an ALERTABLE error kind
+ *      (401 auth = revoked/invalid key, or 403 plan_tier = entitlement block),
+ *      alert now with no debounce. Those need a human immediately; waiting 3
+ *      polls to tell the operator their key was revoked is a bug, not caution.
+ *      Alertable-kind counts come from `QuotaClassifier` (recorded at the
+ *      Polygon fetch sites via `recordProviderError`).
+ *
+ * State is in-process module-level (same posture as ErrorCounter / QuotaClassifier)
+ * and resets on process restart. The send is BEST-EFFORT — every failure path is
+ * swallowed so an alerting hiccup never throws into the cron path.
+ */
+
+import {
+  getErrorKindCount,
+  isAlertableErrorKind,
+  type ProviderErrorKind,
+} from '../data/QuotaClassifier.js';
+import { getAlertDelivery } from '../notifications/AlertDelivery.js';
+import { logger } from './logger.js';
+
+/** Consecutive failing polls before the debounced alert fires. */
+const DEFAULT_THRESHOLD = 3;
+
+/** Operator recipient — the sole operator for v1.3.x (matches health-summary). */
+const DEFAULT_RECIPIENT = 'dicoangelo@metaventionsai.com';
+
+// ── In-process state (resets on restart) ───────────────────────────────────
+let consecutiveFailures = 0;
+/** Guard: only one debounced alert per failing streak (no per-poll spam). */
+let alertedForCurrentStreak = false;
+/** Alertable-kind counts we've already alerted on, so a persistent 401 doesn't
+ * re-alert every 15-minute poll. */
+let lastAlertedAuthCount = 0;
+let lastAlertedPlanTierCount = 0;
+
+export interface MonitorRunSummary {
+  /** Number of failing probes in this poll. */
+  failed: number;
+  /** Number of passing probes in this poll. */
+  passed: number;
+  /** Failing routes (route key + error) for the alert body. */
+  failingRoutes: Array<{ route: string; error: string | null }>;
+}
+
+export interface PolygonAlertOutcome {
+  alerted: boolean;
+  reason: 'debounce-threshold' | 'alertable-kind' | null;
+  consecutiveFailures: number;
+}
+
+function threshold(): number {
+  const raw = Number(process.env.POLYGON_ALERT_THRESHOLD);
+  return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : DEFAULT_THRESHOLD;
+}
+
+function recipient(): string {
+  return process.env.HEALTH_ALERT_RECIPIENT?.trim() || DEFAULT_RECIPIENT;
+}
+
+interface AlertContent {
+  subject: string;
+  html: string;
+  text: string;
+}
+
+/** Best-effort operator email. Never throws — logs and returns on any failure. */
+async function sendOperatorEmail(content: AlertContent): Promise<void> {
+  try {
+    const to = recipient();
+    const result = await getAlertDelivery().sendEmail({
+      to,
+      subject: content.subject,
+      html: content.html,
+      text: content.text,
+    });
+    if (!result.success) {
+      logger.warn(
+        { error: result.error, to },
+        'PolygonHealthAlerter: operator alert email failed',
+      );
+    } else {
+      logger.info({ to, subject: content.subject }, 'PolygonHealthAlerter: alert sent');
+    }
+  } catch (err) {
+    logger.warn({ err }, 'PolygonHealthAlerter: alert send threw (swallowed)');
+  }
+}
+
+function buildAlertContent(
+  reason: 'debounce-threshold' | 'alertable-kind',
+  summary: MonitorRunSummary,
+  detail: string,
+): AlertContent {
+  const headline =
+    reason === 'alertable-kind'
+      ? 'Polygon needs a human NOW'
+      : `Polygon health failing (${consecutiveFailures} consecutive polls)`;
+  const failing = summary.failingRoutes.length
+    ? summary.failingRoutes.map((r) => `  - ${r.route}: ${r.error ?? 'unknown'}`).join('\n')
+    : '  (no per-route detail)';
+  const text = [
+    `FRONTIER ALPHA · HEALTH ALERT`,
+    '',
+    headline,
+    detail,
+    '',
+    `Passed: ${summary.passed} · Failed: ${summary.failed}`,
+    'Failing routes:',
+    failing,
+    '',
+    'Source: synthetic-monitor (GET /api/v1/cron/synthetic-monitor).',
+    'Runbook: CLAUDE.md → Incident playbook (/health/integrations degraded).',
+  ].join('\n');
+  const esc = (s: string) => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  const html = `<!DOCTYPE html><html><body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111;max-width:600px;margin:0 auto;padding:20px;">
+  <h2 style="margin:0 0 8px;color:#b91c1c;">${esc(headline)}</h2>
+  <p style="margin:0 0 12px;color:#374151;">${esc(detail)}</p>
+  <p style="margin:0 0 4px;color:#374151;"><strong>Passed:</strong> ${summary.passed} · <strong>Failed:</strong> ${summary.failed}</p>
+  <pre style="background:#f9fafb;border:1px solid #e5e7eb;border-radius:8px;padding:12px;font-size:12px;overflow:auto;">${esc(failing)}</pre>
+  <p style="margin:12px 0 0;color:#6b7280;font-size:12px;">Source: synthetic-monitor · Runbook: CLAUDE.md incident playbook.</p>
+</body></html>`;
+  const subject =
+    reason === 'alertable-kind'
+      ? 'Frontier Alpha · Polygon ALERT · key/plan action required'
+      : `Frontier Alpha · Polygon health failing (${consecutiveFailures}× polls)`;
+  return { subject, html, text };
+}
+
+/**
+ * Evaluate one synthetic-monitor poll and, if warranted, fire a best-effort
+ * operator alert. Returns the decision so the caller (and tests) can assert
+ * behavior. Never throws.
+ */
+export async function evaluatePolygonHealth(
+  summary: MonitorRunSummary,
+): Promise<PolygonAlertOutcome> {
+  // Update the debounce counter first so the alert body reports the right count.
+  if (summary.failed > 0) {
+    consecutiveFailures += 1;
+  } else {
+    consecutiveFailures = 0;
+    alertedForCurrentStreak = false;
+  }
+
+  // ── 1) Immediate alertable-kind escalation (no debounce) ─────────────────
+  const authCount = getErrorKindCount('polygon', 'auth');
+  const planTierCount = getErrorKindCount('polygon', 'plan_tier');
+  const newAuth = authCount > lastAlertedAuthCount;
+  const newPlanTier = planTierCount > lastAlertedPlanTierCount;
+  if (newAuth || newPlanTier) {
+    const kind: ProviderErrorKind = newAuth ? 'auth' : 'plan_tier';
+    // isAlertableErrorKind is true by construction here, but keep the guard
+    // explicit so the intent (auth/plan-tier only) is legible.
+    if (isAlertableErrorKind(kind)) {
+      // Advance both watermarks so we don't re-alert on the same counts.
+      lastAlertedAuthCount = authCount;
+      lastAlertedPlanTierCount = planTierCount;
+      const detail =
+        kind === 'auth'
+          ? `Polygon returned HTTP 401 (auth). The API key is likely revoked, invalid, or truncated. Rotate it (CLAUDE.md rotation runbook, printf-not-echo).`
+          : `Polygon returned HTTP 403 (plan_tier). The requested data is not entitled on the current plan. Check the Polygon plan / endpoint entitlement.`;
+      await sendOperatorEmail(buildAlertContent('alertable-kind', summary, detail));
+      return { alerted: true, reason: 'alertable-kind', consecutiveFailures };
+    }
+  }
+
+  // ── 2) Debounced threshold alert (transition into failing state only) ────
+  if (summary.failed > 0 && consecutiveFailures >= threshold() && !alertedForCurrentStreak) {
+    alertedForCurrentStreak = true;
+    const detail = `The synthetic monitor has failed ${consecutiveFailures} consecutive polls (threshold ${threshold()}). This is a sustained Polygon-path / production health failure, not a transient blip.`;
+    await sendOperatorEmail(buildAlertContent('debounce-threshold', summary, detail));
+    return { alerted: true, reason: 'debounce-threshold', consecutiveFailures };
+  }
+
+  return { alerted: false, reason: null, consecutiveFailures };
+}
+
+/** Reset all in-process state (test seam). */
+export function resetPolygonHealthAlerter(): void {
+  consecutiveFailures = 0;
+  alertedForCurrentStreak = false;
+  lastAlertedAuthCount = 0;
+  lastAlertedPlanTierCount = 0;
+}
+
+/** Read-only snapshot (test seam / diagnostics). */
+export function getPolygonHealthAlerterState(): {
+  consecutiveFailures: number;
+  alertedForCurrentStreak: boolean;
+} {
+  return { consecutiveFailures, alertedForCurrentStreak };
+}

--- a/src/routes/health-summary.ts
+++ b/src/routes/health-summary.ts
@@ -24,6 +24,8 @@ import type {
 } from 'fastify';
 import { errorCounter } from '../observability/ErrorCounter.js';
 import { logger } from '../observability/logger.js';
+import { getQuotaStats } from '../data/QuotaClassifier.js';
+import { getCacheTelemetry } from '../data/cache/index.js';
 import type {
   APIResponse,
   IntegrationHealthEntry,
@@ -182,8 +184,17 @@ export async function healthSummaryRoutes(
       }
     }
 
-    // ── Cache hit ratio (placeholder until US-006) ────────────────────────
-    const cacheHitRatio: number | null = null;
+    // ── Cache hit ratio (US-006 — real telemetry) ────────────────────────
+    // CompositeCache rolls up memory + supabase hits/misses. Ratio is
+    // hits / (hits + misses); null when nothing has been read yet so the
+    // template renders "n/a" rather than a misleading 0%.
+    const cacheTelemetry = getCacheTelemetry();
+    const cacheReads = cacheTelemetry.total.hits + cacheTelemetry.total.misses;
+    const cacheHitRatio: number | null =
+      cacheReads > 0 ? cacheTelemetry.total.hits / cacheReads : null;
+
+    // ── Provider quota + error-kind stats (IDEA-CIN-5) ────────────────────
+    const quota = getQuotaStats();
 
     // ── Deploy id ─────────────────────────────────────────────────────────
     const deployId = resolveDeployId();
@@ -218,6 +229,7 @@ export async function healthSummaryRoutes(
         badEntries,
       },
       cacheHitRatio,
+      quota,
       deployId,
       sentryConfigured,
       errorsEndpointUrl,

--- a/src/routes/health.ts
+++ b/src/routes/health.ts
@@ -731,27 +731,21 @@ async function checkDatabase(): Promise<{ status: 'ok' | 'error'; message?: stri
 }
 
 async function checkExternalApis(): Promise<{ status: 'ok' | 'error'; message?: string }> {
-  const polygonKey = process.env.POLYGON_API_KEY;
-
-  if (!polygonKey) {
-    return { status: 'error', message: 'Polygon API not configured' };
+  // E4: delegate to probePolygon() so the 429 semantics stay CONSISTENT with
+  // the /api/v1/health/integrations path. Previously this treated HTTP 429 as
+  // `{ status: 'ok', message: 'Rate limited (normal)' }` while probePolygon
+  // reported 429 as `degraded`. Now that Polygon Starter is unlimited, a 429 is
+  // a real signal (something is wrong), so it must NOT read as healthy here.
+  // probePolygon maps: live → ok; degraded/offline (incl. 429, missing key,
+  // 5xx, non-OK body) → error, preserving the reason for the deep health check.
+  const result = await probePolygon();
+  if (result.status === 'live') {
+    return { status: 'ok' };
   }
-
-  try {
-    const response = await fetch(
-      `https://api.polygon.io/v2/aggs/ticker/AAPL/prev?adjusted=true&apiKey=${polygonKey}`
-    );
-
-    if (response.ok) {
-      return { status: 'ok' };
-    }
-    if (response.status === 429) {
-      return { status: 'ok', message: 'Rate limited (normal)' };
-    }
-    return { status: 'error', message: `HTTP ${response.status}` };
-  } catch {
-    return { status: 'error', message: 'Connection failed' };
-  }
+  return {
+    status: 'error',
+    message: result.reason ?? result.lastError ?? `polygon ${result.status}`,
+  };
 }
 
 export async function healthRoutes(fastify: FastifyInstance, opts: RouteContext) {

--- a/src/routes/synthetic-monitor.ts
+++ b/src/routes/synthetic-monitor.ts
@@ -427,6 +427,24 @@ export async function syntheticMonitorRoutes(
       }
     }
 
+    // E1: debounced Polygon/synthetic health alerting. Best-effort — the whole
+    // evaluation is wrapped so an alerting fault never throws into the cron
+    // path (which must always return a 200 status report).
+    try {
+      const { evaluatePolygonHealth } = await import(
+        '../observability/PolygonHealthAlerter.js'
+      );
+      await evaluatePolygonHealth({
+        passed,
+        failed,
+        failingRoutes: results
+          .filter((r) => r.error !== null || !r.schemaValid)
+          .map((r) => ({ route: r.route, error: r.error })),
+      });
+    } catch (err) {
+      logger.warn({ err }, 'synthetic-monitor: health-alert evaluation failed');
+    }
+
     if (failed > 0) {
       logger.warn(
         {

--- a/src/services/factorAnchors.ts
+++ b/src/services/factorAnchors.ts
@@ -13,8 +13,8 @@
  * re-running the factor engine. This is the exact pattern the
  * `/api/v1/portfolio/factors/history` endpoint (v1.3.4) uses. The caller passes
  * already-fetched prices and the factor engine; this module makes ZERO market
- * data calls of its own, so it cannot trip the Polygon free-tier 5-req/min
- * ceiling.
+ * data calls of its own, so it adds no upstream load regardless of provider
+ * plan.
  *
  * ## Bounded token growth
  *

--- a/tests/data/CacheWarmer.groupedDaily.test.ts
+++ b/tests/data/CacheWarmer.groupedDaily.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Tests for the B2 grouped-daily freshness sync (Tier 2 cache warming).
+ *
+ * The grouped-daily endpoint returns EVERY US ticker's OHLCV for ONE trading
+ * day in a SINGLE call — a big win for DAILY FRESHNESS (one call refreshes the
+ * latest bar for all warmed symbols instead of N per-symbol calls). It
+ * COMPLEMENTS the per-symbol backfill; it does not replace it.
+ *
+ * MSW intercepts the grouped endpoint. Coverage:
+ *   - grouped-daily returns a multi-ticker map from ONE call
+ *   - a `status:'ERROR'` / empty body yields an empty map
+ *   - the freshness sync write-throughs the latest bar for warmed symbols
+ *   - weekend ref dates walk back to Friday (mostRecentTradingDay)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../setup.js';
+
+// supabase.ts throws on import without these — set before importing the SUT.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+import { MarketDataProvider } from '../../src/data/MarketDataProvider.js';
+import {
+  warmLatestDayAllSymbols,
+  mostRecentTradingDay,
+} from '../../src/data/CacheWarmer.js';
+import type { CompositeCache } from '../../src/data/cache/index.js';
+import type { Price } from '../../src/types/index.js';
+import { resetBreakers, getBreaker } from '../../src/data/resilience.js';
+import { resetQuotaStats } from '../../src/data/QuotaClassifier.js';
+
+const POLY_KEY = 'x'.repeat(32);
+const POLY_GROUPED =
+  'https://api.polygon.io/v2/aggs/grouped/locale/us/market/stocks/:date';
+
+/** Grouped-daily OK body with one row per ticker (T = ticker, t = ms ts). */
+function groupedOK(tickers: Record<string, number>) {
+  const ts = Date.parse('2026-06-19T20:00:00Z');
+  return HttpResponse.json({
+    status: 'OK',
+    results: Object.entries(tickers).map(([T, c]) => ({
+      T,
+      o: c - 1,
+      h: c + 1,
+      l: c - 2,
+      c,
+      v: 1_000_000,
+      t: ts,
+    })),
+  });
+}
+
+/** A cache stub that records setPrices calls. */
+function stubCache(): CompositeCache {
+  return {
+    getPrices: vi.fn().mockResolvedValue(null),
+    setPrices: vi.fn().mockResolvedValue(undefined),
+    getStalePrices: vi.fn().mockResolvedValue(null),
+    setMemoryOnly: vi.fn(),
+    telemetry: vi.fn(),
+    resetCounters: vi.fn(),
+  } as unknown as CompositeCache;
+}
+
+function makeProvider(): MarketDataProvider {
+  const p = new MarketDataProvider({
+    polygonApiKey: POLY_KEY,
+    allowMockFallback: false,
+  });
+  (p as unknown as { useSupabaseCache: boolean }).useSupabaseCache = false;
+  return p;
+}
+
+beforeEach(() => {
+  resetBreakers();
+  resetQuotaStats();
+});
+
+describe('MarketDataProvider.fetchGroupedDaily', () => {
+  it('returns a multi-ticker map from ONE grouped-daily call', async () => {
+    let hits = 0;
+    server.use(
+      http.get(POLY_GROUPED, () => {
+        hits += 1;
+        return groupedOK({ AAPL: 200, MSFT: 400, NVDA: 120 });
+      }),
+    );
+
+    const provider = makeProvider();
+    const map = await provider.fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+
+    expect(hits).toBe(1); // one call for the whole market
+    expect(map.size).toBe(3);
+    expect(map.get('AAPL')?.[0].close).toBe(200);
+    expect(map.get('MSFT')?.[0].close).toBe(400);
+    expect(map.get('NVDA')?.[0].close).toBe(120);
+    // Each entry is a single-day Price[].
+    expect(map.get('AAPL')).toHaveLength(1);
+    const bar = map.get('AAPL')![0];
+    expect(bar.symbol).toBe('AAPL');
+    expect(bar.open).toBe(199);
+    expect(bar.high).toBe(201);
+    expect(bar.low).toBe(198);
+    expect(bar.volume).toBe(1_000_000);
+    expect(bar.timestamp).toBeInstanceOf(Date);
+  });
+
+  it('yields an empty map on a status:ERROR body', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () =>
+        HttpResponse.json({ status: 'ERROR', error: 'unknown api key' }),
+      ),
+    );
+
+    const map = await makeProvider().fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+    expect(map.size).toBe(0);
+  });
+
+  it('yields an empty map on an OK body with no results (holiday)', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () => HttpResponse.json({ status: 'OK', results: [] })),
+    );
+
+    const map = await makeProvider().fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+    expect(map.size).toBe(0);
+    // A valid empty response is NOT a provider failure — breaker stays closed.
+    expect(getBreaker('polygon').getState()).toBe('closed');
+  });
+
+  it('yields an empty map (no throw) on a non-200 HTTP status', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () => new HttpResponse('rate limited', { status: 429 })),
+    );
+
+    const map = await makeProvider().fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+    expect(map.size).toBe(0);
+  });
+
+  it('skips the call entirely when the polygon breaker is open', async () => {
+    let hits = 0;
+    server.use(
+      http.get(POLY_GROUPED, () => {
+        hits += 1;
+        return groupedOK({ AAPL: 200 });
+      }),
+    );
+
+    const breaker = getBreaker('polygon');
+    for (let i = 0; i < 5; i++) breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+
+    const map = await makeProvider().fetchGroupedDaily(new Date('2026-06-19T12:00:00Z'));
+    expect(map.size).toBe(0);
+    expect(hits).toBe(0); // never called — breaker open
+  });
+});
+
+describe('warmLatestDayAllSymbols — freshness sync', () => {
+  it('write-throughs the latest bar for each warmed symbol found in the group', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () => groupedOK({ AAPL: 200, MSFT: 400, NVDA: 120, TSLA: 250 })),
+    );
+
+    const provider = makeProvider();
+    const cache = stubCache();
+    (provider as unknown as { historicalPriceCache: CompositeCache }).historicalPriceCache = cache;
+
+    // Ask for 3 warmed symbols; only those present in the group are refreshed.
+    const result = await warmLatestDayAllSymbols(
+      provider,
+      ['aapl', 'msft', 'GOOGL'], // GOOGL is NOT in the group
+      new Date('2026-06-19T12:00:00Z'),
+    );
+
+    expect(result.tickersInGroup).toBe(4);
+    expect(result.updated).toBe(2);
+    expect(result.symbols).toEqual(['AAPL', 'MSFT']);
+
+    expect(cache.setPrices).toHaveBeenCalledTimes(2);
+    const [aaplSym, aaplBars] = (cache.setPrices as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(aaplSym).toBe('AAPL');
+    expect(aaplBars).toHaveLength(1);
+    expect((aaplBars as Price[])[0].close).toBe(200);
+  });
+
+  it('is a no-op (no cache writes) when grouped-daily returns nothing', async () => {
+    server.use(
+      http.get(POLY_GROUPED, () => HttpResponse.json({ status: 'OK', results: [] })),
+    );
+
+    const provider = makeProvider();
+    const cache = stubCache();
+    (provider as unknown as { historicalPriceCache: CompositeCache }).historicalPriceCache = cache;
+
+    const result = await warmLatestDayAllSymbols(provider, ['AAPL', 'MSFT'], new Date('2026-06-19T12:00:00Z'));
+
+    expect(result.updated).toBe(0);
+    expect(cache.setPrices).not.toHaveBeenCalled();
+  });
+
+  it('returns early without an upstream call when no symbols are warmed', async () => {
+    let hits = 0;
+    server.use(
+      http.get(POLY_GROUPED, () => {
+        hits += 1;
+        return groupedOK({ AAPL: 200 });
+      }),
+    );
+
+    const result = await warmLatestDayAllSymbols(makeProvider(), [], new Date('2026-06-19T12:00:00Z'));
+    expect(result.updated).toBe(0);
+    expect(hits).toBe(0);
+  });
+});
+
+describe('mostRecentTradingDay', () => {
+  it('returns the same day for a weekday', () => {
+    // 2026-06-19 is a Friday.
+    const d = mostRecentTradingDay(new Date('2026-06-19T12:00:00Z'));
+    expect(d.toISOString().slice(0, 10)).toBe('2026-06-19');
+  });
+
+  it('walks Saturday back to Friday', () => {
+    // 2026-06-20 is a Saturday.
+    const d = mostRecentTradingDay(new Date('2026-06-20T12:00:00Z'));
+    expect(d.toISOString().slice(0, 10)).toBe('2026-06-19');
+  });
+
+  it('walks Sunday back to Friday', () => {
+    // 2026-06-21 is a Sunday.
+    const d = mostRecentTradingDay(new Date('2026-06-21T12:00:00Z'));
+    expect(d.toISOString().slice(0, 10)).toBe('2026-06-19');
+  });
+});

--- a/tests/data/MarketDataProvider.test.ts
+++ b/tests/data/MarketDataProvider.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Integration tests for MarketDataProvider's failure-path behavior
+ * (harden/data-provider-cdf). Before this suite there was ZERO coverage on the
+ * real fetch path — only the health-probe's separate implementation was tested.
+ *
+ * MSW intercepts every upstream (Polygon, Alpaca, Alpha Vantage). Each test
+ * drives one scenario the plan called out:
+ *   - Polygon 429 → retry → Alpaca fallback
+ *   - Polygon 401 (revoked key) → classified `auth`, failover still serves
+ *   - all providers down → serve last-resort STALE cache (no hard throw)
+ *   - quote dedup: concurrent same-symbol callers hit upstream once
+ *   - circuit breaker open → provider skipped straight to failover
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { server } from '../setup.js';
+
+// supabase.ts throws on import without these — set before importing the SUT.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+import { MarketDataProvider } from '../../src/data/MarketDataProvider.js';
+import type { CompositeCache } from '../../src/data/cache/index.js';
+import type { Price } from '../../src/types/index.js';
+import { resetBreakers, getBreaker } from '../../src/data/resilience.js';
+import { resetQuotaStats, getErrorKindCount } from '../../src/data/QuotaClassifier.js';
+
+const POLY_KEY = 'x'.repeat(32);
+
+// URL matchers for MSW.
+const POLY_SNAPSHOT = 'https://api.polygon.io/v2/snapshot/locale/us/markets/stocks/tickers/:symbol';
+const POLY_AGGS = 'https://api.polygon.io/v2/aggs/ticker/:symbol/range/1/day/:from/:to';
+const ALPACA_SNAPSHOT = 'https://data.alpaca.markets/v2/stocks/:symbol/snapshot';
+const ALPACA_BARS = 'https://data.alpaca.markets/v2/stocks/:symbol/bars';
+
+function polygonSnapshotOK(last: number) {
+  return HttpResponse.json({
+    status: 'OK',
+    ticker: {
+      todaysChange: 1.5,
+      todaysChangePerc: 1.0,
+      updated: Date.now() * 1e6,
+      min: { c: last },
+      day: { c: last - 1 },
+      prevDay: { c: last - 2 },
+    },
+  });
+}
+
+function alpacaSnapshotOK(last: number) {
+  return HttpResponse.json({
+    latestTrade: { p: last, t: new Date().toISOString() },
+    latestQuote: { bp: last - 0.05, ap: last + 0.05 },
+    dailyBar: { c: last },
+    prevDailyBar: { c: last - 1 },
+  });
+}
+
+/** A cache stub with controllable getStalePrices for the degradation test. */
+function stubCache(stale: Price[] | null = null): CompositeCache {
+  return {
+    getPrices: vi.fn().mockResolvedValue(null),
+    setPrices: vi.fn().mockResolvedValue(undefined),
+    getStalePrices: vi.fn().mockResolvedValue(stale),
+    telemetry: vi.fn(),
+    resetCounters: vi.fn(),
+  } as unknown as CompositeCache;
+}
+
+function makeProvider(overrides: Record<string, unknown> = {}): MarketDataProvider {
+  const p = new MarketDataProvider({
+    polygonApiKey: POLY_KEY,
+    alpacaApiKey: 'ak',
+    alpacaApiSecret: 'as',
+    allowMockFallback: false,
+    ...overrides,
+  });
+  // Force the durable quote-cache read off so tests exercise the upstream
+  // chain deterministically (no supabase-js calls MSW would flag).
+  (p as unknown as { useSupabaseCache: boolean }).useSupabaseCache = false;
+  return p;
+}
+
+beforeEach(() => {
+  resetBreakers();
+  resetQuotaStats();
+});
+
+describe('getQuote — failover + retry', () => {
+  it('retries a Polygon 429, then falls over to Alpaca', async () => {
+    let polyHits = 0;
+    server.use(
+      http.get(POLY_SNAPSHOT, () => {
+        polyHits += 1;
+        return new HttpResponse('rate limited', { status: 429 });
+      }),
+      http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(200)),
+    );
+
+    const provider = makeProvider();
+    const quote = await provider.getQuote('AAPL');
+
+    expect(quote?.last).toBe(200); // came from Alpaca
+    expect(polyHits).toBeGreaterThan(1); // 429 was retried before failover
+  });
+
+  it('classifies a Polygon 401 as an auth failure and still serves via Alpaca', async () => {
+    server.use(
+      http.get(POLY_SNAPSHOT, () => new HttpResponse('bad key', { status: 401 })),
+      http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(321)),
+    );
+
+    const provider = makeProvider();
+    const quote = await provider.getQuote('AAPL');
+
+    expect(quote?.last).toBe(321);
+    expect(getErrorKindCount('polygon', 'auth')).toBe(1);
+  });
+
+  it('does not retry a 401 (single Polygon hit)', async () => {
+    let polyHits = 0;
+    server.use(
+      http.get(POLY_SNAPSHOT, () => {
+        polyHits += 1;
+        return new HttpResponse('bad key', { status: 401 });
+      }),
+      http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(100)),
+    );
+
+    await makeProvider().getQuote('AAPL');
+    expect(polyHits).toBe(1);
+  });
+});
+
+describe('getQuote — dedup (D3)', () => {
+  it('coalesces concurrent same-symbol callers onto one upstream fetch', async () => {
+    let polyHits = 0;
+    server.use(
+      http.get(POLY_SNAPSHOT, async () => {
+        polyHits += 1;
+        // Small delay so the second caller arrives while the first is inflight.
+        await new Promise((r) => setTimeout(r, 20));
+        return polygonSnapshotOK(150);
+      }),
+    );
+
+    const provider = makeProvider();
+    const [a, b] = await Promise.all([provider.getQuote('AAPL'), provider.getQuote('AAPL')]);
+
+    expect(a?.last).toBe(150);
+    expect(b?.last).toBe(150);
+    expect(polyHits).toBe(1); // deduped
+  });
+});
+
+describe('getQuote — circuit breaker (D2)', () => {
+  it('skips Polygon entirely once its breaker is open', async () => {
+    let polyHits = 0;
+    server.use(
+      http.get(POLY_SNAPSHOT, () => {
+        polyHits += 1;
+        return polygonSnapshotOK(999);
+      }),
+      http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(42)),
+    );
+
+    // Pre-open the shared polygon breaker (default threshold 5).
+    const breaker = getBreaker('polygon');
+    for (let i = 0; i < 5; i++) breaker.recordFailure();
+    expect(breaker.getState()).toBe('open');
+
+    const quote = await makeProvider().getQuote('AAPL');
+    expect(quote?.last).toBe(42); // served by Alpaca
+    expect(polyHits).toBe(0); // Polygon never called — breaker open
+  });
+});
+
+describe('getHistoricalPrices — graceful degradation (C2)', () => {
+  it('serves stale cache rows when every provider fails instead of throwing', async () => {
+    server.use(
+      http.get(POLY_AGGS, () => new HttpResponse('boom', { status: 500 })),
+      http.get(ALPACA_BARS, () => new HttpResponse('boom', { status: 500 })),
+    );
+
+    const staleRows: Price[] = [
+      { symbol: 'AAPL', timestamp: new Date('2026-05-01'), open: 1, high: 2, low: 1, close: 1.5, volume: 100 },
+      { symbol: 'AAPL', timestamp: new Date('2026-05-02'), open: 1.5, high: 2.5, low: 1.4, close: 2.0, volume: 120 },
+    ];
+    const cache = stubCache(staleRows);
+    const provider = makeProvider();
+    (provider as unknown as { historicalPriceCache: CompositeCache }).historicalPriceCache = cache;
+
+    const prices = await provider.getHistoricalPrices('AAPL', 2);
+    expect(prices).toHaveLength(2);
+    expect(prices[1].close).toBe(2.0);
+    expect(cache.getStalePrices).toHaveBeenCalledWith('AAPL', 2);
+  });
+
+  it('throws DataNotAvailableError when providers fail AND no stale cache exists', async () => {
+    server.use(
+      http.get(POLY_AGGS, () => new HttpResponse('boom', { status: 500 })),
+      http.get(ALPACA_BARS, () => new HttpResponse('boom', { status: 500 })),
+    );
+
+    const cache = stubCache(null); // no stale rows
+    const provider = makeProvider();
+    (provider as unknown as { historicalPriceCache: CompositeCache }).historicalPriceCache = cache;
+
+    await expect(provider.getHistoricalPrices('ZZZZ', 2)).rejects.toThrow(/all providers failed/);
+  });
+});

--- a/tests/data/QuotaClassifier.test.ts
+++ b/tests/data/QuotaClassifier.test.ts
@@ -10,7 +10,11 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import {
   classifyHttpStatus,
   classifyErrorBody,
+  classifyErrorKind,
+  isAlertableErrorKind,
   recordUpstreamError,
+  recordProviderError,
+  getErrorKindCount,
   getQuotaStats,
   resetQuotaStats,
   BACKOFF_GUIDANCE,
@@ -102,5 +106,64 @@ describe('recordUpstreamError / getQuotaStats', () => {
     resetQuotaStats();
     const stats = getQuotaStats();
     expect(stats.providers.polygon.quota_burned).toBe(0);
+  });
+});
+
+describe('classifyErrorKind (C3 — operational error axis)', () => {
+  it('distinguishes the two human-actionable cases from benign client errors', () => {
+    expect(classifyErrorKind(429)).toBe('rate_limit');
+    expect(classifyErrorKind(401)).toBe('auth'); // revoked/invalid key
+    expect(classifyErrorKind(403)).toBe('plan_tier'); // entitlement block
+    expect(classifyErrorKind(400)).toBe('client_error');
+    expect(classifyErrorKind(404)).toBe('client_error');
+    expect(classifyErrorKind(422)).toBe('client_error');
+    expect(classifyErrorKind(500)).toBe('server_fault');
+    expect(classifyErrorKind(503)).toBe('server_fault');
+  });
+
+  it('flags only auth + plan_tier as alertable', () => {
+    expect(isAlertableErrorKind('auth')).toBe(true);
+    expect(isAlertableErrorKind('plan_tier')).toBe(true);
+    expect(isAlertableErrorKind('rate_limit')).toBe(false);
+    expect(isAlertableErrorKind('client_error')).toBe(false);
+    expect(isAlertableErrorKind('server_fault')).toBe(false);
+  });
+});
+
+describe('recordProviderError (dual-axis recorder)', () => {
+  it('records both quota impact and operational kind from one status', () => {
+    const r = recordProviderError('polygon', 401);
+    expect(r.impact).toBe('quota_free'); // auth rejection is not metered
+    expect(r.kind).toBe('auth');
+
+    const stats = getQuotaStats();
+    expect(stats.providers.polygon.quota_free).toBe(1);
+    expect(stats.providers.polygon.errorKinds.auth).toBe(1);
+    expect(getErrorKindCount('polygon', 'auth')).toBe(1);
+  });
+
+  it('separates a revoked key (401) from a plan-tier block (403)', () => {
+    recordProviderError('polygon', 401);
+    recordProviderError('polygon', 403);
+    recordProviderError('polygon', 403);
+
+    expect(getErrorKindCount('polygon', 'auth')).toBe(1);
+    expect(getErrorKindCount('polygon', 'plan_tier')).toBe(2);
+    // Both still land in the quota_free bucket for budget accounting.
+    expect(getQuotaStats().providers.polygon.quota_free).toBe(3);
+  });
+
+  it('counts a 429 as both quota_burned and rate_limit kind', () => {
+    recordProviderError('alpaca', 429);
+    const stats = getQuotaStats();
+    expect(stats.providers.alpaca.quota_burned).toBe(1);
+    expect(stats.providers.alpaca.errorKinds.rate_limit).toBe(1);
+  });
+
+  it('resetQuotaStats clears error-kind counters too', () => {
+    recordProviderError('polygon', 401);
+    resetQuotaStats();
+    expect(getErrorKindCount('polygon', 'auth')).toBe(0);
+    expect(getQuotaStats().providers.polygon.errorKinds.auth).toBe(0);
   });
 });

--- a/tests/data/resilience.test.ts
+++ b/tests/data/resilience.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Unit tests for the upstream resilience primitives (harden/data-provider-cdf).
+ * Pure logic — no network, no MSW. Timers/clock/jitter are all injected so the
+ * tests are deterministic and instant.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  fetchWithRetry,
+  backoffDelay,
+  isRetryableStatus,
+  CircuitBreaker,
+  getBreaker,
+  resetBreakers,
+} from '../../src/data/resilience.js';
+
+describe('isRetryableStatus', () => {
+  it('retries 429 and 5xx', () => {
+    expect(isRetryableStatus(429)).toBe(true);
+    expect(isRetryableStatus(500)).toBe(true);
+    expect(isRetryableStatus(503)).toBe(true);
+  });
+
+  it('does NOT retry 4xx that is not 429', () => {
+    expect(isRetryableStatus(400)).toBe(false);
+    expect(isRetryableStatus(401)).toBe(false);
+    expect(isRetryableStatus(403)).toBe(false);
+    expect(isRetryableStatus(404)).toBe(false);
+  });
+
+  it('does not retry 2xx', () => {
+    expect(isRetryableStatus(200)).toBe(false);
+  });
+});
+
+describe('backoffDelay', () => {
+  it('grows exponentially and is capped', () => {
+    // random()~=1 => the full ceiling (floor of base*2^(n-1), capped at max)
+    const r = () => 0.999999;
+    expect(backoffDelay(1, 100, 10000, r)).toBe(99); // ~100*2^0
+    expect(backoffDelay(2, 100, 10000, r)).toBe(199); // ~100*2^1
+    expect(backoffDelay(3, 100, 10000, r)).toBe(399); // ~100*2^2
+    expect(backoffDelay(10, 100, 500, r)).toBe(499); // capped at 500
+  });
+
+  it('full jitter: random()=0 yields 0 delay', () => {
+    expect(backoffDelay(5, 100, 10000, () => 0)).toBe(0);
+  });
+});
+
+describe('fetchWithRetry', () => {
+  const noSleep = () => Promise.resolve();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns immediately on a 200 (no retry)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { sleep: noSleep });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a 429 then succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('rl', { status: 429 }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { retries: 3, sleep: noSleep });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('exhausts retries and returns the last non-OK response', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('rl', { status: 429 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { retries: 3, sleep: noSleep });
+    expect(res.status).toBe(429);
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 + 2 retries
+  });
+
+  it('does NOT retry a 401 (returns it on the first call)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('nope', { status: 401 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { retries: 3, sleep: noSleep });
+    expect(res.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries a thrown network error then succeeds', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await fetchWithRetry('https://x.test', undefined, { retries: 3, sleep: noSleep });
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws the last error when every attempt throws', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('down'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchWithRetry('https://x.test', undefined, { retries: 2, sleep: noSleep }),
+    ).rejects.toThrow('down');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('CircuitBreaker', () => {
+  it('stays closed and allows attempts below the failure threshold', () => {
+    const b = new CircuitBreaker({ failureThreshold: 3 });
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.canAttempt()).toBe(true);
+    expect(b.getState()).toBe('closed');
+  });
+
+  it('opens after the failure threshold and blocks attempts', () => {
+    const b = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 1000 });
+    b.recordFailure();
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.getState()).toBe('open');
+    expect(b.canAttempt()).toBe(false);
+  });
+
+  it('half-opens after cooldown and allows a single probe', () => {
+    let t = 1000;
+    const b = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 500, now: () => t });
+    b.recordFailure(); // opens at t=1000
+    expect(b.canAttempt()).toBe(false);
+    t = 1600; // cooldown elapsed
+    expect(b.canAttempt()).toBe(true);
+    expect(b.getState()).toBe('half_open');
+  });
+
+  it('closes on success after a half-open probe', () => {
+    let t = 0;
+    const b = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 100, now: () => t });
+    b.recordFailure();
+    t = 200;
+    b.canAttempt(); // → half_open
+    b.recordSuccess();
+    expect(b.getState()).toBe('closed');
+    expect(b.canAttempt()).toBe(true);
+  });
+
+  it('re-opens if the half-open probe fails', () => {
+    let t = 0;
+    const b = new CircuitBreaker({ failureThreshold: 1, cooldownMs: 100, now: () => t });
+    b.recordFailure();
+    t = 200;
+    b.canAttempt(); // → half_open
+    b.recordFailure(); // probe failed → re-open
+    expect(b.getState()).toBe('open');
+    expect(b.canAttempt()).toBe(false); // still within the new cooldown
+  });
+
+  it('a success resets the consecutive-failure count', () => {
+    const b = new CircuitBreaker({ failureThreshold: 3 });
+    b.recordFailure();
+    b.recordFailure();
+    b.recordSuccess();
+    b.recordFailure();
+    b.recordFailure();
+    expect(b.getState()).toBe('closed'); // only 2 in a row since the success
+  });
+});
+
+describe('getBreaker registry', () => {
+  beforeEach(() => resetBreakers());
+
+  it('returns the same instance for a provider name', () => {
+    const a = getBreaker('polygon');
+    const b = getBreaker('polygon');
+    expect(a).toBe(b);
+  });
+
+  it('resetBreakers clears shared state', () => {
+    const a = getBreaker('polygon');
+    resetBreakers();
+    const b = getBreaker('polygon');
+    expect(a).not.toBe(b);
+  });
+});

--- a/tests/unit/observability-alerting.test.ts
+++ b/tests/unit/observability-alerting.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Unit tests: Workstream E — observability + alerting.
+ *
+ *   E4  reconcile the two Polygon health-check paths — HTTP 429 must read as
+ *       `degraded` in BOTH probePolygon (/health/integrations) and
+ *       checkExternalApis (/api/v1/health), never as "ok / rate limited (normal)".
+ *   E2  weekly digest surfaces per-provider quota + error-kind stats and a REAL
+ *       (non-null) cache hit ratio computed from CompositeCache telemetry.
+ *   E1  debounced Polygon health alerting off the synthetic monitor — no alert
+ *       before the threshold, one alert AT the threshold, no duplicate spam,
+ *       reset on a clean poll, and immediate escalation on an alertable error
+ *       kind (401 auth / 403 plan-tier).
+ *
+ * MSW intercepts outbound HTTP. Resend/PushService are never hit — AlertDelivery
+ * is mocked at the module level so no real mail/push is sent.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from 'vitest';
+import type { FastifyInstance } from 'fastify';
+import { http, HttpResponse } from 'msw';
+import { server } from '../setup.js';
+import { _probeCacheForTests } from '../../src/routes/health.js';
+import { renderWeeklyHealthDigest } from '../../src/notifications/email-templates/weekly-health-digest.js';
+import {
+  recordProviderError,
+  resetQuotaStats,
+} from '../../src/data/QuotaClassifier.js';
+import { marketDataCache } from '../../src/data/cache/index.js';
+
+// supabase.ts throws on import without these — set before any import resolves.
+vi.hoisted(() => {
+  process.env.SUPABASE_URL ??= 'http://localhost:54321';
+  process.env.SUPABASE_SERVICE_KEY ??= 'test-service-key';
+});
+
+// Capture-only email spy so no real Resend/PushService call is made.
+const { sendEmailSpy } = vi.hoisted(() => ({ sendEmailSpy: vi.fn() }));
+
+vi.mock('../../src/notifications/AlertDelivery.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../../src/notifications/AlertDelivery.js')>();
+  return {
+    ...actual,
+    getAlertDelivery: vi.fn(() => ({ sendEmail: sendEmailSpy })),
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function buildTestApp(): Promise<FastifyInstance> {
+  const { buildApp } = await import('../../src/app.js');
+  const { app } = await buildApp({ websockets: false, enableLogger: false });
+  await app.ready();
+  return app;
+}
+
+const savedEnv: Record<string, string | undefined> = {};
+function saveEnv(...keys: string[]) {
+  for (const k of keys) savedEnv[k] = process.env[k];
+}
+function restoreEnv(...keys: string[]) {
+  for (const k of keys) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+}
+
+const POLYGON_PREV = 'https://api.polygon.io/v2/aggs/ticker/AAPL/prev';
+const SUPABASE_REST = 'http://localhost:54321/rest/v1/';
+
+let app: FastifyInstance;
+
+beforeAll(async () => {
+  app = await buildTestApp();
+});
+
+afterAll(async () => {
+  await app.close();
+});
+
+beforeEach(() => {
+  _probeCacheForTests.clear();
+  sendEmailSpy.mockReset();
+  sendEmailSpy.mockResolvedValue({ success: true, messageId: 'test' });
+});
+
+// ===========================================================================
+// E4 — 429 → degraded consistency across BOTH health-check paths
+// ===========================================================================
+
+describe('E4: Polygon 429 is degraded in both health-check paths', () => {
+  beforeEach(() => {
+    saveEnv('POLYGON_API_KEY');
+    process.env.POLYGON_API_KEY = 'test-polygon-key';
+    _probeCacheForTests.clear();
+  });
+  afterEach(() => {
+    restoreEnv('POLYGON_API_KEY');
+    _probeCacheForTests.clear();
+  });
+
+  it('probePolygon path (/health/integrations): 429 → degraded', async () => {
+    server.use(
+      http.get(POLYGON_PREV, () => new HttpResponse(null, { status: 429 })),
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/v1/health/integrations' });
+    const body = res.json() as {
+      integrations: Record<string, { status: string; reason?: string }>;
+    };
+    expect(body.integrations.polygon.status).toBe('degraded');
+    expect(body.integrations.polygon.reason).toContain('429');
+  });
+
+  it('checkExternalApis path (/api/v1/health): 429 → error (not "ok / normal") → overall degraded', async () => {
+    server.use(
+      http.get(POLYGON_PREV, () => new HttpResponse(null, { status: 429 })),
+      // Keep the DB check green so the ONLY error is the external Polygon 429,
+      // which must drop overall health to `degraded` (one error), proving the
+      // 429 is no longer swallowed as "ok".
+      http.get(SUPABASE_REST, () => HttpResponse.json({}, { status: 200 })),
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/v1/health' });
+    const body = res.json() as {
+      status: string;
+      checks: {
+        database?: { status: string };
+        external?: { status: string; message?: string };
+      };
+    };
+    expect(body.checks.external?.status).toBe('error');
+    // The message must reflect the rate-limit signal, not "normal".
+    expect(body.checks.external?.message ?? '').toMatch(/429/);
+    expect(body.checks.external?.message ?? '').not.toMatch(/normal/i);
+    expect(body.checks.database?.status).toBe('ok');
+    expect(body.status).toBe('degraded');
+  });
+
+  it('checkExternalApis path: healthy Polygon → external ok', async () => {
+    server.use(
+      http.get(POLYGON_PREV, () =>
+        HttpResponse.json({ status: 'OK', resultsCount: 1, results: [] }),
+      ),
+      http.get(SUPABASE_REST, () => HttpResponse.json({}, { status: 200 })),
+    );
+    const res = await app.inject({ method: 'GET', url: '/api/v1/health' });
+    const body = res.json() as { status: string; checks: { external?: { status: string } } };
+    expect(body.checks.external?.status).toBe('ok');
+    expect(body.status).toBe('healthy');
+  });
+});
+
+// ===========================================================================
+// E2 — digest quota stats + real cache hit ratio
+// ===========================================================================
+
+describe('E2: weekly digest renders quota + cache ratio', () => {
+  const baseDigest = {
+    dateRange: 'May 4 – May 10, 2026',
+    totalErrors: 0,
+    topRoutes: [],
+    integrations: { live: 5, degraded: 1, offline: 0, badEntries: [] },
+    deployId: 'abc123',
+    sentryConfigured: false,
+    errorsEndpointUrl: 'https://example.com/api/v1/health/errors',
+  };
+
+  it('template: renders per-provider rate/auth/plan counts + computed cache %', () => {
+    const payload = renderWeeklyHealthDigest({
+      ...baseDigest,
+      cacheHitRatio: 0.75,
+      quota: {
+        since: '2026-05-04T00:00:00.000Z',
+        providers: {
+          polygon: {
+            quota_burned: 3,
+            quota_free: 2,
+            provider_fault: 0,
+            guidance: 'back off the full rate window before retrying',
+            errorKinds: {
+              rate_limit: 3,
+              auth: 2,
+              plan_tier: 1,
+              client_error: 2,
+              server_fault: 0,
+            },
+          },
+        },
+      },
+    });
+    // Cache ratio is computed, not "pending".
+    expect(payload.html).toContain('75.0%');
+    expect(payload.html).not.toContain('pending US-006');
+    // Quota card present with the three headline error-kind counts.
+    expect(payload.html).toContain('Upstream Quota');
+    expect(payload.html).toContain('rate 3');
+    expect(payload.html).toContain('auth 2');
+    expect(payload.html).toContain('plan 1');
+    // Text mirror carries it too.
+    expect(payload.text).toContain('Cache hit ratio: 75.0%');
+    expect(payload.text).toMatch(/polygon\s+rate 3 · auth 2 · plan 1/);
+  });
+
+  it('template: null quota omits the card; null ratio renders n/a', () => {
+    const payload = renderWeeklyHealthDigest({ ...baseDigest, cacheHitRatio: null });
+    expect(payload.html).not.toContain('Upstream Quota');
+    expect(payload.html).toContain('n/a');
+  });
+
+  it('route: /digest/health-summary computes a NON-null cache ratio and includes quota', async () => {
+    saveEnv('CRON_SECRET', 'EMAIL_PROVIDER');
+    process.env.CRON_SECRET = 'test-cron-secret';
+    process.env.EMAIL_PROVIDER = 'resend';
+
+    // Seed real quota state (alertable auth kind on polygon).
+    resetQuotaStats();
+    recordProviderError('polygon', 401);
+    recordProviderError('polygon', 429);
+
+    // Seed real CompositeCache telemetry so hits+misses > 0 → ratio is non-null.
+    marketDataCache.resetCounters();
+    marketDataCache.memory.set('AAPL:7', []);
+    marketDataCache.memory.get('AAPL:7'); // hit
+    marketDataCache.memory.get('MISS:7'); // miss
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/v1/digest/health-summary?key=test-cron-secret',
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+    const payload = sendEmailSpy.mock.calls[0][0] as { html: string; text: string };
+    // Non-null ratio: 1 hit / 2 reads = 50.0%.
+    expect(payload.html).toContain('50.0%');
+    expect(payload.html).not.toContain('pending US-006');
+    // Quota card carries the seeded polygon counts.
+    expect(payload.html).toContain('Upstream Quota');
+    expect(payload.text).toMatch(/polygon\s+rate 1 · auth 1 · plan 0/);
+
+    resetQuotaStats();
+    marketDataCache.resetCounters();
+    restoreEnv('CRON_SECRET', 'EMAIL_PROVIDER');
+  });
+});
+
+// ===========================================================================
+// E1 — debounced Polygon health alerting
+// ===========================================================================
+
+describe('E1: debounced Polygon health alerter', () => {
+  let evaluatePolygonHealth: typeof import('../../src/observability/PolygonHealthAlerter.js')['evaluatePolygonHealth'];
+  let resetPolygonHealthAlerter: typeof import('../../src/observability/PolygonHealthAlerter.js')['resetPolygonHealthAlerter'];
+
+  beforeAll(async () => {
+    const mod = await import('../../src/observability/PolygonHealthAlerter.js');
+    evaluatePolygonHealth = mod.evaluatePolygonHealth;
+    resetPolygonHealthAlerter = mod.resetPolygonHealthAlerter;
+  });
+
+  const failingPoll = { failed: 1, passed: 9, failingRoutes: [{ route: 'quotesHistory', error: 'non-200 (500)' }] };
+  const cleanPoll = { failed: 0, passed: 10, failingRoutes: [] };
+
+  beforeEach(() => {
+    resetPolygonHealthAlerter();
+    resetQuotaStats();
+    sendEmailSpy.mockReset();
+    sendEmailSpy.mockResolvedValue({ success: true, messageId: 'test' });
+  });
+
+  it('does NOT alert before the threshold (default 3)', async () => {
+    const r1 = await evaluatePolygonHealth(failingPoll);
+    const r2 = await evaluatePolygonHealth(failingPoll);
+    expect(r1.alerted).toBe(false);
+    expect(r2.alerted).toBe(false);
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+  });
+
+  it('alerts exactly AT the threshold with reason=debounce-threshold', async () => {
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll);
+    const r3 = await evaluatePolygonHealth(failingPoll);
+    expect(r3.alerted).toBe(true);
+    expect(r3.reason).toBe('debounce-threshold');
+    expect(r3.consecutiveFailures).toBe(3);
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT re-alert on subsequent failing polls (no spam)', async () => {
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll); // alert #1
+    const r4 = await evaluatePolygonHealth(failingPoll);
+    const r5 = await evaluatePolygonHealth(failingPoll);
+    expect(r4.alerted).toBe(false);
+    expect(r5.alerted).toBe(false);
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets the counter (and re-arms) on a clean poll', async () => {
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll);
+    const clean = await evaluatePolygonHealth(cleanPoll);
+    expect(clean.consecutiveFailures).toBe(0);
+
+    // Must take a fresh full run of 3 to alert again.
+    await evaluatePolygonHealth(failingPoll);
+    await evaluatePolygonHealth(failingPoll);
+    expect(sendEmailSpy).not.toHaveBeenCalled();
+    const third = await evaluatePolygonHealth(failingPoll);
+    expect(third.alerted).toBe(true);
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('escalates IMMEDIATELY (no debounce) on an alertable auth kind', async () => {
+    recordProviderError('polygon', 401); // revoked/invalid key
+    const r1 = await evaluatePolygonHealth(failingPoll);
+    expect(r1.alerted).toBe(true);
+    expect(r1.reason).toBe('alertable-kind');
+    expect(r1.consecutiveFailures).toBe(1); // fired well before threshold
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+    const subject = (sendEmailSpy.mock.calls[0][0] as { subject: string }).subject;
+    expect(subject).toMatch(/action required/i);
+  });
+
+  it('escalates immediately on a plan-tier (403) block', async () => {
+    recordProviderError('polygon', 403);
+    const r1 = await evaluatePolygonHealth(failingPoll);
+    expect(r1.alerted).toBe(true);
+    expect(r1.reason).toBe('alertable-kind');
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-escalate on the same alertable count across polls', async () => {
+    recordProviderError('polygon', 401);
+    await evaluatePolygonHealth(failingPoll); // alertable alert #1
+    const r2 = await evaluatePolygonHealth(failingPoll); // same 401 count, no new alert
+    expect(r2.reason).not.toBe('alertable-kind');
+    expect(sendEmailSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Consolidated bundle for the Polygon Starter harden+unlock plan. Supersedes the auto-closed #23 (its base branch was deleted when #21 merged) and folds in #25 (B2) and #26 (E), which are already merged into this branch.

## What's in here

**C — Correctness**
- C1 WebSocket → Polygon delayed cluster (`wss://delayed.polygon.io/stocks`); rationale corrected after a live probe showed auth succeeds on both clusters (a green auth is not proof of a working feed). Overridable via `POLYGON_WS_URL`.
- C2 graceful degradation: serve last-resort stale cache rows when every provider fails, instead of throwing.
- C3 error classification: split 401 (auth/rotate key) vs 403 (plan-tier) vs 400/404 (benign) via `classifyErrorKind`/`recordProviderError`.

**D — Reliability**
- D1 `fetchWithRetry` (bounded retry + jittered backoff on 429/5xx/network; never retries 401/403/404).
- D2 per-provider `CircuitBreaker` (open after N failures, half-open probe, shared registry).
- D3 quote dedup (coalesce concurrent same-symbol callers).
- D4 first-ever fetch-path tests (`tests/data/resilience.test.ts`, `tests/data/MarketDataProvider.test.ts`).

**F — Cleanup**
- Removed stale "free tier 5 req/min" comments; `CacheWarmer.MAX_CONCURRENT_UPSTREAM` 4→8; documented `POLYGON_WS_URL`.

**B2 — Entitlement unlock**
- `fetchGroupedDaily` (one call → all US tickers; validated live at 12,445 tickers) + `warmLatestDayAllSymbols` daily-freshness sync. Additive: deep backfill stays per-symbol.

**E — Observability**
- E1 `PolygonHealthAlerter` (debounced 3-poll alert + immediate escalation on auth/plan-tier) wired into the synthetic monitor.
- E2 quota stats + real cache hit ratio in the weekly digest.
- E4 reconciled the two health-check paths (429 = degraded consistently).

## Testing
- **1025 server tests pass**, typecheck + lint + arch:check clean.

## Not included
- B1 (5yr history) shipped separately in #24 (already merged).
- E3 (`VERCEL_TOKEN` repo secret) is a user action.