### PR TITLE
fix(data): quotes were dead in production — Polygon snapshot is not entitled

### DIFF
--- a/api/edge/quotes.ts
+++ b/api/edge/quotes.ts
@@ -27,27 +27,14 @@ interface QuoteResult {
   timestamp: string;
 }
 
-interface PolygonSnapshotTicker {
-  ticker: string;
-  todaysChange: number;
-  todaysChangePerc: number;
-  day: {
-    o: number;
-    h: number;
-    l: number;
-    c: number;
-    v: number;
-    vw: number;
-  };
-  lastTrade?: {
-    p: number;
-    t: number;
-  };
-  prevDay?: {
-    c: number;
-    v: number;
-  };
-  updated: number;
+/** One daily OHLCV bar from `/v2/aggs/ticker/{T}/range/1/day/...`. */
+interface PolygonAggBar {
+  o: number;
+  h: number;
+  l: number;
+  c: number;
+  v: number;
+  t: number; // unix milliseconds
 }
 
 interface CacheEntry {
@@ -67,50 +54,76 @@ const STALE_MAX_MS = 30_000; // 30 seconds — serve stale while revalidating
 // Polygon.io fetch
 // ---------------------------------------------------------------------------
 
+/** Outcome of a provider fetch — quotes plus any upstream rejection. */
+interface PolygonFetchOutcome {
+  quotes: Map<string, QuoteResult>;
+  /** HTTP status of the first plan-tier/auth rejection, if any. */
+  deniedStatus?: number;
+}
+
+/**
+ * Fetch quotes from Polygon **daily aggregates**.
+ *
+ * Do NOT use the Snapshot endpoint here. `/v2/snapshot/...` is NOT entitled on
+ * the Stocks Starter plan — it returns HTTP 403 NOT_AUTHORIZED (verified
+ * 2026-07-30 against the production key). Neither is `/v2/last/trade`.
+ * Aggregates ARE entitled, so the quote is derived from the two most recent
+ * daily bars: the latest close is the price, and the prior close gives
+ * change / changePercent.
+ *
+ * Prices are 15-minute delayed on this plan; that is a plan property, not a bug.
+ */
 async function fetchFromPolygon(
   symbols: string[],
   apiKey: string,
-): Promise<Map<string, QuoteResult>> {
-  const results = new Map<string, QuoteResult>();
+): Promise<PolygonFetchOutcome> {
+  const quotes = new Map<string, QuoteResult>();
+  let deniedStatus: number | undefined;
 
-  // Polygon Snapshot endpoint supports multiple tickers via comma-separated
-  // GET /v2/snapshot/locale/us/markets/stocks/tickers?tickers=AAPL,MSFT
-  const tickerParam = symbols.join(',');
-  const url = `https://api.polygon.io/v2/snapshot/locale/us/markets/stocks/tickers?tickers=${tickerParam}&apiKey=${apiKey}`;
+  // A 10-day calendar window always contains at least two trading sessions,
+  // even across a long weekend plus a market holiday.
+  const to = new Date();
+  const from = new Date(to.getTime() - 10 * 24 * 60 * 60 * 1000);
+  const range = `${from.toISOString().slice(0, 10)}/${to.toISOString().slice(0, 10)}`;
 
-  const response = await fetch(url, {
-    headers: { 'Accept': 'application/json' },
-  });
+  await Promise.all(
+    symbols.map(async (symbol) => {
+      const url =
+        `https://api.polygon.io/v2/aggs/ticker/${symbol}/range/1/day/${range}` +
+        `?adjusted=true&sort=desc&limit=2&apiKey=${apiKey}`;
 
-  if (!response.ok) {
-    // If Polygon returns an error, return whatever we can
-    console.error(`Polygon API error: ${response.status} ${response.statusText}`);
-    return results;
-  }
+      const response = await fetch(url, { headers: { Accept: 'application/json' } });
 
-  const json = await response.json() as {
-    status: string;
-    tickers?: PolygonSnapshotTicker[];
-  };
+      if (!response.ok) {
+        // 401/403 mean the key or the plan is the problem — that is an outage,
+        // not an empty result, and the handler must not report success.
+        if (response.status === 401 || response.status === 403) {
+          deniedStatus ??= response.status;
+        }
+        console.error(`Polygon API error for ${symbol}: ${response.status} ${response.statusText}`);
+        return;
+      }
 
-  if (json.tickers) {
-    for (const t of json.tickers) {
-      const price = t.lastTrade?.p ?? t.day?.c ?? 0;
-      const quote: QuoteResult = {
-        symbol: t.ticker,
-        price,
-        change: t.todaysChange ?? 0,
-        changePercent: t.todaysChangePerc ?? 0,
-        volume: t.day?.v ?? 0,
-        timestamp: t.updated
-          ? new Date(t.updated / 1e6).toISOString() // Polygon timestamps are in nanoseconds
-          : new Date().toISOString(),
-      };
-      results.set(t.ticker, quote);
-    }
-  }
+      const json = (await response.json()) as { results?: PolygonAggBar[] };
+      // `limit` bounds the aggregation window, not the row count, so slice.
+      const [latest, prior] = (json.results ?? []).slice(0, 2);
+      if (!latest || !latest.c) return;
 
-  return results;
+      const prevClose = prior?.c ?? latest.o;
+      const change = latest.c - prevClose;
+
+      quotes.set(symbol, {
+        symbol,
+        price: latest.c,
+        change,
+        changePercent: prevClose ? (change / prevClose) * 100 : 0,
+        volume: latest.v ?? 0,
+        timestamp: new Date(latest.t).toISOString(), // aggregate `t` is milliseconds
+      });
+    }),
+  );
+
+  return { quotes, deniedStatus };
 }
 
 // ---------------------------------------------------------------------------
@@ -212,10 +225,20 @@ export default async function handler(request: Request): Promise<Response> {
 
   const apiKey = process.env.POLYGON_API_KEY;
   let fetchedQuotes = new Map<string, QuoteResult>();
+  let providerFailed = false;
+  let deniedStatus: number | undefined;
+
+  if (needsFetch.length > 0 && !apiKey) {
+    providerFailed = true;
+    console.error('POLYGON_API_KEY is not set in this environment');
+  }
 
   if (needsFetch.length > 0 && apiKey) {
     try {
-      fetchedQuotes = await fetchFromPolygon(needsFetch, apiKey);
+      const outcome = await fetchFromPolygon(needsFetch, apiKey);
+      fetchedQuotes = outcome.quotes;
+      deniedStatus = outcome.deniedStatus;
+      if (deniedStatus || fetchedQuotes.size === 0) providerFailed = true;
 
       // Update cache
       const fetchTime = Date.now();
@@ -223,6 +246,7 @@ export default async function handler(request: Request): Promise<Response> {
         quoteCache.set(sym, { data: quote, fetchedAt: fetchTime });
       }
     } catch (err) {
+      providerFailed = true;
       console.error('Polygon fetch error:', err);
       // Fall through — serve whatever stale data we have
     }
@@ -256,11 +280,31 @@ export default async function handler(request: Request): Promise<Response> {
   const latencyMs = Date.now() - start;
   const isSingle = symbols.length === 1;
 
+  // A request that resolved zero quotes because the provider rejected us is an
+  // upstream failure, not an empty result set. Reporting success:true here is
+  // what let a plan-tier 403 masquerade as "no data" in production for months.
+  if (quotes.length === 0 && providerFailed) {
+    return jsonResponse(
+      {
+        success: false,
+        error: {
+          code: deniedStatus ? 'PROVIDER_NOT_ENTITLED' : 'PROVIDER_UNAVAILABLE',
+          message: deniedStatus
+            ? `Polygon rejected the request (HTTP ${deniedStatus}). The API key or plan tier is not entitled to this data.`
+            : 'Upstream market data provider returned no data.',
+        },
+        meta: { requested: symbols.length, latencyMs, timestamp: new Date().toISOString(), edge: true },
+      },
+      deniedStatus ? 502 : 503,
+    );
+  }
+
   return jsonResponse(
     {
       success: true,
       data: isSingle ? (quotes[0] ?? null) : quotes,
       meta: {
+        degraded: providerFailed || undefined,
         count: quotes.length,
         requested: symbols.length,
         cacheStatus,

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch --env-file .env src/index.ts",
+    "dev": "tsx watch --env-file-if-exists .env --env-file-if-exists .env.local src/index.ts",
     "dev:all": "concurrently \"npm run dev\" \"npm run client:dev\"",
     "build": "tsc && npm run client:build",
     "build:server": "esbuild src/index.ts --bundle --platform=node --target=node20 --outfile=dist/index.js --format=esm --packages=external",
-    "start": "node --env-file .env dist/index.js",
+    "start": "node --env-file-if-exists .env --env-file-if-exists .env.local dist/index.js",
     "test": "vitest",
     "test:unit": "vitest run src/**/*.test.ts",
     "test:e2e": "vitest run tests/e2e",

--- a/src/data/MarketDataProvider.ts
+++ b/src/data/MarketDataProvider.ts
@@ -930,13 +930,21 @@ export class MarketDataProvider {
   // ============================================================================
 
   private async fetchPolygonQuote(symbol: string): Promise<Quote | null> {
-    // Polygon Stocks Starter is 15-min delayed and is NOT entitled to the
-    // real-time `/v2/last/trade` endpoint (it 403s). The snapshot endpoint is
-    // entitled on Starter and returns the delayed last price plus today's
-    // change/changePercent in a single call.
+    // Endpoint entitlement on the Stocks Starter plan, measured against the
+    // production key on 2026-07-30 — do not "upgrade" this to a richer endpoint
+    // without re-measuring, because the failures are silent:
+    //   /v2/last/trade            -> 403 NOT_AUTHORIZED (real-time)
+    //   /v2/snapshot/...          -> 403 NOT_AUTHORIZED  <-- previously used here
+    //   /v3/snapshot/options/...  -> 403 NOT_AUTHORIZED (needs Options plan)
+    //   /v2/aggs/...              -> 200 OK, 15-min delayed  <-- entitled
+    // So the quote is derived from the two most recent daily bars: the latest
+    // close is the price, and the prior close gives change / changePercent.
+    const to = new Date();
+    const from = new Date(to.getTime() - 10 * 24 * 60 * 60 * 1000); // >= 2 sessions
     const url =
-      `https://api.polygon.io/v2/snapshot/locale/us/markets/stocks/tickers/` +
-      `${encodeURIComponent(symbol)}?apiKey=${this.config.polygonApiKey}`;
+      `https://api.polygon.io/v2/aggs/ticker/${encodeURIComponent(symbol)}` +
+      `/range/1/day/${from.toISOString().slice(0, 10)}/${to.toISOString().slice(0, 10)}` +
+      `?adjusted=true&sort=desc&limit=2&apiKey=${this.config.polygonApiKey}`;
 
     const response = await fetchWithRetry(url, undefined);
     if (!response.ok) {
@@ -949,42 +957,27 @@ export class MarketDataProvider {
 
     const data = (await response.json()) as {
       status?: string;
-      ticker?: {
-        todaysChange?: number;
-        todaysChangePerc?: number;
-        updated?: number; // unix nanoseconds
-        day?: { c?: number };
-        min?: { c?: number };
-        prevDay?: { c?: number };
-      };
+      results?: Array<{ o: number; h: number; l: number; c: number; v: number; t: number }>;
     };
 
-    const t = data.ticker;
-    if (!t) return null;
+    // `limit` bounds the aggregation window rather than the row count, so slice.
+    const [latest, prior] = (data.results ?? []).slice(0, 2);
+    if (!latest?.c) return null;
 
-    // Prefer the freshest delayed price available: intraday minute close, then
-    // the current day close, then the previous day close as a floor. (The
-    // real-time lastTrade field is absent on the delayed Starter plan.)
-    const last =
-      t.min?.c && t.min.c > 0
-        ? t.min.c
-        : t.day?.c && t.day.c > 0
-          ? t.day.c
-          : (t.prevDay?.c ?? 0);
-
-    if (!last) return null;
-
-    // `updated` is unix nanoseconds; convert to ms. Fall back to now if absent.
-    const timestamp = t.updated ? new Date(Math.floor(t.updated / 1e6)) : new Date();
+    const last = latest.c;
+    // With only one bar available (freshly listed ticker), fall back to that
+    // bar's open so change is intraday rather than a fabricated zero.
+    const prevClose = prior?.c ?? latest.o;
+    const change = last - prevClose;
 
     return {
       symbol,
-      timestamp,
+      timestamp: new Date(latest.t), // aggregate `t` is unix milliseconds
       bid: last * 0.9999, // Approximate (no real-time bid/ask on delayed plan)
       ask: last * 1.0001,
       last,
-      change: t.todaysChange ?? 0,
-      changePercent: t.todaysChangePerc ?? 0,
+      change,
+      changePercent: prevClose ? (change / prevClose) * 100 : 0,
     };
   }
 

--- a/tests/data/MarketDataProvider.test.ts
+++ b/tests/data/MarketDataProvider.test.ts
@@ -31,22 +31,22 @@ import { resetQuotaStats, getErrorKindCount } from '../../src/data/QuotaClassifi
 const POLY_KEY = 'x'.repeat(32);
 
 // URL matchers for MSW.
-const POLY_SNAPSHOT = 'https://api.polygon.io/v2/snapshot/locale/us/markets/stocks/tickers/:symbol';
+// Quotes are derived from daily aggregates, not the snapshot endpoint —
+// `/v2/snapshot/...` is not entitled on the Stocks Starter plan (403).
 const POLY_AGGS = 'https://api.polygon.io/v2/aggs/ticker/:symbol/range/1/day/:from/:to';
+const POLY_QUOTE = POLY_AGGS;
 const ALPACA_SNAPSHOT = 'https://data.alpaca.markets/v2/stocks/:symbol/snapshot';
 const ALPACA_BARS = 'https://data.alpaca.markets/v2/stocks/:symbol/bars';
 
-function polygonSnapshotOK(last: number) {
+/** Two daily bars, newest first — the shape `fetchPolygonQuote` parses. */
+function polygonQuoteAggsOK(last: number) {
+  const day = 24 * 60 * 60 * 1000;
   return HttpResponse.json({
     status: 'OK',
-    ticker: {
-      todaysChange: 1.5,
-      todaysChangePerc: 1.0,
-      updated: Date.now() * 1e6,
-      min: { c: last },
-      day: { c: last - 1 },
-      prevDay: { c: last - 2 },
-    },
+    results: [
+      { o: last - 0.5, h: last + 1, l: last - 1, c: last, v: 1_000_000, t: Date.now() },
+      { o: last - 2, h: last, l: last - 3, c: last - 1.5, v: 900_000, t: Date.now() - day },
+    ],
   });
 }
 
@@ -93,7 +93,7 @@ describe('getQuote — failover + retry', () => {
   it('retries a Polygon 429, then falls over to Alpaca', async () => {
     let polyHits = 0;
     server.use(
-      http.get(POLY_SNAPSHOT, () => {
+      http.get(POLY_QUOTE, () => {
         polyHits += 1;
         return new HttpResponse('rate limited', { status: 429 });
       }),
@@ -109,7 +109,7 @@ describe('getQuote — failover + retry', () => {
 
   it('classifies a Polygon 401 as an auth failure and still serves via Alpaca', async () => {
     server.use(
-      http.get(POLY_SNAPSHOT, () => new HttpResponse('bad key', { status: 401 })),
+      http.get(POLY_QUOTE, () => new HttpResponse('bad key', { status: 401 })),
       http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(321)),
     );
 
@@ -123,7 +123,7 @@ describe('getQuote — failover + retry', () => {
   it('does not retry a 401 (single Polygon hit)', async () => {
     let polyHits = 0;
     server.use(
-      http.get(POLY_SNAPSHOT, () => {
+      http.get(POLY_QUOTE, () => {
         polyHits += 1;
         return new HttpResponse('bad key', { status: 401 });
       }),
@@ -139,11 +139,11 @@ describe('getQuote — dedup (D3)', () => {
   it('coalesces concurrent same-symbol callers onto one upstream fetch', async () => {
     let polyHits = 0;
     server.use(
-      http.get(POLY_SNAPSHOT, async () => {
+      http.get(POLY_QUOTE, async () => {
         polyHits += 1;
         // Small delay so the second caller arrives while the first is inflight.
         await new Promise((r) => setTimeout(r, 20));
-        return polygonSnapshotOK(150);
+        return polygonQuoteAggsOK(150);
       }),
     );
 
@@ -160,9 +160,9 @@ describe('getQuote — circuit breaker (D2)', () => {
   it('skips Polygon entirely once its breaker is open', async () => {
     let polyHits = 0;
     server.use(
-      http.get(POLY_SNAPSHOT, () => {
+      http.get(POLY_QUOTE, () => {
         polyHits += 1;
-        return polygonSnapshotOK(999);
+        return polygonQuoteAggsOK(999);
       }),
       http.get(ALPACA_SNAPSHOT, () => alpacaSnapshotOK(42)),
     );


### PR DESCRIPTION
## Problem

Every production quote returned `null` while reporting HTTP 200 `success: true`.

```
$ curl .../api/edge/quotes?symbols=AAPL
{"success":true,"data":null,"meta":{"count":0,"requested":1,...}}
```

## Root cause

The quote path called `/v2/snapshot/...`, which the **Stocks Starter** plan rejects. Entitlement measured against the production key on 2026-07-30:

| Endpoint | Result |
|---|---|
| `/v2/aggs/...` (day, minute, grouped) | ✅ 200, 15-min delayed |
| `/v2/snapshot/...` (any form) | ❌ 403 NOT_AUTHORIZED — **was in use** |
| `/v2/last/trade/{T}` | ❌ 403 NOT_AUTHORIZED |
| `/v3/snapshot/options/{T}` | ❌ 403 — separate Options plan |

A prior fix swapped `/v2/last/trade` → `/v2/snapshot` believing snapshot was entitled on Starter. It is not; it 403s identically. That assumption was written into a code comment **and** into CLAUDE.md, so it was never re-measured.

## Why it stayed invisible

Two independent failures of observability:

1. `fetchFromPolygon` returned an empty map on `!response.ok`, and the handler wrapped that as `{"success":true,"data":null}` — a plan-tier rejection was indistinguishable from "no data".
2. The health probe (`src/routes/health.ts:155`) checks `/v2/aggs/ticker/AAPL/prev` — an endpoint the plan **does** allow — so it reported `polygon: "live"` throughout. **The health check validated a different endpoint than the feature it covered.**

## Changes

- **`api/edge/quotes.ts`** — quotes derived from the two most recent daily bars; 401/403 now returns `502 PROVIDER_NOT_ENTITLED` instead of an empty success.
- **`src/data/MarketDataProvider.ts`** — same swap, with the measured entitlement table inline so it cannot silently regress.
- **`package.json`** — `dev`/`start` used `--env-file .env`, which doesn't exist (only `.env.local`), so local dev could not boot at all. Now `--env-file-if-exists` for both.
- **`tests/`** — MSW mocks retargeted to the aggregates endpoint.

## Verification

- typecheck clean, lint clean
- **1025/1025 server tests pass**
- live API through the new logic: AAPL $338.19 (−0.56%), MSFT $390.54 (−0.71%), NVDA $190.01 (−3.55%), SPY $729.46 (−1.54%), session 2026-07-29

## Follow-ups (not in this PR)

- Point the health probe at the same call the quote path makes, so it can't pass while the feature fails.
- Flat Files (S3) are entitled for stocks `day_aggs` + `minute_aggs` and entirely unused — `HistoricalDataLoader` still fetches per-symbol over REST.
- Options data is genuinely unentitled on this plan.